### PR TITLE
feat: implement useDebounce hook and optimize search #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "test": "echo \"No tests configured\" && exit 0"
+    "test": "echo \"No tests configured\" && exit 0",
+    "test:unit": "vitest run"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md,mdx}": [
@@ -80,19 +81,24 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.0.13",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.20",
     "concurrently": "^9.1.2",
     "eslint": "^9",
     "eslint-config-next": "16.1.3",
     "husky": "^9.1.7",
+    "jsdom": "^28.1.0",
     "lint-staged": "^15.5.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -7,6 +7,7 @@ import React, {
   useImperativeHandle,
   useEffect,
 } from 'react';
+import { useDebounce } from '@/hooks-d/use-debounce';
 import { Dialog, DialogTrigger, DialogContent } from '@/components/dialog';
 import { Input } from '@/components/input';
 import SearchButton from '@/components/search-button';
@@ -101,6 +102,7 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
   ({ searchData }, ref) => {
     const [open, setOpen] = useState(false);
     const [query, setQuery] = useState('');
+    const debouncedQuery = useDebounce(query, 300, true);
 
     useImperativeHandle(ref, () => ({
       close: () => setOpen(false),
@@ -119,14 +121,14 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
     }, []);
 
     const filteredDocs = useMemo(() => {
-      if (!query) return [];
-      const q = query.toLowerCase();
+      if (!debouncedQuery) return [];
+      const q = debouncedQuery.toLowerCase();
       return searchData.filter((doc) => {
         const title = doc.title.toLowerCase();
         const description = stripMarkdown(doc.body.raw || '').toLowerCase();
         return title.includes(q) || description.includes(q);
       });
-    }, [query, searchData]);
+    }, [debouncedQuery, searchData]);
 
     return (
       <Dialog open={open} setOpen={setOpen}>
@@ -173,12 +175,12 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
                     >
                       <div className="flex flex-col gap-3">
                         <div className="flex gap-2 font-bold">
-                          <Text /> <div>{highlightText(doc.title, query)}</div>
+                          <Text /> <div>{highlightText(doc.title, debouncedQuery)}</div>
                         </div>
                         <div className="text-sm">
                           {getSnippet(
                             stripMarkdown(doc.body.raw || ''),
-                            query
+                            debouncedQuery
                           ) || 'No description'}
                         </div>
                       </div>

--- a/src/hooks-d/__tests__/use-debounce.test.ts
+++ b/src/hooks-d/__tests__/use-debounce.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from '../use-debounce';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('useDebounce', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should return initial value', () => {
+        const { result } = renderHook(() => useDebounce('test', 300));
+        expect(result.current).toBe('test');
+    });
+
+    it('should debounce value changes', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebounce(value, 300),
+            {
+                initialProps: { value: 'initial' },
+            }
+        );
+
+        rerender({ value: 'changed' });
+
+        // Should still be initial immediately after change
+        expect(result.current).toBe('initial');
+
+        // Fast-forward time
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(result.current).toBe('changed');
+    });
+
+    it('should cleanup timeout on unmount', () => {
+        const spy = vi.spyOn(global, 'clearTimeout');
+        const { unmount } = renderHook(() => useDebounce('test', 300));
+
+        unmount();
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('should update immediately if immediate is true for the first change', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebounce(value, 300, true),
+            {
+                initialProps: { value: 'initial' },
+            }
+        );
+
+        rerender({ value: 'immediate-change' });
+
+        // Should update immediately due to immediate=true and being the first change
+        expect(result.current).toBe('immediate-change');
+    });
+
+    it('should debounce subsequent changes even if immediate is true', () => {
+        const { result, rerender } = renderHook(
+            ({ value }) => useDebounce(value, 300, true),
+            {
+                initialProps: { value: 'initial' },
+            }
+        );
+
+        // First change: immediate
+        rerender({ value: 'first-change' });
+        expect(result.current).toBe('first-change');
+
+        // Second change: debounced
+        rerender({ value: 'second-change' });
+        expect(result.current).toBe('first-change');
+
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+
+        expect(result.current).toBe('second-change');
+    });
+});

--- a/src/hooks-d/use-debounce.ts
+++ b/src/hooks-d/use-debounce.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * A hook that debounces a value.
+ * Useful for optimizing search inputs or any other fast-changing values.
+ *
+ * @param value The value to debounce
+ * @param delay The delay in milliseconds (default: 300)
+ * @param immediate Whether to update the value immediately on the first change
+ * @returns The debounced value
+ */
+export function useDebounce<T>(
+  value: T,
+  delay: number = 300,
+  immediate: boolean = false
+): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const isFirstUpdate = useRef(true);
+
+  useEffect(() => {
+    // If immediate is true and it's the first value change (from initial), update immediately
+    if (immediate && isFirstUpdate.current && value !== debouncedValue) {
+      setDebouncedValue(value);
+      isFirstUpdate.current = false;
+      return;
+    }
+
+    // Update isFirstUpdate even if immediate is false, so we track that at least one update happened
+    if (value !== debouncedValue) {
+      isFirstUpdate.current = false;
+    }
+
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cleanup on unmount or whenever value/delay changes
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay, immediate, debouncedValue]);
+
+  return debouncedValue;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        environment: 'jsdom',
+        globals: true,
+    },
+});


### PR DESCRIPTION
## Description
Create a useDebounce hook to debounce rapidly changing values, primarily for the search dialog in the docs to avoid filtering on every keystroke.

Closes #43

## Changes proposed

### What were you told to do?
I was tasked with creating a useDebounce hook for search input optimization.

Requirements included:
- Create useDebounce hook in hooks-d/ folder.
- Configurable delay (default 300ms).
- Cleanup on unmount to prevent memory leaks.
- Immediate mode option for the first call.
- Proper TypeScript generic support.
- Unit tests with fake timers.
- Integrate with the existing search-dialog.tsx component.

### What did I do?

#### Implementation of the useDebounce hook
- Created \src/hooks-d/use-debounce.ts\ implementing the generic hook with an \immediate\ mode option.
- Implemented state management and \useEffect\ logic with \setTimeout\ and \clearTimeout\.

#### Verification and testing
- Created \src/hooks-d/__tests__/use-debounce.test.ts\ using Vitest and React Testing Library.
- Tests cover initial value, debouncing logic, cleanup, and immediate mode behavior.
- Configured \itest.config.ts\ and added \	est:unit\ script to \package.json\.

#### Integration
- Updated \src/components/search-dialog.tsx\ to use the new hook.
- Enabled \immediate\ mode for the first keystroke to ensure a responsive search experience while debouncing subsequent rapid typing.

#### Validation and results
- All tests passed successfully.
- Code follows project structure and naming conventions.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Vitest output showing 5 passed tests for useDebounce.
- Manual verification of search dialog responsiveness and debounce behavior.