### PR TITLE
Add table-based CLI Commands reference page

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -1,0 +1,68 @@
+---
+
+title: CLI Commands
+description: Reference guide for all Nextellar CLI commands using a structured table format.
+date: 2025-03-12
+---
+
+# Nextellar CLI — Commands Reference
+
+This page provides a clean, table-based reference for every available Nextellar CLI command. For flags and advanced configuration, see the **Flags & Options** page.
+
+---
+
+## 1. Core Commands
+
+| Command                             | Description                                                 | Example                     |
+| ----------------------------------- | ----------------------------------------------------------- | --------------------------- |
+| `nextellar <project-name>`          | Creates a new Nextellar project using the default scaffold. | `nextellar my-app`          |
+| `npx nextellar <project-name>`      | Runs the CLI without a global install (recommended).        | `npx nextellar my-app`      |
+| `pnpm dlx nextellar <project-name>` | pnpm on-demand execution.                                   | `pnpm dlx nextellar my-app` |
+| `bunx nextellar <project-name>`     | bun on-demand execution.                                    | `bunx nextellar my-app`     |
+
+---
+
+## 2. Informational Commands
+
+| Command               | Description                                 | Example               |
+| --------------------- | ------------------------------------------- | --------------------- |
+| `nextellar --help`    | Shows help text for all commands and flags. | `nextellar --help`    |
+| `nextellar --version` | Prints the installed version of the CLI.    | `nextellar --version` |
+
+---
+
+## 3. Upcoming Commands (Planned)
+
+These commands are referenced in the roadmap and will be added to Nextellar in future releases.
+
+| Command                            | Status      | Description                                                                 |
+| ---------------------------------- | ----------- | --------------------------------------------------------------------------- |
+| `nextellar generate <type> <name>` | Coming Soon | Will generate components, hooks, utilities, or Stellar-specific modules.    |
+| `nextellar doctor`                 | Coming Soon | Diagnose system environment, Node version, and Stellar connectivity issues. |
+| `nextellar upgrade`                | Coming Soon | Automatically update scaffold dependencies and recommended configs.         |
+
+---
+
+## 4. Usage Examples
+
+### Create a new project
+
+```bash
+npx nextellar my-app
+```
+
+### Create a JavaScript project (with flag)
+
+```bash
+npx nextellar my-app --javascript
+```
+
+### Use a template (with flag)
+
+```bash
+npx nextellar my-app --example payments-demo
+```
+
+---
+
+This page lists the full set of available commands. For configuration and customization, continue to the **Flags & Options** and **Scaffolding Templates** pages.


### PR DESCRIPTION

## Summary

This PR adds the new **CLI Commands** documentation page using a clean, table-based format.  
The page provides a complete reference for all available Nextellar CLI commands, including:

- Core project-scaffolding commands  
- Informational commands (`--help`, `--version`)  
- Planned future commands (`doctor`, `upgrade`, `generate`)  
- Usage examples for common workflows  

This page replaces the earlier step-formatted Commands page with a more maintainable and scalable structure.

---

## Files Added

- **docs/cli/commands.mdx**  
  A comprehensive table-driven CLI command reference.

---

## Motivation

- Developers need a quick, scannable reference for all CLI commands.  
- The table format is more appropriate for command documentation than step-based components.  
- Aligns the Commands page with the structure used in the new Flags & Options page.

This improves clarity, reduces verbosity, and improves future extensibility (e.g., more commands or subcommands).

---

## Implementation Notes

- Organized commands into three categories:
  - Core Commands  
  - Informational Commands  
  - Upcoming Commands  
- Each command includes a description and usage example.
- Markdown tables were chosen for readability and consistency.
- All content validated against the PDF specification.

---

## How to Test

1. Check out this branch:
   ```bash
   git checkout docs/cli/commands
````

2. Run the documentation site locally.
3. Navigate to:

   ```
   /docs/cli/commands
   ```
4. Verify:

   * All tables render correctly
   * Code blocks render and highlight properly
   * No MDX/Contentlayer errors occur
   * Links to related pages (Flags & Options, Templates) function as expected

---

## Reviewer Checklist

* [ ] Table formatting renders correctly in light and dark mode
* [ ] All commands match the official specs
* [ ] No broken indentation or fenced-block issues
* [ ] No JSX components remain (this page uses pure markdown)
* [ ] Page follows the same writing style as Installation/Quick Start

---

## Additional Notes

If new commands are added to the CLI (e.g., “generate” or “doctor”), the page is designed to be easily extendable in a new section.


