### PR TITLE
Implement useToggle hook for boolean state management

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
+import { useToggle } from '@/hooks-d/use-toggle';
 import { Menu, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ModeToggle } from '@/components/mode-toggle';
@@ -15,7 +16,7 @@ const routes = [
 ];
 
 const NavigationBar = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, { toggle, off: closeMenu }] = useToggle(false);
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-black">
@@ -119,7 +120,7 @@ const NavigationBar = () => {
             <ModeToggle />
             <motion.button
               className="p-2 text-black dark:text-white"
-              onClick={() => setIsOpen(!isOpen)}
+              onClick={toggle}
               whileTap={{ scale: 0.95 }}
               aria-label={isOpen ? 'Close menu' : 'Open menu'}
             >
@@ -171,7 +172,7 @@ const NavigationBar = () => {
                   >
                     <Link
                       href={path}
-                      onClick={() => setIsOpen(false)}
+                      onClick={closeMenu}
                       className="block px-4 py-3 text-base font-medium text-black/70 dark:text-white/70 hover:text-black dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
                     >
                       {name}
@@ -187,7 +188,7 @@ const NavigationBar = () => {
                 >
                   <Link
                     href="/docs/getting-started/introduction"
-                    onClick={() => setIsOpen(false)}
+                    onClick={closeMenu}
                     className="block w-full text-white text-center font-medium px-5 py-3 bg-black dark:bg-white dark:text-black"
                   >
                     Get Started

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { useDebounce } from '@/hooks-d/use-debounce';
 import { useKeyboardShortcut } from '@/hooks-d/use-keyboard-shortcut';
+import { useToggle } from '@/hooks-d/use-toggle';
 import { Dialog, DialogTrigger, DialogContent } from '@/components/dialog';
 import { Input } from '@/components/input';
 import SearchButton from '@/components/search-button';
@@ -101,16 +102,17 @@ function getSnippet(
 
 const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
   ({ searchData }, ref) => {
-    const [open, setOpen] = useState(false);
+    const [open, { on: openDialog, off: closeDialog, set: setOpen }] =
+      useToggle(false);
     const [query, setQuery] = useState('');
     const debouncedQuery = useDebounce(query, 300, true);
 
     useImperativeHandle(ref, () => ({
-      close: () => setOpen(false),
-      open: () => setOpen(true),
+      close: closeDialog,
+      open: openDialog,
     }));
 
-    useKeyboardShortcut('mod+k', () => setOpen(true));
+    useKeyboardShortcut('mod+k', openDialog);
 
 
     const filteredDocs = useMemo(() => {
@@ -124,7 +126,7 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
     }, [debouncedQuery, searchData]);
 
     return (
-      <Dialog open={open} setOpen={setOpen}>
+      <Dialog open={open} setOpen={setOpen as React.Dispatch<React.SetStateAction<boolean>>}>
         <DialogTrigger className="hidden sm:block">
           <SearchButton size="sm" placeholder="Search documentation.." />
         </DialogTrigger>
@@ -164,7 +166,7 @@ const SearchDialog = forwardRef<SearchDialogHandle, SearchDialogProps>(
                   >
                     <Link
                       href={`/docs/${doc._raw.flattenedPath}`}
-                      onClick={() => setOpen(false)}
+                      onClick={closeDialog}
                     >
                       <div className="flex flex-col gap-3">
                         <div className="flex gap-2 font-bold">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
 import clsx from 'clsx';
 import { cn } from '@/lib/utils';
 import { useEventListener } from '../hooks-d/use-event-listener';
+import { useToggle } from '../hooks-d/use-toggle';
 
 type SidebarContextType = {
   isOpen: boolean;
@@ -66,13 +67,9 @@ export function SidebarProvider({
 
   const isMobile = mobileView ? useMobile : false;
 
-  const [isOpen, setIsOpen] = React.useState(defaultOpen);
+  const [isOpen, { toggle: toggleSidebar, set: setIsOpen }] = useToggle(defaultOpen);
   const [side] = React.useState<'left' | 'right'>(defaultSide);
   const [maxWidth] = React.useState(defaultMaxWidth);
-
-  const toggleSidebar = React.useCallback(() => {
-    setIsOpen((prev) => !prev);
-  }, []);
 
   // Add keyboard shortcut (Ctrl+B) to toggle sidebar
   useEventListener('keydown', (e) => {

--- a/src/hooks-d/use-toggle.test.ts
+++ b/src/hooks-d/use-toggle.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, act } from '@testing-library/react';
+import { useToggle } from './use-toggle';
+import { describe, it, expect } from 'vitest';
+
+describe('useToggle', () => {
+    it('1. Default initial value is false when no argument is passed', () => {
+        const { result } = renderHook(() => useToggle());
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('2. Accepts explicit true as initial value', () => {
+        const { result } = renderHook(() => useToggle(true));
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('3. Accepts explicit false as initial value', () => {
+        const { result } = renderHook(() => useToggle(false));
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('4. toggle() flips false -> true', () => {
+        const { result } = renderHook(() => useToggle(false));
+        act(() => {
+            result.current[1].toggle();
+        });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('5. toggle() flips true -> false', () => {
+        const { result } = renderHook(() => useToggle(true));
+        act(() => {
+            result.current[1].toggle();
+        });
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('6. on() sets value to true from false', () => {
+        const { result } = renderHook(() => useToggle(false));
+        act(() => {
+            result.current[1].on();
+        });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('7. on() is idempotent - calling twice stays true', () => {
+        const { result } = renderHook(() => useToggle(false));
+        act(() => {
+            result.current[1].on();
+            result.current[1].on();
+        });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('8. off() sets value to false from true', () => {
+        const { result } = renderHook(() => useToggle(true));
+        act(() => {
+            result.current[1].off();
+        });
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('9. off() is idempotent - calling twice stays false', () => {
+        const { result } = renderHook(() => useToggle(true));
+        act(() => {
+            result.current[1].off();
+            result.current[1].off();
+        });
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('10. set(true) sets value to true', () => {
+        const { result } = renderHook(() => useToggle(false));
+        act(() => {
+            result.current[1].set(true);
+        });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('11. set(false) sets value to false', () => {
+        const { result } = renderHook(() => useToggle(true));
+        act(() => {
+            result.current[1].set(false);
+        });
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('12. toggle reference is stable across re-renders (strict toBe equality)', () => {
+        const { result, rerender } = renderHook(() => useToggle());
+        const initialToggle = result.current[1].toggle;
+        rerender();
+        expect(result.current[1].toggle).toBe(initialToggle);
+    });
+
+    it('13. on reference is stable across re-renders (strict toBe equality)', () => {
+        const { result, rerender } = renderHook(() => useToggle());
+        const initialOn = result.current[1].on;
+        rerender();
+        expect(result.current[1].on).toBe(initialOn);
+    });
+
+    it('14. off reference is stable across re-renders (strict toBe equality)', () => {
+        const { result, rerender } = renderHook(() => useToggle());
+        const initialOff = result.current[1].off;
+        rerender();
+        expect(result.current[1].off).toBe(initialOff);
+    });
+
+    it('15. set reference is stable across re-renders (strict toBe equality)', () => {
+        const { result, rerender } = renderHook(() => useToggle());
+        const initialSet = result.current[1].set;
+        rerender();
+        expect(result.current[1].set).toBe(initialSet);
+    });
+});

--- a/src/hooks-d/use-toggle.ts
+++ b/src/hooks-d/use-toggle.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback, useMemo } from 'react';
+
+export interface ToggleHelpers {
+    toggle: () => void;
+    on: () => void;
+    off: () => void;
+    set: (value: boolean) => void;
+}
+
+export type UseToggleReturn = [boolean, ToggleHelpers];
+
+/**
+ * Manages a boolean state value with stable, named helper methods.
+ *
+ * @param initialValue - Starting boolean value. Defaults to `false`.
+ * @returns A tuple of `[value, { toggle, on, off, set }]` where all helpers
+ *          are referentially stable and safe to pass as props or dependencies.
+ *
+ * @example
+ * // 1. Modal
+ * const [isOpen, { on: openModal, off: closeModal }] = useToggle();
+ * <button onClick={openModal}>Open</button>
+ * <Modal open={isOpen} onClose={closeModal} />
+ *
+ * @example
+ * // 2. Feature flag toggle switch
+ * const [enabled, { toggle }] = useToggle(false);
+ * <Switch checked={enabled} onChange={toggle} />
+ *
+ * @example
+ * // 3. Conditional section
+ * const [showDetails, { toggle }] = useToggle();
+ * <button onClick={toggle}>{showDetails ? 'Hide' : 'Show'} Details</button>
+ * {showDetails && <Details />}
+ */
+export function useToggle(initialValue: boolean = false): UseToggleReturn {
+    const [value, setValue] = useState<boolean>(initialValue);
+
+    const toggle = useCallback(() => setValue((prev) => !prev), []);
+    const on = useCallback(() => setValue(true), []);
+    const off = useCallback(() => setValue(false), []);
+    const set = useCallback((v: boolean) => setValue(v), []);
+
+    const helpers = useMemo(
+        () => ({ toggle, on, off, set }),
+        [toggle, on, off, set]
+    );
+
+    return [value, helpers];
+}


### PR DESCRIPTION
Closes #77 

## Overview

This PR implements the `useToggle` hook as specified in [Issue #77](#77). The hook replaces repetitive `useState(false)` + inline handler boilerplate with a clean, type-safe tuple API — providing referentially stable `toggle`, `on`, `off`, and `set` helpers out of the box.

---

## Key Features

### 🔷 Clean Tuple API
Returns a `[value, helpers]` tuple that mirrors the `useState` pattern, making it instantly familiar while adding structured, named control methods.

```ts
const [isOpen, { toggle, on, off, set }] = useToggle(false);
```

### 📌 Referentially Stable Helpers
All four helpers are wrapped in `useCallback` with empty dependency arrays, and the helpers object itself is wrapped in `useMemo` — guaranteeing that no helper reference ever changes between renders and preventing unnecessary child re-renders.

### 🔷 Full TypeScript Support
Exports both the `ToggleHelpers` interface and the `UseToggleReturn` type so consumers can annotate destructured values precisely. The `set` method enforces `boolean` only — no implicit truthy/falsy coercion.

```ts
export interface ToggleHelpers {
  toggle: () => void;
  on:     () => void;
  off:    () => void;
  set:    (value: boolean) => void;
}

export type UseToggleReturn = [boolean, ToggleHelpers];
```
