### PR TITLE
feat: implement useClipboard hook with tests (issue 42)

### DIFF
--- a/src/hooks-d/use-clipboard.test.ts
+++ b/src/hooks-d/use-clipboard.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, act } from '@testing-library/react';
+import { useClipboard } from './use-clipboard';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('useClipboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset window and navigator mocks
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should initialize with default states', () => {
+    const { result } = renderHook(() => useClipboard());
+    expect(result.current.copied).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.copy).toBe('function');
+  });
+
+  it('should successfully copy text using navigator.clipboard', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText: writeTextMock } });
+    vi.stubGlobal('window', { isSecureContext: true });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let success;
+    await act(async () => {
+      success = await result.current.copy('test text');
+    });
+
+    expect(success).toBe(true);
+    expect(writeTextMock).toHaveBeenCalledWith('test text');
+    expect(result.current.copied).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should auto-reset copied state after timeout', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText: writeTextMock } });
+    vi.stubGlobal('window', { isSecureContext: true });
+
+    const { result } = renderHook(() => useClipboard({ timeout: 1000 }));
+
+    await act(async () => {
+      await result.current.copy('test text');
+    });
+
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('should use fallback execCommand when navigator.clipboard is unavailable', async () => {
+    vi.stubGlobal('navigator', {}); // No clipboard
+    const execCommandMock = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('document', {
+      ...document,
+      execCommand: execCommandMock,
+      createElement: () => ({
+        style: {},
+        select: vi.fn(),
+        remove: vi.fn(),
+      }),
+      body: {
+        prepend: vi.fn(),
+      },
+    });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let success;
+    await act(async () => {
+      success = await result.current.copy('fallback text');
+    });
+
+    expect(success).toBe(true);
+    expect(execCommandMock).toHaveBeenCalledWith('copy');
+    expect(result.current.copied).toBe(true);
+  });
+
+  it('should handle copy errors correctly', async () => {
+    const errorMessage = 'Permission denied';
+    const writeTextMock = vi.fn().mockRejectedValue(new Error(errorMessage));
+    vi.stubGlobal('navigator', { clipboard: { writeText: writeTextMock } });
+    vi.stubGlobal('window', { isSecureContext: true });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let success;
+    await act(async () => {
+      success = await result.current.copy('error text');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.copied).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe(errorMessage);
+  });
+});

--- a/src/hooks-d/use-clipboard.ts
+++ b/src/hooks-d/use-clipboard.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+interface UseClipboardOptions {
+  timeout?: number;
+}
+
+interface UseClipboardResult<T extends string | number | boolean = string> {
+  copy: (text: T) => Promise<boolean>;
+  copied: boolean;
+  error: Error | null;
+}
+
+export function useClipboard<T extends string | number | boolean = string>({
+  timeout = 2000,
+}: UseClipboardOptions = {}): UseClipboardResult<T> {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  }, []);
+
+  const copy = useCallback(
+    async (text: T) => {
+      clearTimer();
+      setCopied(false);
+      setError(null);
+
+      const textToCopy = String(text);
+
+      if (typeof window === 'undefined') {
+        const ssrError = new Error('Clipboard is not supported in SSR');
+        setError(ssrError);
+        return false;
+      }
+
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(textToCopy);
+        } else {
+          // Fallback for older browsers or non-HTTPS contexts
+          const textArea = document.createElement('textarea');
+          textArea.value = textToCopy;
+
+          // Move outside of viewport
+          textArea.style.position = 'absolute';
+          textArea.style.left = '-999999px';
+
+          document.body.prepend(textArea);
+          textArea.select();
+
+          try {
+            const successful = document.execCommand('copy');
+            if (!successful) {
+              throw new Error('Fallback copy command was unsuccessful');
+            }
+          } finally {
+            textArea.remove();
+          }
+        }
+
+        setCopied(true);
+        timeoutRef.current = setTimeout(() => {
+          setCopied(false);
+        }, timeout);
+
+        return true;
+      } catch (err) {
+        setCopied(false);
+        setError(
+          err instanceof Error
+            ? err
+            : new Error('Unknown error during clipboard copy')
+        );
+        return false;
+      }
+    },
+    [timeout, clearTimer]
+  );
+
+  useEffect(() => {
+    return clearTimer;
+  }, [clearTimer]);
+
+  return { copy, copied, error };
+}


### PR DESCRIPTION
## Description

Closes #42

This PR introduces the `useClipboard` hook, a reusable custom React hook designed to provide cross-browser, SSR-safe copy-to-clipboard functionality. This hook is primarily intended for use in documentation code blocks and the CodePlayground component.

### Changes Included

- **`useClipboard` hook (`src/hooks-d/use-clipboard.ts`)**:
  - Implements the modern `navigator.clipboard.writeText` API for secure contexts.
  - Provides a robust fallback mechanism using a hidden `textarea` and `document.execCommand('copy')` for older browsers or non-HTTPS environments.
  - Includes a configurable auto-reset timeout for the `copied` state (defaults to 2000ms).
  - Gracefully handles SSR (Server-Side Rendering) by checking for the `window` object and safely returning a relevant error without crashing.
  - Exposes `copy` function, `copied` boolean, and `error` state.
  - Types generic `T` to explicitly allow strings, numbers, or booleans.
- **Unit Tests (`src/hooks-d/use-clipboard.test.ts`)**:
  - Comprehensive unit tests written for Vitest covering:
    - Default initialization state.
    - Successful modern API copy flow.
    - Auto-reset timeout behavior using fake timers.
    - Fallback `execCommand` flow.
    - Error handling (e.g., when permission is denied).

## Acceptance Criteria Met

- [x] Hook file located at `hooks-d/use-clipboard.ts`
- [x] Works safely in SSR (no `navigator` access during server render)
- [x] Auto-resets copied state after a configurable timeout (default 2s)
- [x] Fallback provided for older browsers
- [x] Unit tests strictly cover success, failure, and timeout reset on one file.
