### PR TITLE
feat(hooks-d): add useIntersectionObserver hook and tests

### DIFF
--- a/src/hooks-d/use-intersection-observer.test.ts
+++ b/src/hooks-d/use-intersection-observer.test.ts
@@ -1,0 +1,263 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useIntersectionObserver,
+  useScrollSpy,
+} from './use-intersection-observer';
+
+describe('useIntersectionObserver', () => {
+  let observerCallback: (entries: IntersectionObserverEntry[]) => void;
+  let observe: ReturnType<typeof vi.fn>;
+  let disconnect: ReturnType<typeof vi.fn>;
+  let unobserve: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+
+    const MockIntersectionObserver = vi.fn(
+      class MockIntersectionObserver implements IntersectionObserver {
+        readonly root: Element | null = null;
+        readonly rootMargin: string = '';
+        readonly thresholds: ReadonlyArray<number> = [];
+
+        constructor(callback: (entries: IntersectionObserverEntry[]) => void) {
+          observerCallback = callback;
+        }
+
+        observe = observe;
+        disconnect = disconnect;
+        unobserve = unobserve;
+        takeRecords = vi.fn().mockReturnValue([]);
+      }
+    );
+
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns ref, isIntersecting, and entry', () => {
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    expect(result.current).toHaveProperty('ref');
+    expect(result.current).toHaveProperty('isIntersecting');
+    expect(result.current).toHaveProperty('entry');
+    expect(typeof result.current.ref).toBe('function');
+    expect(result.current.isIntersecting).toBe(false);
+    expect(result.current.entry).toBeNull();
+  });
+
+  it('observes element when ref is attached', () => {
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    expect(observe).toHaveBeenCalledWith(el);
+  });
+
+  it('updates isIntersecting and entry when element intersects', () => {
+    const el = document.createElement('div');
+    el.id = 'test-el';
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    const entry = {
+      target: el,
+      isIntersecting: true,
+      intersectionRatio: 1,
+      boundingClientRect: {} as DOMRectReadOnly,
+      intersectionRect: {} as DOMRectReadOnly,
+      rootBounds: null,
+      time: 0,
+    } as IntersectionObserverEntry;
+
+    act(() => {
+      observerCallback([entry]);
+    });
+
+    expect(result.current.isIntersecting).toBe(true);
+    expect(result.current.entry).toBe(entry);
+  });
+
+  it('disconnects observer on unmount', () => {
+    const el = document.createElement('div');
+    const { result, unmount } = renderHook(() => useIntersectionObserver());
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('disconnects when ref is set to null', () => {
+    const el = document.createElement('div');
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    act(() => {
+      result.current.ref(null);
+    });
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('triggerOnce disconnects after first intersection', () => {
+    const el = document.createElement('div');
+    const { result } = renderHook(() =>
+      useIntersectionObserver({ triggerOnce: true })
+    );
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    const entry = {
+      target: el,
+      isIntersecting: true,
+      intersectionRatio: 1,
+      boundingClientRect: {} as DOMRectReadOnly,
+      intersectionRect: {} as DOMRectReadOnly,
+      rootBounds: null,
+      time: 0,
+    } as IntersectionObserverEntry;
+
+    act(() => {
+      observerCallback([entry]);
+    });
+
+    expect(result.current.isIntersecting).toBe(true);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('passes threshold and rootMargin to IntersectionObserver', () => {
+    let capturedOptions: IntersectionObserverInit | undefined;
+    const MockIO = vi.fn(
+      function (
+        this: unknown,
+        _callback: () => void,
+        options?: IntersectionObserverInit
+      ) {
+        capturedOptions = options;
+        return {
+          observe: vi.fn(),
+          disconnect: vi.fn(),
+          unobserve: vi.fn(),
+          takeRecords: vi.fn().mockReturnValue([]),
+        };
+      }
+    );
+    vi.stubGlobal('IntersectionObserver', MockIO);
+
+    const el = document.createElement('div');
+    const { result } = renderHook(() =>
+      useIntersectionObserver({ threshold: 0.5, rootMargin: '10px' })
+    );
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    expect(capturedOptions).toEqual(
+      expect.objectContaining({
+        threshold: 0.5,
+        rootMargin: '10px',
+      })
+    );
+  });
+
+  it('works with dynamically attached ref (element added later)', () => {
+    const { result } = renderHook(() => useIntersectionObserver());
+
+    expect(observe).not.toHaveBeenCalled();
+
+    const el = document.createElement('div');
+    act(() => {
+      result.current.ref(el);
+    });
+
+    expect(observe).toHaveBeenCalledWith(el);
+  });
+});
+
+describe('useScrollSpy', () => {
+  let observerCallback: (entries: IntersectionObserverEntry[]) => void;
+  let observe: ReturnType<typeof vi.fn>;
+  let disconnect: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    observe = vi.fn();
+    disconnect = vi.fn();
+
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(
+        class MockIntersectionObserver implements IntersectionObserver {
+          readonly root: Element | null = null;
+          readonly rootMargin: string = '';
+          readonly thresholds: ReadonlyArray<number> = [];
+
+          constructor(
+            callback: (entries: IntersectionObserverEntry[]) => void
+          ) {
+            observerCallback = callback;
+          }
+
+          observe = observe;
+          disconnect = disconnect;
+          unobserve = vi.fn();
+          takeRecords = vi.fn().mockReturnValue([]);
+        }
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('returns empty string when no headings', () => {
+    const { result } = renderHook(() => useScrollSpy([]));
+    expect(result.current).toBe('');
+  });
+
+  it('returns active id when element is intersecting', () => {
+    const el = document.createElement('div');
+    el.id = 'section-1';
+    document.body.appendChild(el);
+
+    const { result } = renderHook(() => useScrollSpy(['section-1']));
+
+    act(() => {
+      observerCallback([
+        {
+          target: el,
+          isIntersecting: true,
+          intersectionRatio: 1,
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRect: {} as DOMRectReadOnly,
+          rootBounds: null,
+          time: 0,
+        } as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(result.current).toBe('section-1');
+  });
+});

--- a/src/hooks-d/use-intersection-observer.ts
+++ b/src/hooks-d/use-intersection-observer.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseIntersectionObserverOptions {
+  /** Number or array of ratios in [0, 1] at which to trigger. Default 0. */
+  threshold?: number | number[];
+  /** Margin around the root. Default "0px". */
+  rootMargin?: string;
+  /** Root element for the observer. Default null (viewport). */
+  root?: Element | null;
+  /** If true, disconnect after the first time the element intersects. */
+  triggerOnce?: boolean;
+}
+
+export interface UseIntersectionObserverReturn {
+  /** Callback ref to attach to the element to observe. */
+  ref: (node: Element | null) => void;
+  /** Whether the element is currently intersecting the root. */
+  isIntersecting: boolean;
+  /** Latest IntersectionObserverEntry, or null before first callback. */
+  entry: IntersectionObserverEntry | null;
+}
+
+/**
+ * Wraps the IntersectionObserver API with React lifecycle management.
+ * Use for lazy-loading (e.g. Mermaid, CodePlayground) or scroll-spy.
+ * Disconnects the observer on unmount and, when triggerOnce is true, after first intersection.
+ */
+export function useIntersectionObserver(
+  options: UseIntersectionObserverOptions = {}
+): UseIntersectionObserverReturn {
+  const {
+    threshold = 0,
+    rootMargin = '0px',
+    root = null,
+    triggerOnce = false,
+  } = options;
+
+  const [entry, setEntry] = useState<IntersectionObserverEntry | null>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  const elementRef = useRef<Element | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const triggeredOnceRef = useRef(false);
+
+  const ref = useCallback(
+    (node: Element | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      elementRef.current = node;
+
+      if (node === null) {
+        setEntry(null);
+        setIsIntersecting(false);
+        return;
+      }
+
+      if (triggeredOnceRef.current && triggerOnce) return;
+
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          const first = entries[0];
+          if (!first) return;
+          setEntry(first);
+          setIsIntersecting(first.isIntersecting);
+          if (first.isIntersecting && triggerOnce) {
+            triggeredOnceRef.current = true;
+            observerRef.current?.disconnect();
+            observerRef.current = null;
+          }
+        },
+        { threshold, rootMargin, root: root ?? undefined }
+      );
+      observerRef.current.observe(node);
+    },
+    [threshold, rootMargin, root, triggerOnce]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+    };
+  }, []);
+
+  return { ref, isIntersecting, entry };
+}
+
+export interface UseScrollSpyOptions {
+  threshold?: number | number[];
+  rootMargin?: string;
+  root?: Element | null;
+}
+
+/**
+ * Observes multiple heading elements by id and returns the id of the one
+ * currently intersecting (for table-of-contents scroll-spy).
+ * Uses the same options as useIntersectionObserver.
+ */
+export function useScrollSpy(
+  headingIds: string[],
+  options: UseScrollSpyOptions = {}
+): string {
+  const { threshold = 0, rootMargin = '-80px 0px -80% 0px', root = null } =
+    options;
+  const [activeId, setActiveId] = useState('');
+
+  const idsKey = headingIds.join(',');
+
+  useEffect(() => {
+    if (headingIds.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { threshold, rootMargin, root: root ?? undefined }
+    );
+
+    headingIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [idsKey, rootMargin, root, threshold]);
+
+  return activeId;
+}


### PR DESCRIPTION
## Description

Closes #45

This PR adds a `useIntersectionObserver` hook in `hooks-d/` to power lazy-loading of heavy components (e.g. Mermaid diagrams, CodePlayground) and to support scroll-spy highlighting in the table of contents. The hook wraps the IntersectionObserver API with React lifecycle management and supports configurable options and `triggerOnce` mode.

### Changes Included

- **`src/hooks-d/use-intersection-observer.ts`**:
  - `useIntersectionObserver(options)` – returns `{ ref, isIntersecting, entry }`.
  - Configurable `threshold`, `rootMargin`, and `root` element.
  - `triggerOnce` option disconnects the observer after the first intersection.
  - Callback `ref` for attaching to dynamically rendered elements.
  - Disconnects observer on unmount.
  - `useScrollSpy(headingIds, options)` – helper for TOC scroll-spy (same options shape).
- **`src/hooks-d/use-intersection-observer.test.ts`**:
  - Unit tests with mocked `IntersectionObserver`.
  - Covers: return shape, observe on ref attach, `isIntersecting`/`entry` updates, disconnect on unmount, disconnect when ref set to null, `triggerOnce` disconnects after first intersection, options passed to observer, dynamically attached ref.
  - `useScrollSpy`: empty headings, active id when intersecting.

## Acceptance Criteria Met

- [x] Hook file at `hooks-d/use-intersection-observer.ts`
- [x] `triggerOnce` mode disconnects after first intersection
- [x] Works with dynamically rendered elements (callback ref)
- [x] Unit tests with mocked IntersectionObserver
- [ ] Integrate with auto-toc.tsx for scroll-spy highlighting (follow-up PR or separate commit)

