### PR TITLE
feat: create useWindowSizeHook for responsive component logic

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -156,6 +156,7 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'BalanceCard', href: '/docs/components/balance-card' },
       { title: 'TransactionList', href: '/docs/components/transaction-list' },
       { title: 'PaymentForm', href: '/docs/components/payment-form' },
+      { title: 'useWindowSize', href: '/docs/components/use-window-size' },
     ],
   },
 ];

--- a/docs/components/use-window-size.mdx
+++ b/docs/components/use-window-size.mdx
@@ -1,0 +1,80 @@
+---
+title: useWindowSize
+description: 'Track window dimensions and breakpoint helpers for responsive logic that can''t be handled with CSS alone.'
+date: 2025-02-25
+---
+
+# useWindowSize
+
+The `useWindowSize` hook tracks window dimensions and exposes `width`, `height`, and Tailwind-aligned breakpoint helpers (`isMobile`, `isTablet`, `isDesktop`) for responsive logic that can't be handled with CSS alone.
+
+## Features
+
+- **SSR-safe:** Returns `undefined` for dimensions and breakpoints during server render to avoid Next.js hydration mismatch.
+- **Throttled resize** (default 100ms) to avoid excessive updates.
+- **Optional debounce** for expensive recalculations.
+- **Breakpoints** match Tailwind: `sm` 640px, `md` 768px, `lg` 1024px.
+
+## API
+
+```ts
+const { width, height, isMobile, isTablet, isDesktop } = useWindowSize({ throttle: 100 });
+```
+
+| Return      | Type              | Description                                      |
+| ----------- | ----------------- | ------------------------------------------------ |
+| `width`     | `number \| undefined` | Window inner width; `undefined` during SSR. |
+| `height`    | `number \| undefined` | Window inner height; `undefined` during SSR. |
+| `isMobile`  | `boolean \| undefined` | `true` when width &lt; 640px (below `sm`).   |
+| `isTablet`  | `boolean \| undefined` | `true` when 640px ≤ width &lt; 1024px (`sm` to `lg`). |
+| `isDesktop` | `boolean \| undefined` | `true` when width ≥ 1024px (`lg` and up).   |
+
+Options:
+
+- `throttle` (default `100`): Throttle interval for resize events in ms.
+- `debounce`: If set, use debounce instead of throttle for resize updates.
+
+## Example: Conditional mobile vs desktop navigation
+
+Use the breakpoint helpers to render different navigation UIs for mobile and desktop without relying only on CSS:
+
+```tsx
+'use client';
+
+import { useWindowSize } from '@/hooks-d/use-window-size';
+
+function MobileNav() {
+  return (
+    <nav className="flex md:hidden">
+      <button aria-label="Menu">☰</button>
+      {/* Mobile menu content */}
+    </nav>
+  );
+}
+
+function DesktopNav() {
+  return (
+    <nav className="hidden md:flex gap-6">
+      <a href="/docs">Docs</a>
+      <a href="/api">API</a>
+    </nav>
+  );
+}
+
+export function AppNav() {
+  const { isMobile, isDesktop } = useWindowSize({ throttle: 100 });
+
+  // SSR: isMobile/isDesktop are undefined → render a single default or placeholder
+  if (isMobile === undefined && isDesktop === undefined) {
+    return <nav className="h-10" aria-hidden />; // placeholder to avoid layout shift
+  }
+
+  if (isMobile) return <MobileNav />;
+  if (isDesktop) return <DesktopNav />;
+
+  // Tablet: could render either or a dedicated layout
+  return <DesktopNav />;
+}
+```
+
+This pattern avoids hydration mismatch because the hook returns `undefined` on the server and on the first client paint until the effect runs; you can render a neutral placeholder until dimensions are known, then switch to mobile or desktop nav.

--- a/src/hooks-d/__tests__/use-window-size.test.ts
+++ b/src/hooks-d/__tests__/use-window-size.test.ts
@@ -1,0 +1,138 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWindowSize } from '../use-window-size';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('useWindowSize', () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight, writable: true });
+  });
+
+  function setWindowSize(width: number, height: number) {
+    Object.defineProperty(window, 'innerWidth', { value: width, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: height, writable: true });
+  }
+
+  function dispatchResize() {
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+  }
+
+  it('returns shape with width, height, and breakpoint helpers', () => {
+    setWindowSize(800, 600);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    expect(result.current).toHaveProperty('width');
+    expect(result.current).toHaveProperty('height');
+    expect(result.current).toHaveProperty('isMobile');
+    expect(result.current).toHaveProperty('isTablet');
+    expect(result.current).toHaveProperty('isDesktop');
+  });
+
+  it('updates to window dimensions after effect and resize', () => {
+    setWindowSize(800, 600);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.width).toBe(800);
+    expect(result.current.height).toBe(600);
+  });
+
+  it('breakpoint helpers match Tailwind: isTablet at 768', () => {
+    setWindowSize(768, 600);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.width).toBe(768);
+    expect(result.current.isMobile).toBe(false); // 768 >= 640
+    expect(result.current.isTablet).toBe(true);  // 640 <= 768 < 1024
+    expect(result.current.isDesktop).toBe(false);
+  });
+
+  it('breakpoint helpers: isMobile below 640', () => {
+    setWindowSize(639, 480);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.isMobile).toBe(true);
+    expect(result.current.isTablet).toBe(false);
+    expect(result.current.isDesktop).toBe(false);
+  });
+
+  it('breakpoint helpers: isDesktop at 1024', () => {
+    setWindowSize(1024, 768);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.isMobile).toBe(false);
+    expect(result.current.isTablet).toBe(false);
+    expect(result.current.isDesktop).toBe(true);
+  });
+
+  it('throttles resize events (default 100ms)', () => {
+    setWindowSize(500, 500);
+    const { result } = renderHook(() => useWindowSize({ throttle: 100 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.width).toBe(500);
+    expect(result.current.height).toBe(500);
+    setWindowSize(600, 600);
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.width).toBe(600);
+    expect(result.current.height).toBe(600);
+  });
+
+  it('uses custom throttle option', () => {
+    setWindowSize(400, 400);
+    const { result } = renderHook(() => useWindowSize({ throttle: 200 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current.width).toBe(400);
+    expect(result.current.height).toBe(400);
+  });
+
+  it('debounce option delays update', () => {
+    setWindowSize(300, 300);
+    const { result } = renderHook(() => useWindowSize({ debounce: 150 }));
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    setWindowSize(320, 320);
+    dispatchResize();
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(result.current.width).toBe(320);
+    expect(result.current.height).toBe(320);
+  });
+});

--- a/src/hooks-d/use-window-size.ts
+++ b/src/hooks-d/use-window-size.ts
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Tailwind default breakpoints (match tailwind.config.js).
+ * Used for isMobile / isTablet / isDesktop helpers.
+ */
+const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+} as const;
+
+export interface UseWindowSizeOptions {
+  /** Throttle interval for resize events in ms. Default: 100 */
+  throttle?: number;
+  /** If set, use debounce instead of throttle for resize (e.g. for expensive recalculations). */
+  debounce?: number;
+}
+
+export interface UseWindowSizeReturn {
+  /** Window inner width, or undefined during SSR */
+  width: number | undefined;
+  /** Window inner height, or undefined during SSR */
+  height: number | undefined;
+  /** true when width < 640px (Tailwind sm), undefined during SSR */
+  isMobile: boolean | undefined;
+  /** true when 640px <= width < 1024px (sm to lg), undefined during SSR */
+  isTablet: boolean | undefined;
+  /** true when width >= 1024px (Tailwind lg), undefined during SSR */
+  isDesktop: boolean | undefined;
+}
+
+function getSize(): { width: number; height: number } | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+function getBreakpointHelpers(width: number | undefined): Pick<UseWindowSizeReturn, 'isMobile' | 'isTablet' | 'isDesktop'> {
+  if (width === undefined) {
+    return { isMobile: undefined, isTablet: undefined, isDesktop: undefined };
+  }
+  return {
+    isMobile: width < BREAKPOINTS.sm,
+    isTablet: width >= BREAKPOINTS.sm && width < BREAKPOINTS.lg,
+    isDesktop: width >= BREAKPOINTS.lg,
+  };
+}
+
+/**
+ * Tracks window dimensions and exposes width/height plus breakpoint helpers for
+ * responsive logic that can't be handled with CSS alone.
+ *
+ * SSR-safe: width, height, and breakpoint helpers are undefined during server render
+ * to avoid hydration mismatch in Next.js.
+ *
+ * @param options.throttle - Throttle interval for resize events (default 100ms).
+ * @param options.debounce - If set, debounce resize updates instead of throttling.
+ * @returns { width, height, isMobile, isTablet, isDesktop }
+ *
+ * @example
+ * // Conditionally render mobile vs desktop navigation
+ * function Nav() {
+ *   const { isMobile, isDesktop } = useWindowSize({ throttle: 100 });
+ *   if (isMobile) return <MobileNav />;
+ *   if (isDesktop) return <DesktopNav />;
+ *   return <TabletNav />;
+ * }
+ */
+export function useWindowSize(options: UseWindowSizeOptions = {}): UseWindowSizeReturn {
+  const { throttle = 100, debounce: debounceMs } = options;
+
+  // SSR-safe: undefined on server and on first client paint to avoid hydration mismatch
+  const [size, setSize] = useState<{ width: number; height: number } | undefined>(() => undefined);
+  const lastRun = useRef<number>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const updateSize = useCallback(() => {
+    const next = getSize();
+    if (next) setSize(next);
+  }, []);
+
+  const scheduleUpdate = useCallback(() => {
+    if (debounceMs !== undefined) {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(updateSize, debounceMs);
+      return;
+    }
+    const now = Date.now();
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    if (now - lastRun.current >= throttle) {
+      lastRun.current = now;
+      updateSize();
+    } else {
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        const now2 = Date.now();
+        if (now2 - lastRun.current >= throttle) {
+          lastRun.current = now2;
+          updateSize();
+        }
+      });
+    }
+  }, [throttle, debounceMs, updateSize]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setSize(getSize());
+    window.addEventListener('resize', scheduleUpdate);
+    return () => {
+      window.removeEventListener('resize', scheduleUpdate);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [scheduleUpdate]);
+
+  const { isMobile, isTablet, isDesktop } = getBreakpointHelpers(size?.width);
+
+  return {
+    width: size?.width,
+    height: size?.height,
+    isMobile,
+    isTablet,
+    isDesktop,
+  };
+}


### PR DESCRIPTION
Closes #60

---

Added a `useWindowSize` hook in `hooks-d/` that tracks window dimensions and exposes:

- `width`
- `height`
- Tailwind-aligned breakpoint helpers:
  - `isMobile`
  - `isTablet`
  - `isDesktop`

This enables responsive logic that cannot be handled with CSS alone.
---
## Changes

### `src/hooks-d/use-window-size.ts`

New hook with:
- **Throttled resize listener**  
  - Default throttle: `100ms`
  - Optional debounce mode for heavier computations

- **SSR-safe behavior**
  - `width` and `height` are `undefined` on the server and during the first client render
  - Breakpoint helpers are also `undefined` initially
  - Prevents hydration mismatches

- **Tailwind-aligned breakpoints**
  - `isMobile`: `< 640px`
  - `isTablet`: `640px – 1023px`
  - `isDesktop`: `≥ 1024px`

---

### `src/hooks-d/__tests__/use-window-size.test.ts`

Unit tests include:

- Mocked `window.innerWidth` and `window.innerHeight`
- Resize event simulation
- Throttle and debounce behavior validation
- Breakpoint helper validation

**Total: 8 tests**

---

### `docs/components/use-window-size.mdx`

Documentation includes:

- Hook API
- Available options
- Example: conditional mobile vs desktop navigation rendering

---

### `config/sidebar.tsx`

- Added sidebar link to the new documentation under **Components**

---

## API

```ts
const { width, height, isMobile, isTablet, isDesktop } = useWindowSize({
  throttle: 100,
});
```

### Options

| Option   | Type   | Default | Description                          |
|----------|--------|---------|--------------------------------------|
| throttle | number | 100     | Resize event throttle duration (ms)  |
| debounce | number | —       | Optional debounce duration (ms)      |

---

## Acceptance Criteria

- [x] Hook exists at `hooks-d/use-window-size.ts`
- [x] Throttled resize listener (default `100ms`)
- [x] SSR-safe (no hydration mismatch)
- [x] Breakpoint helpers match Tailwind
- [x] Unit tests with mocked window dimensions
- [x] Documentation example: conditional mobile vs desktop navigation