### PR TITLE
feat(hooks): implement useKeyboardShortcut hook #46

### DIFF
--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
 } from 'react';
 import { useDebounce } from '@/hooks-d/use-debounce';
+import { useKeyboardShortcut } from '@/hooks-d/use-keyboard-shortcut';
 import { Dialog, DialogTrigger, DialogContent } from '@/components/dialog';
 import { Input } from '@/components/input';
 import SearchButton from '@/components/search-button';
@@ -109,16 +110,8 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
       open: () => setOpen(true),
     }));
 
-    useEffect(() => {
-      const handleKeyDown = (e: KeyboardEvent) => {
-        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-          e.preventDefault();
-          setOpen(true);
-        }
-      };
-      document.addEventListener('keydown', handleKeyDown);
-      return () => document.removeEventListener('keydown', handleKeyDown);
-    }, []);
+    useKeyboardShortcut('mod+k', () => setOpen(true));
+
 
     const filteredDocs = useMemo(() => {
       if (!debouncedQuery) return [];

--- a/src/hooks-d/__tests__/use-keyboard-shortcut.test.ts
+++ b/src/hooks-d/__tests__/use-keyboard-shortcut.test.ts
@@ -1,0 +1,124 @@
+import { renderHook, act } from '@testing-library/react';
+import { useKeyboardShortcut } from '../use-keyboard-shortcut';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('useKeyboardShortcut', () => {
+    const mockCallback = vi.fn();
+
+    beforeEach(() => {
+        mockCallback.mockClear();
+        vi.useFakeTimers();
+    });
+
+    const fireKeyEvent = (params: any) => {
+        const event = new KeyboardEvent('keydown', params);
+        window.dispatchEvent(event);
+        return event;
+    };
+
+    it('should trigger callback for simple key', () => {
+        renderHook(() => useKeyboardShortcut('k', mockCallback));
+        fireKeyEvent({ key: 'k' });
+        expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it('should trigger callback for mod+k (MacOS metaKey)', () => {
+        // Mock navigator to appear as Mac
+        Object.defineProperty(navigator, 'userAgent', {
+            value: 'Macintosh',
+            configurable: true
+        });
+
+        renderHook(() => useKeyboardShortcut('mod+k', mockCallback));
+
+        // Should NOT fire with just k
+        fireKeyEvent({ key: 'k' });
+        expect(mockCallback).not.toHaveBeenCalled();
+
+        // Should fire with meta+k
+        fireKeyEvent({ key: 'k', metaKey: true });
+        expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it('should trigger callback for mod+k (Windows/Linux ctrlKey)', () => {
+        // Mock navigator to appear as Windows
+        Object.defineProperty(navigator, 'userAgent', {
+            value: 'Windows',
+            configurable: true
+        });
+
+        renderHook(() => useKeyboardShortcut('mod+k', mockCallback));
+
+        // Should fire with ctrl+k
+        fireKeyEvent({ key: 'k', ctrlKey: true });
+        expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it('should trigger callback for multiple modifiers alt+shift+d', () => {
+        renderHook(() => useKeyboardShortcut('alt+shift+d', mockCallback));
+
+        fireKeyEvent({ key: 'd', altKey: true, shiftKey: true });
+        expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it('should not trigger callback when typing in input field by default', () => {
+        renderHook(() => useKeyboardShortcut('k', mockCallback));
+
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+
+        fireKeyEvent({ key: 'k' });
+        expect(mockCallback).not.toHaveBeenCalled();
+
+        document.body.removeChild(input);
+    });
+
+    it('should trigger callback in input if ignoreInputFocus is false', () => {
+        renderHook(() => useKeyboardShortcut('k', mockCallback, { ignoreInputFocus: false }));
+
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+
+        fireKeyEvent({ key: 'k' });
+        expect(mockCallback).toHaveBeenCalled();
+
+        document.body.removeChild(input);
+    });
+
+    it('should handle key sequences (g then d)', () => {
+        renderHook(() => useKeyboardShortcut('g d', mockCallback));
+
+        fireKeyEvent({ key: 'g' });
+        expect(mockCallback).not.toHaveBeenCalled();
+
+        fireKeyEvent({ key: 'd' });
+        expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it('should reset sequence after timeout', () => {
+        renderHook(() => useKeyboardShortcut('g d', mockCallback));
+
+        fireKeyEvent({ key: 'g' });
+
+        // Fast forward more than 1s
+        act(() => {
+            vi.advanceTimersByTime(1500);
+        });
+
+        fireKeyEvent({ key: 'd' });
+        expect(mockCallback).not.toHaveBeenCalled();
+    });
+
+    it('should prevent default when configured', () => {
+        renderHook(() => useKeyboardShortcut('k', mockCallback, { preventDefault: true }));
+
+        const event = new KeyboardEvent('keydown', { key: 'k' });
+        vi.spyOn(event, 'preventDefault');
+        window.dispatchEvent(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(mockCallback).toHaveBeenCalled();
+    });
+});

--- a/src/hooks-d/use-keyboard-shortcut.ts
+++ b/src/hooks-d/use-keyboard-shortcut.ts
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export type KeyboardShortcutOptions = {
+    preventDefault?: boolean;
+    ignoreInputFocus?: boolean;
+};
+
+/**
+ * A hook that registers global keyboard shortcuts for the documentation site.
+ * Supports modifier keys (Ctrl, Cmd, Shift, Alt) and key sequences.
+ * 
+ * @param shortcut Standardized shortcut string (e.g., 'mod+k', 'alt+shift+d', 'g d')
+ * @param callback Function to execute when shortcut is triggered
+ * @param options Configuration options
+ */
+export function useKeyboardShortcut(
+    shortcut: string,
+    callback: (event: KeyboardEvent) => void,
+    options: KeyboardShortcutOptions = {}
+) {
+    const { preventDefault = true, ignoreInputFocus = true } = options;
+    const callbackRef = useRef(callback);
+    const sequenceRef = useRef<{ keys: string[]; lastTime: number }>({
+        keys: [],
+        lastTime: 0,
+    });
+
+    // Always use the latest callback
+    useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            // 1. Check if we should ignore based on focus
+            if (ignoreInputFocus) {
+                const activeElement = document.activeElement;
+                const isInput =
+                    activeElement instanceof HTMLInputElement ||
+                    activeElement instanceof HTMLTextAreaElement ||
+                    activeElement?.hasAttribute('contenteditable') ||
+                    (activeElement as any)?.isContentEditable;
+
+                if (isInput) {
+                    // Exceptions: allow Escape even in inputs if needed? 
+                    // Usually, shortcuts like mod+k should be ignored in inputs.
+                    // But sequences like 'Escape' might be useful.
+                    // For now, follow the requirement: "Does not fire when user is typing in an input field".
+                    return;
+                }
+            }
+
+            const isMac =
+                typeof window !== 'undefined' &&
+                /Mac|iPod|iPhone|iPad/.test(navigator.userAgent || navigator.platform || '');
+
+            const parts = shortcut.toLowerCase().split(' ');
+            const isSequence = parts.length > 1;
+
+            if (isSequence) {
+                // Handle sequence (e.g., 'g d')
+                const now = Date.now();
+                // If more than 1 second since last key, reset sequence
+                if (now - sequenceRef.current.lastTime > 1000) {
+                    sequenceRef.current.keys = [];
+                }
+
+                sequenceRef.current.keys.push(event.key.toLowerCase());
+                sequenceRef.current.lastTime = now;
+
+                // Check if current buffer matches sequence
+                const currentBuffer = sequenceRef.current.keys.join(' ');
+                if (currentBuffer.endsWith(shortcut.toLowerCase())) {
+                    if (preventDefault) event.preventDefault();
+                    callbackRef.current(event);
+                    sequenceRef.current.keys = []; // Reset after match
+                }
+            } else {
+                // Handle single shortcut (e.g., 'mod+k')
+                const keys = shortcut.toLowerCase().split('+');
+
+                const hasMod = keys.includes('mod');
+                const hasCtrl = keys.includes('ctrl') || (hasMod && !isMac);
+                const hasMeta = keys.includes('meta') || (hasMod && isMac);
+                const hasAlt = keys.includes('alt');
+                const hasShift = keys.includes('shift');
+
+                // Find the main key (the one that isn't a modifier)
+                const mainKey = keys.find(k => !['mod', 'ctrl', 'meta', 'alt', 'shift'].includes(k));
+
+                if (!mainKey) return;
+
+                const isMatch =
+                    event.key.toLowerCase() === mainKey &&
+                    event.ctrlKey === hasCtrl &&
+                    event.metaKey === hasMeta &&
+                    event.altKey === hasAlt &&
+                    event.shiftKey === hasShift;
+
+                if (isMatch) {
+                    if (preventDefault) event.preventDefault();
+                    callbackRef.current(event);
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [shortcut, preventDefault, ignoreInputFocus]);
+}


### PR DESCRIPTION
## Description
Create a `useKeyboardShortcut` hook that registers global keyboard shortcuts for the documentation site.

Closes #46

## Changes proposed

### What were you told to do?
I was tasked with creating a reusable hook to handle global keyboard shortcuts, specifically to replace hardcoded listeners and support complex key interactions.

Requirements included:
- Create hook in `hooks-d/` folder.
- Register/unregister global keyboard event listeners with cleanup.
- Support platform-specific `mod` alias (Cmd on macOS, Ctrl on Windows/Linux).
- Prevent shortcuts from firing when typing in input fields (configurable).
- Support key sequences (e.g., "g" then "d").
- Unit tests for modifier detection and input exclusion.
- Integrate with `search-dialog.tsx`.

### What did I do?

#### Implementation of the useKeyboardShortcut hook
- Created `src/hooks-d/use-keyboard-shortcut.ts` which implements a robust listener with modifier detection.
- Added logic to identify "Mac" vs "Other" platforms to resolve the `mod` key correctly.
- Implemented a sequence buffer that resets after a 1-second timeout to support multi-key sequences like "g d".
- Added an `ignoreInputFocus` protection layer that detects if the user is currently focused on an `input`, `textarea`, or `contenteditable` element.

#### Verification and testing
- Created `src/hooks-d/__tests__/use-keyboard-shortcut.test.ts` with 9 comprehensive tests.
- Verified:
    - Platform-specific modifier resolution.
    - Default prevention and cleanup.
    - Focus detection (ignoring shortcuts while the user is typing).
    - Sequence matching and time-based resets.

#### Integration
- Updated `src/components/search-dialog.tsx`.
- Removed the manual `useEffect` logic and replaced it with a clean `useKeyboardShortcut('mod+k', ...)` call.

#### Validation and results
- All 9 unit tests passed successfully.
- Code matches the project's TypeScript and naming conventions.

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Vitest output showing 9 passed tests for `useKeyboardShortcut`.
- Manual verification of the Search Dialog opening correctly with `Cmd+K` (Mac) and `Ctrl+K` (Windows).
- Verified that shortcuts do not trigger while typing inside the Search Input field itself.
