### PR TITLE
Implement usePrevious hook

### DIFF
--- a/pr_description_previous.md
+++ b/pr_description_previous.md
@@ -1,0 +1,19 @@
+# feat(hooks-d): implement `usePrevious` hook — closes #76
+
+## Overview
+This PR introduces the `usePrevious` hook, which allows tracking the value of a prop or state from the previous render. This is particularly useful for comparing changes, detecting trends (e.g., scroll direction), or implementing logic that relies on state transitions.
+
+## Key Features
+- **Generic Support**: Preserves the type of the input value.
+- **Render Cycle Alignment**: Updates via `useEffect` to ensure it captures the value *after* the render is committed, making it available on the *next* render.
+- **Initial State**: Returns `undefined` on the first render, consistent with standard "previous" hook implementations.
+- **Zero Dependencies**: Lightweight implementation using only standard React hooks.
+
+## Changes
+- Created `src/hooks-d/use-previous.ts`.
+- Created `src/hooks-d/use-previous.test.ts` with comprehensive unit tests.
+- Added JSDoc documentation with a practical example for detecting scroll direction.
+
+## Verification
+- ✅ **Unit Tests**: 5 test cases passing (initial state, updates, primitive types, objects).
+- ✅ **Build**: Successfully ran `npm run build`.

--- a/src/hooks-d/use-previous.test.ts
+++ b/src/hooks-d/use-previous.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { usePrevious } from './use-previous';
+import { describe, it, expect } from 'vitest';
+
+describe('usePrevious', () => {
+    it('returns undefined on initial render', () => {
+        const { result } = renderHook(() => usePrevious(0));
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns the previous value after update', () => {
+        const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+            initialProps: { value: 0 },
+        });
+
+        expect(result.current).toBeUndefined();
+
+        rerender({ value: 1 });
+        expect(result.current).toBe(0);
+
+        rerender({ value: 2 });
+        expect(result.current).toBe(1);
+
+        rerender({ value: 3 });
+        expect(result.current).toBe(2);
+    });
+
+    it('works with strings', () => {
+        const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+            initialProps: { value: 'first' },
+        });
+
+        expect(result.current).toBeUndefined();
+
+        rerender({ value: 'second' });
+        expect(result.current).toBe('first');
+
+        rerender({ value: 'third' });
+        expect(result.current).toBe('second');
+    });
+
+    it('works with objects', () => {
+        const obj1 = { id: 1 };
+        const obj2 = { id: 2 };
+        const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+            initialProps: { value: obj1 },
+        });
+
+        expect(result.current).toBeUndefined();
+
+        rerender({ value: obj2 });
+        expect(result.current).toBe(obj1);
+    });
+
+    it('preserves types correctly', () => {
+        const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+            initialProps: { value: 0 as number },
+        });
+
+        // Verification of type safety is implicit here via TS
+        rerender({ value: 5 });
+        expect(typeof result.current).toBe('number');
+    });
+});

--- a/src/hooks-d/use-previous.ts
+++ b/src/hooks-d/use-previous.ts
@@ -1,0 +1,23 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * A hook that returns the value from the previous render.
+ * 
+ * @param value - The value to track.
+ * @returns The value from the previous render, or undefined on the first render.
+ * 
+ * @example
+ * // Detect scroll direction change
+ * const [scrollY, setScrollY] = useState(0);
+ * const prevScrollY = usePrevious(scrollY);
+ * const direction = scrollY > (prevScrollY ?? 0) ? 'down' : 'up';
+ */
+export function usePrevious<T>(value: T): T | undefined {
+    const ref = useRef<T | undefined>(undefined);
+
+    useEffect(() => {
+        ref.current = value;
+    }, [value]);
+
+    return ref.current;
+}


### PR DESCRIPTION
closes #76 

## Overview
This PR introduces the `usePrevious` hook, which allows tracking the value of a prop or state from the previous render. This is particularly useful for comparing changes, detecting trends (e.g., scroll direction), or implementing logic that relies on state transitions.

## Key Features
- **Generic Support**: Preserves the type of the input value.
- **Render Cycle Alignment**: Updates via `useEffect` to ensure it captures the value *after* the render is committed, making it available on the *next* render.
- **Initial State**: Returns `undefined` on the first render, consistent with standard "previous" hook implementations.
- **Zero Dependencies**: Lightweight implementation using only standard React hooks.

## Changes
- Created `src/hooks-d/use-previous.ts`.
- Created `src/hooks-d/use-previous.test.ts` with comprehensive unit tests.
- Added JSDoc documentation with a practical example for detecting scroll direction.

## Verification
- ✅ **Unit Tests**: 5 test cases passing (initial state, updates, primitive types, objects).
- ✅ **Build**: Successfully ran `npm run build`.
