### PR TITLE
feat(hooks-d): add useCountdown hook and tests

### DIFF
--- a/src/hooks-d/__tests__/use-countdown.test.ts
+++ b/src/hooks-d/__tests__/use-countdown.test.ts
@@ -1,0 +1,125 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useCountdown } from '../use-countdown';
+
+describe('useCountdown', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // Set system time to a known point for deterministic tests
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it('should initialize correctly with a duration', () => {
+        const duration = 1000 * 60; // 1 minute
+        const { result } = renderHook(() => useCountdown(duration));
+
+        expect(result.current.days).toBe('00');
+        expect(result.current.hours).toBe('00');
+        expect(result.current.minutes).toBe('01');
+        expect(result.current.seconds).toBe('00');
+        expect(result.current.isRunning).toBe(true);
+    });
+
+    it('should calculate time correctly and update over time', () => {
+        const duration = 5000; // 5 seconds
+        const { result } = renderHook(() => useCountdown(duration));
+
+        expect(result.current.seconds).toBe('05');
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+
+        expect(result.current.seconds).toBe('03');
+    });
+
+    it('should format long durations correctly (DD:HH:MM:SS)', () => {
+        const duration = (2 * 24 * 60 * 60 * 1000) + (5 * 60 * 60 * 1000) + (30 * 60 * 1000) + 15000; // 2 days, 5 hours, 30 min, 15 sec
+        const { result } = renderHook(() => useCountdown(duration));
+
+        expect(result.current.days).toBe('02');
+        expect(result.current.hours).toBe('05');
+        expect(result.current.minutes).toBe('30');
+        expect(result.current.seconds).toBe('15');
+    });
+
+    it('should pause and resume correctly', () => {
+        // 10 seconds duration
+        const duration = 10000;
+        const { result } = renderHook(() => useCountdown(duration));
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+        expect(result.current.seconds).toBe('08');
+        expect(result.current.isRunning).toBe(true);
+
+        act(() => {
+            result.current.pause();
+        });
+        expect(result.current.isRunning).toBe(false);
+
+        // advance time while paused
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+        // Should still be at 8 seconds
+        expect(result.current.seconds).toBe('08');
+
+        act(() => {
+            result.current.resume();
+        });
+        expect(result.current.isRunning).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+        expect(result.current.seconds).toBe('06');
+    });
+
+    it('should reset correctly', () => {
+        const duration = 10000;
+        const { result } = renderHook(() => useCountdown(duration));
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+        expect(result.current.seconds).toBe('05');
+
+        act(() => {
+            result.current.reset();
+        });
+        expect(result.current.seconds).toBe('10');
+    });
+
+    it('should trigger onComplete when reaches zero', () => {
+        const onComplete = vi.fn();
+        const duration = 3000;
+        const { result } = renderHook(() => useCountdown(duration, { onComplete }));
+
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        expect(result.current.seconds).toBe('00');
+        expect(result.current.isRunning).toBe(false);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support target timestamp input (Date object)', () => {
+        const targetDate = new Date('2026-01-01T00:00:10Z'); // 10 seconds ahead
+        const { result } = renderHook(() => useCountdown(targetDate));
+
+        expect(result.current.seconds).toBe('10');
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+        expect(result.current.seconds).toBe('05');
+    });
+});

--- a/src/hooks-d/use-countdown.ts
+++ b/src/hooks-d/use-countdown.ts
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export interface UseCountdownOptions {
+  /**
+   * Callback fired when the countdown reaches 0
+   */
+  onComplete?: () => void;
+  /**
+   * Explicitly set to true to treat targetDate as a duration in milliseconds,
+   * otherwise it assumes numbers less than 946684800000 (year 2000) are durations.
+   */
+  isDuration?: boolean;
+}
+
+export interface UseCountdownReturn {
+  days: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+  isRunning: boolean;
+  pause: () => void;
+  resume: () => void;
+  reset: () => void;
+}
+
+/**
+ * A hook that manages a countdown timer with formatting and controls.
+ *
+ * @param targetDate The target date/timestamp, or a duration in milliseconds.
+ * @param options Additional options for the hook.
+ * @returns Formatted time components and control functions.
+ */
+export function useCountdown(
+  targetDate: number | Date | string,
+  options?: UseCountdownOptions
+): UseCountdownReturn {
+  const onCompleteRef = useRef(options?.onComplete);
+
+  // Keep the onComplete ref updated so we don't trigger stale closures
+  useEffect(() => {
+    onCompleteRef.current = options?.onComplete;
+  }, [options?.onComplete]);
+
+  const getTargetTimeMS = useCallback(
+    (target: number | Date | string) => {
+      if (target instanceof Date) return target.getTime();
+      if (typeof target === 'string') return new Date(target).getTime();
+      if (typeof target === 'number') {
+        if (options?.isDuration) return Date.now() + target;
+        // Assume duration if < year 2000 in ms (approx 946684800000)
+        if (target < 946684800000) return Date.now() + target;
+        return target;
+      }
+      return Date.now();
+    },
+    [options?.isDuration]
+  );
+
+  const [timeLeft, setTimeLeft] = useState<number>(() => {
+    const end = getTargetTimeMS(targetDate);
+    return Math.max(0, end - Date.now());
+  });
+
+  const [isRunning, setIsRunning] = useState<boolean>(false);
+
+  const endTimeRef = useRef<number | null>(null);
+  const initialTargetRef = useRef<number | Date | string>(targetDate);
+
+  const initTimer = useCallback(() => {
+    const end = getTargetTimeMS(targetDate);
+    endTimeRef.current = end;
+    const remaining = Math.max(0, end - Date.now());
+    setTimeLeft(remaining);
+
+    if (remaining > 0) {
+      setIsRunning(true);
+    } else {
+      setIsRunning(false);
+    }
+  }, [targetDate, getTargetTimeMS]);
+
+  // Handle prop changes: reset the timer if the targetDate changes
+  useEffect(() => {
+    if (initialTargetRef.current !== targetDate) {
+      initialTargetRef.current = targetDate;
+      initTimer();
+    }
+  }, [targetDate, initTimer]);
+
+  // Initial mount setup
+  useEffect(() => {
+    if (endTimeRef.current === null) {
+      const end = getTargetTimeMS(initialTargetRef.current);
+      endTimeRef.current = end;
+      const remaining = Math.max(0, end - Date.now());
+      if (remaining > 0) {
+        setIsRunning(true);
+      }
+    }
+  }, [getTargetTimeMS]);
+
+  const pause = useCallback(() => {
+    setIsRunning(false);
+  }, []);
+
+  const resume = useCallback(() => {
+    if (timeLeft > 0 && !isRunning) {
+      endTimeRef.current = Date.now() + timeLeft;
+      setIsRunning(true);
+    }
+  }, [timeLeft, isRunning]);
+
+  const reset = useCallback(() => {
+    initTimer();
+  }, [initTimer]);
+
+  useEffect(() => {
+    if (!isRunning || !endTimeRef.current) return;
+
+    const tick = () => {
+      const now = Date.now();
+      const remaining = Math.max(0, endTimeRef.current! - now);
+
+      setTimeLeft(remaining);
+
+      if (remaining === 0) {
+        setIsRunning(false);
+        onCompleteRef.current?.();
+      }
+    };
+
+    // Use 500ms to ensure accurate sub-second updates without excessive renders
+    // and effectively completely removes visual drift on standard devices
+    const intervalId = setInterval(tick, 500);
+
+    return () => clearInterval(intervalId);
+  }, [isRunning]);
+
+  const days = Math.floor(timeLeft / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((timeLeft / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((timeLeft / 1000 / 60) % 60);
+  const seconds = Math.floor((timeLeft / 1000) % 60);
+
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  return {
+    days: pad(days),
+    hours: pad(hours),
+    minutes: pad(minutes),
+    seconds: pad(seconds),
+    isRunning,
+    pause,
+    resume,
+    reset,
+  };
+}


### PR DESCRIPTION
## Description

Created a `useCountdown` hook for managing countdown timers in the `hooks-d/` directory. This hook helps track remaining time accurately, manages states like pause and resume, and triggers an optional `onComplete` callback when the timer finishes. Also, fake-timer unit tests were implemented for robust validation of these timing events.

Fixes #95

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Using Vitest fake timers (`vi.useFakeTimers()`), the core functionalities were simulated:
- Verified countdown calculates accurate `DD:HH:MM:SS` duration correctly and increments accurately against native time calculations
- Advanced internal clocks mathematically to test time elapsed
- Verified `pause`, `resume`, and `reset` controls halt/continue calculations without drifting
- Validated `onComplete` triggers precisely after durations end
- Checked target `Date` object inputs parsing capabilities correctly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
