### PR TITLE
Add Flags & Options reference page

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -1,0 +1,144 @@
+---
+
+title: CLI Flags & Options
+description: Complete reference for all Nextellar CLI flags and configuration options.
+date: 2025-03-12
+---
+
+# Nextellar CLI — Flags & Options
+
+This page documents **all available CLI flags**, grouped into categories for clarity. Use this as a reference when customizing how the Nextellar CLI scaffolds your project.
+
+You can combine multiple flags in a single command:
+
+```bash
+npx nextellar my-app --javascript --wallets freighter,xbull --horizon-url https://horizon-testnet.stellar.org
+```
+
+---
+
+## 1. Language Options
+
+These flags determine whether the generated project uses **TypeScript** or **JavaScript**.
+
+| Flag           | Alias | Description                                         |
+| -------------- | ----- | --------------------------------------------------- |
+| `--typescript` | `-t`  | Generate a TypeScript project (default)             |
+| `--javascript` | `-j`  | Generate a JavaScript project instead of TypeScript |
+
+**Examples:**
+
+```bash
+npx nextellar my-app --typescript
+npx nextellar my-app --javascript
+```
+
+---
+
+## 2. Network Configuration Flags
+
+Configure the Horizon or Soroban RPC endpoints used inside the generated project.
+
+| Flag                  | Description                               |
+| --------------------- | ----------------------------------------- |
+| `--horizon-url <url>` | Override the default Horizon API endpoint |
+| `--soroban-url <url>` | Override the default Soroban RPC endpoint |
+
+**Examples:**
+
+```bash
+npx nextellar my-app --horizon-url https://horizon-testnet.stellar.org
+npx nextellar my-app --soroban-url https://rpc-futurenet.stellar.org
+```
+
+---
+
+## 3. Wallet Configuration Flags
+
+Select which wallet adapters to include in the scaffold.
+
+| Flag               | Alias | Description                                |
+| ------------------ | ----- | ------------------------------------------ |
+| `--wallets <list>` | `-w`  | Comma‑separated list of wallets to include |
+
+**Supported Wallets:**
+
+* `freighter`
+* `xbull`
+* `ledger`
+
+**Example:**
+
+```bash
+npx nextellar my-app --wallets freighter,xbull
+```
+
+---
+
+## 4. Template Flags
+
+Use an example or template instead of the default scaffold.
+
+| Flag               | Alias | Description                                                                |
+| ------------------ | ----- | -------------------------------------------------------------------------- |
+| `--example <name>` | `-e`  | Generates a project using one of the available Nextellar example templates |
+
+**Example:**
+
+```bash
+npx nextellar my-app --example payments-demo
+```
+
+---
+
+## 5. Automation & Defaults
+
+These flags control how interactive or automated the CLI should be.
+
+| Flag             | Alias | Description                                     |
+| ---------------- | ----- | ----------------------------------------------- |
+| `--defaults`     | `-d`  | Use all default settings without prompting      |
+| `--skip-install` | —     | Generate files but skip dependency installation |
+
+**Example:**
+
+```bash
+npx nextellar my-app --defaults --skip-install
+```
+
+---
+
+## 6. Global Flags
+
+These flags do not affect scaffolding but control CLI behavior.
+
+| Flag        | Alias | Description                               |
+| ----------- | ----- | ----------------------------------------- |
+| `--help`    | `-h`  | Show help text                            |
+| `--version` | `-v`  | Print the installed Nextellar CLI version |
+
+**Examples:**
+
+```bash
+nextellar --help
+nextellar --version
+```
+
+---
+
+## 7. Combining Multiple Flags
+
+You can combine any number of flags in a single command.
+
+```bash
+npx nextellar my-app \
+  --javascript \
+  --wallets freighter,ledger \
+  --horizon-url https://horizon-testnet.stellar.org \
+  --soroban-url https://rpc-futurenet.stellar.org \
+  --skip-install
+```
+
+---
+
+This page serves as the complete reference for all current Nextellar CLI flags. New flags will be added as Nextellar introduces more templates, generators, and automation tools.


### PR DESCRIPTION
## Summary

This PR adds the **CLI Flags & Options** documentation page to the Nextellar docs.
The page provides a complete, table-driven reference for all available CLI flags,
organized into clear categories for easier scanning and long-term maintainability.

This page complements the CLI Commands page and improves the onboarding experience
for developers who need full control over scaffolding and configuration.

---

## Files Added

- **docs/cli/flags-and-options.mdx**

This file includes:
- Full breakdown of all CLI flags
- Table sections for clarity and fast lookup
- Examples for each flag
- Combined-flags examples for real-world usage

---

## Motivation

The Flags & Options page is essential for developers customizing their projects.
The previous documentation only described commands, but not the full range of:
- Language selection flags  
- Network override flags  
- Wallet adapter selection  
- Template selection  
- Automation/default behaviors  
- Global/help flags  

Adding this page creates a complete CLI documentation set:
1. Commands  
2. Flags & Options  
3. Scaffolding Templates (coming next)

---

## Implementation Details

- Uses a **section + table** format to match industry-standard CLI documentation.
- All flags were validated against the official Nextellar CLI specification.
- Code examples use fenced code blocks for safe MDX parsing.
- No JSX components are used on this page to reduce rendering risks.

Sections include:
- Language Options  
- Network Configuration Flags  
- Wallet Configuration Flags  
- Template Flags  
- Automation & Defaults  
- Global Flags  
- Combining Multiple Flags  

---

## How to Test

1. Check out the branch:
   ```bash
   git checkout docs/cli/flags
