### PR TITLE
Implement useClickOutside hook

### DIFF
--- a/pr_description_outside.md
+++ b/pr_description_outside.md
@@ -1,0 +1,21 @@
+# feat(hooks-d): implement `useClickOutside` hook — closes #75
+
+## Overview
+This PR introduces the `useClickOutside` hook for the library, providing a standardized way to handle clicks occurring outside specific elements. This is essential for components like dropdowns, menus, and popovers.
+
+## Key Features
+- **Flexible Targets**: Supports both a single ref and an array of refs.
+- **Exclusion Logic**: Allows excluding specific elements (via `excludeRefs`) to prevent unwanted closures when clicking on triggers or related UI.
+- **Event Handling**: Listens for both `mousedown` and `touchstart` to ensure mobile compatibility.
+- **Conditional Activation**: Includes an `enabled` flag to easily toggle the listener without re-rendering the hook logic manually.
+- **Auto-Cleanup**: Ensures listeners are properly removed on unmount.
+
+## Changes
+- Created `src/hooks-d/use-click-outside.ts`.
+- Created `src/hooks-d/use-click-outside.test.ts` with comprehensive unit tests.
+- Migrated `src/components/menu.tsx` to use the new hook.
+- Migrated `src/components/popover.tsx` to use the new hook.
+
+## Verification
+- ✅ **Unit Tests**: 7 test cases covering single/multiple refs, exclusion, enabled flag, and mobile touch events.
+- ✅ **Build**: Successfully ran `npm run build`.

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useClickOutside } from '@/hooks-d/use-click-outside';
 
 // Type definitions
 interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -179,22 +180,7 @@ export const Menu: React.FC<MenuProps> = ({
   }, [isOpen, position, isPositioning]);
 
   // Close menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(event.target as Node) &&
-        isOpen
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, setIsOpen]);
+  useClickOutside(menuRef, () => setIsOpen(false), { enabled: isOpen });
 
   return (
     <div
@@ -212,11 +198,11 @@ export const Menu: React.FC<MenuProps> = ({
           if (child.type === PopMenu) {
             return isOpen
               ? React.cloneElement(child as React.ReactElement<any>, {
-                  onClose: () => setIsOpen(false),
-                  position: position,
-                  isPositioning: isPositioning,
-                  ref: popupRef,
-                })
+                onClose: () => setIsOpen(false),
+                position: position,
+                isPositioning: isPositioning,
+                ref: popupRef,
+              })
               : null;
           }
           return child;

--- a/src/components/popover.tsx
+++ b/src/components/popover.tsx
@@ -9,6 +9,7 @@ import {
   ReactNode,
 } from 'react';
 import { useFocusTrap } from '@/hooks-d/use-focus-trap';
+import { useClickOutside } from '@/hooks-d/use-click-outside';
 
 export type Position = {
   xAlign: 'left' | 'center' | 'right';
@@ -73,23 +74,7 @@ export const Popover = ({
   };
 
   // Handle outside clicks
-  useEffect(() => {
-    if (!closeOnOutsideClick) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(event?.target as Node)
-      ) {
-        close();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, closeOnOutsideClick, onClose]);
+  useClickOutside(popoverRef, close, { enabled: isOpen && closeOnOutsideClick });
 
   // Handle ESC key
   useEffect(() => {

--- a/src/hooks-d/use-click-outside.test.ts
+++ b/src/hooks-d/use-click-outside.test.ts
@@ -1,0 +1,117 @@
+import { renderHook } from '@testing-library/react';
+import { useClickOutside } from './use-click-outside';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+describe('useClickOutside', () => {
+    let handler: (event: MouseEvent | TouchEvent) => void;
+    const mockHandler = vi.fn();
+
+    beforeEach(() => {
+        mockHandler.mockClear();
+        handler = (e) => mockHandler(e);
+    });
+
+    it('calls handler when clicking outside a single ref', () => {
+        const el = document.createElement('div');
+        const ref = { current: el };
+        renderHook(() => useClickOutside(ref, handler));
+
+        const outsideEl = document.createElement('span');
+        document.body.appendChild(outsideEl);
+        outsideEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(mockHandler).toHaveBeenCalled();
+        document.body.removeChild(outsideEl);
+    });
+
+    it('does NOT call handler when clicking inside the ref', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        const ref = { current: el };
+        renderHook(() => useClickOutside(ref, handler));
+
+        el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(mockHandler).not.toHaveBeenCalled();
+        document.body.removeChild(el);
+    });
+
+    it('supports multiple refs', () => {
+        const el1 = document.createElement('div');
+        const el2 = document.createElement('div');
+        document.body.appendChild(el1);
+        document.body.appendChild(el2);
+
+        const refs = [{ current: el1 }, { current: el2 }];
+        renderHook(() => useClickOutside(refs, handler));
+
+        el1.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        el2.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(mockHandler).not.toHaveBeenCalled();
+
+        const outside = document.createElement('span');
+        document.body.appendChild(outside);
+        outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(mockHandler).toHaveBeenCalledTimes(1);
+
+        document.body.removeChild(el1);
+        document.body.removeChild(el2);
+        document.body.removeChild(outside);
+    });
+
+    it('respects the enabled flag', () => {
+        const el = document.createElement('div');
+        const ref = { current: el };
+        const { rerender } = renderHook(({ enabled }) => useClickOutside(ref, handler, { enabled }), {
+            initialProps: { enabled: false }
+        });
+
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        expect(mockHandler).not.toHaveBeenCalled();
+
+        rerender({ enabled: true });
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        expect(mockHandler).toHaveBeenCalled();
+    });
+
+    it('excludes specific refs', () => {
+        const el = document.createElement('div');
+        const excludedEl = document.createElement('button');
+        document.body.appendChild(el);
+        document.body.appendChild(excludedEl);
+
+        const ref = { current: el };
+        const excludeRef = { current: excludedEl };
+
+        renderHook(() => useClickOutside(ref, handler, { excludeRefs: [excludeRef] }));
+
+        excludedEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        expect(mockHandler).not.toHaveBeenCalled();
+
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        expect(mockHandler).toHaveBeenCalled();
+
+        document.body.removeChild(el);
+        document.body.removeChild(excludedEl);
+    });
+
+    it('handles touch events', () => {
+        const el = document.createElement('div');
+        const ref = { current: el };
+        renderHook(() => useClickOutside(ref, handler));
+
+        document.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
+        expect(mockHandler).toHaveBeenCalled();
+    });
+
+    it('cleans up listeners on unmount', () => {
+        const spy = vi.spyOn(document, 'removeEventListener');
+        const { unmount } = renderHook(() => useClickOutside({ current: null as unknown as HTMLElement }, handler));
+
+        unmount();
+        expect(spy).toHaveBeenCalledWith('mousedown', expect.any(Function));
+        expect(spy).toHaveBeenCalledWith('touchstart', expect.any(Function));
+    });
+});

--- a/src/hooks-d/use-click-outside.ts
+++ b/src/hooks-d/use-click-outside.ts
@@ -1,0 +1,61 @@
+import { RefObject, useEffect, useCallback } from 'react';
+
+export interface UseClickOutsideOptions {
+    /** Whether the listener is active. Defaults to true. */
+    enabled?: boolean;
+    /** Refs that should be excluded from "outside" detection. */
+    excludeRefs?: RefObject<HTMLElement | null>[];
+}
+
+/**
+ * Hook that detects clicks or touches outside a referenced element or elements.
+ * 
+ * @param refs - A single ref or an array of refs to the elements to monitor.
+ * @param handler - Callback function to trigger when an outside click occurs.
+ * @param options - Configuration options (enabled, excludeRefs).
+ */
+export function useClickOutside<T extends HTMLElement = HTMLElement>(
+    refs: RefObject<T | null> | RefObject<T | null>[],
+    handler: (event: MouseEvent | TouchEvent) => void,
+    options: UseClickOutsideOptions = {}
+): void {
+    const { enabled = true, excludeRefs = [] } = options;
+
+    const listener = useCallback(
+        (event: MouseEvent | TouchEvent) => {
+            if (!enabled) return;
+
+            const target = event.target as HTMLElement;
+
+            // Check if click is on any of the main refs
+            const targetRefs = (Array.isArray(refs) ? refs : [refs]) as RefObject<HTMLElement | null>[];
+            const isInsideMain = targetRefs.some((ref) => {
+                return ref.current && ref.current.contains(target);
+            });
+
+            if (isInsideMain) return;
+
+            // Check if click is on any of the excluded refs
+            const isInsideExcluded = excludeRefs.some((ref) => {
+                return ref.current && ref.current.contains(target);
+            });
+
+            if (isInsideExcluded) return;
+
+            handler(event);
+        },
+        [refs, handler, enabled, excludeRefs]
+    );
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        document.addEventListener('mousedown', listener);
+        document.addEventListener('touchstart', listener);
+
+        return () => {
+            document.removeEventListener('mousedown', listener);
+            document.removeEventListener('touchstart', listener);
+        };
+    }, [enabled, listener]);
+}


### PR DESCRIPTION
# feat(hooks-d): implement `useClickOutside` hook — closes #75

## Overview
This PR introduces the `useClickOutside` hook for the library, providing a standardized way to handle clicks occurring outside specific elements. This is essential for components like dropdowns, menus, and popovers.

## Key Features
- **Flexible Targets**: Supports both a single ref and an array of refs.
- **Exclusion Logic**: Allows excluding specific elements (via `excludeRefs`) to prevent unwanted closures when clicking on triggers or related UI.
- **Event Handling**: Listens for both `mousedown` and `touchstart` to ensure mobile compatibility.
- **Conditional Activation**: Includes an `enabled` flag to easily toggle the listener without re-rendering the hook logic manually.
- **Auto-Cleanup**: Ensures listeners are properly removed on unmount.

## Changes
- Created `src/hooks-d/use-click-outside.ts`.
- Created `src/hooks-d/use-click-outside.test.ts` with comprehensive unit tests.
- Migrated `src/components/menu.tsx` to use the new hook.
- Migrated `src/components/popover.tsx` to use the new hook.

## Verification
- ✅ **Unit Tests**: 7 test cases covering single/multiple refs, exclusion, enabled flag, and mobile touch events.
- ✅ **Build**: Successfully ran `npm run build`.
