### PR TITLE
Add useQueue/useIdle hooks and batch API docs

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -99,6 +99,10 @@ export const sidebarNav: SidebarSection[] = [
         href: '/docs/routes-d/wallet-connect',
       },
       {
+        title: 'POST /api/batch',
+        href: '/docs/routes-d/batch',
+      },
+      {
         title: 'GET /api/assets/search',
         href: '/docs/routes-d/assets-search',
       },

--- a/docs/routes-d/batch.mdx
+++ b/docs/routes-d/batch.mdx
@@ -1,0 +1,132 @@
+---
+title: POST /api/batch
+description: Bundle multiple API requests into a single round trip.
+---
+
+# POST /api/batch
+
+Documentation for the **`/api/batch`** route that bundles multiple API calls into a single HTTP request.
+
+## Overview
+
+This endpoint accepts a list of API calls and returns a list of results in the same order. It is useful for reducing client/network overhead when you need multiple related reads or writes at once.
+
+---
+
+## Request / Response Schema
+
+### Request
+
+| Method | Content-Type | Body |
+|--------|--------------|------|
+| `POST` | `application/json` | JSON (see below) |
+
+**Request body (JSON):**
+
+```json
+{
+  "requests": [
+    { "method": "GET", "path": "/api/account/GABC...XYZ" },
+    {
+      "method": "POST",
+      "path": "/api/transactions/submit",
+      "body": { "xdr": "AAAA..." }
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `requests` | array | Yes | Array of batched requests (max size is implementation-dependent). |
+| `requests[].method` | string | Yes | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. |
+| `requests[].path` | string | Yes | API path beginning with `/api/`. |
+| `requests[].body` | object | No | Optional JSON body for non-GET requests. |
+| `requests[].headers` | object | No | Optional request headers for the sub-request. |
+
+### Response (success)
+
+**Status:** `200 OK`
+
+```json
+{
+  "ok": true,
+  "results": [
+    { "ok": true, "status": 200, "data": { "accountId": "GABC...XYZ" } },
+    { "ok": false, "status": 400, "error": { "code": "BAD_XDR", "message": "Invalid XDR" } }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ok` | boolean | Always `true` on a successful batch response. |
+| `results` | array | Results mapped 1:1 with `requests` by index. |
+| `results[].ok` | boolean | Whether the sub-request succeeded. |
+| `results[].status` | number | HTTP status code for the sub-request. |
+| `results[].data` | object | Parsed response body for success. |
+| `results[].error` | object | Error payload for failures. |
+
+### Response (error)
+
+**Status:** `4xx` or `5xx`
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "INVALID_BATCH",
+    "message": "Request body must include a non-empty requests array."
+  }
+}
+```
+
+---
+
+## Example: client usage
+
+```typescript
+const res = await fetch('/api/batch', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    requests: [
+      { method: 'GET', path: '/api/account/GABC...XYZ' },
+      { method: 'GET', path: '/api/assets/search?code=USDC' },
+    ],
+  }),
+});
+
+const data = await res.json();
+if (!data.ok) throw new Error(data.error?.message ?? 'Batch failed');
+
+data.results.forEach((result, index) => {
+  if (!result.ok) {
+    console.error('Sub-request failed', index, result.error);
+  }
+});
+```
+
+---
+
+## Error codes and edge cases
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `INVALID_BATCH` | `400` | Missing or invalid `requests` array. |
+| `UNSUPPORTED_PATH` | `400` | `path` is not an allowed `/api/*` endpoint. |
+| `BATCH_TOO_LARGE` | `413` | Batch exceeds server limits. |
+| `INTERNAL_ERROR` | `500` | Server error while processing batch. |
+
+### Notes
+
+- **Ordering:** Results are returned in the same order as the incoming requests array.
+- **Isolation:** Each sub-request is processed independently; one failure does not stop the rest.
+- **Authorization:** Auth headers can be provided per request via `requests[].headers`.
+
+---
+
+## See also
+
+- [POST /api/transactions/submit](/docs/routes-d/transaction-submit)
+- [GET /api/account/[address]](/docs/routes-d/account-lookup)

--- a/src/hooks-d/__tests__/use-idle.test.ts
+++ b/src/hooks-d/__tests__/use-idle.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useIdle } from '../use-idle';
+
+describe('useIdle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('becomes idle after timeout', () => {
+        const { result } = renderHook(() => useIdle(1000));
+
+        expect(result.current).toBe(false);
+
+        act(() => {
+            vi.advanceTimersByTime(999);
+        });
+        expect(result.current).toBe(false);
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+        expect(result.current).toBe(true);
+    });
+
+    it('resets idle state on activity', () => {
+        const { result } = renderHook(() => useIdle(1000));
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(result.current).toBe(true);
+
+        act(() => {
+            window.dispatchEvent(new Event('mousemove'));
+        });
+        expect(result.current).toBe(false);
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(result.current).toBe(true);
+    });
+});

--- a/src/hooks-d/__tests__/use-queue.test.ts
+++ b/src/hooks-d/__tests__/use-queue.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useQueue } from '../use-queue';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('useQueue', () => {
+    it('runs tasks sequentially with concurrency 1', async () => {
+        const { result } = renderHook(() => useQueue<string>({ concurrency: 1 }));
+
+        const task1 = deferred<string>();
+        const task2 = deferred<string>();
+
+        let p1: Promise<string>;
+        let p2: Promise<string>;
+
+        await act(async () => {
+            p1 = result.current.enqueue(() => task1.promise);
+            p2 = result.current.enqueue(() => task2.promise);
+        });
+
+        expect(result.current.running).toBe(1);
+        expect(result.current.pending).toBe(1);
+
+        await act(async () => {
+            task1.resolve('a');
+            await p1!;
+        });
+
+        expect(result.current.running).toBe(1);
+        expect(result.current.pending).toBe(0);
+
+        await act(async () => {
+            task2.resolve('b');
+            await p2!;
+        });
+
+        expect(result.current.isIdle).toBe(true);
+        expect(result.current.lastResult).toBe('b');
+    });
+
+    it('pauses and resumes processing', async () => {
+        const { result } = renderHook(() =>
+            useQueue<string>({ autoStart: false })
+        );
+
+        const task = deferred<string>();
+
+        await act(async () => {
+            result.current.enqueue(() => task.promise);
+        });
+
+        expect(result.current.running).toBe(0);
+        expect(result.current.pending).toBe(1);
+        expect(result.current.isPaused).toBe(true);
+
+        await act(async () => {
+            result.current.resume();
+        });
+
+        expect(result.current.isPaused).toBe(false);
+        expect(result.current.running).toBe(1);
+
+        await act(async () => {
+            task.resolve('done');
+        });
+
+        expect(result.current.isIdle).toBe(true);
+    });
+
+    it('captures lastError on rejection', async () => {
+        const { result } = renderHook(() => useQueue<string>());
+
+        const error = new Error('boom');
+        let promise!: Promise<string>;
+
+        await act(async () => {
+            promise = result.current.enqueue(() => Promise.reject(error));
+        });
+
+        await expect(promise).rejects.toThrow('boom');
+        expect(result.current.lastError).toBe(error);
+    });
+});

--- a/src/hooks-d/use-idle.ts
+++ b/src/hooks-d/use-idle.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseIdleOptions {
+  /** Events that reset the idle timer */
+  events?: Array<keyof WindowEventMap>;
+  /** Initial idle state. Default: false */
+  initialState?: boolean;
+}
+
+const DEFAULT_EVENTS: Array<keyof WindowEventMap> = [
+  'mousemove',
+  'mousedown',
+  'keydown',
+  'touchstart',
+  'scroll',
+];
+
+/**
+ * Detects user inactivity. Returns true when no activity occurs within timeout.
+ */
+export function useIdle(
+  timeout: number = 60000,
+  options: UseIdleOptions = {}
+): boolean {
+  const { events = DEFAULT_EVENTS, initialState = false } = options;
+
+  const [idle, setIdle] = useState(initialState);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+
+    setIdle((prev) => (prev ? false : prev));
+    timerRef.current = setTimeout(() => {
+      setIdle(true);
+    }, timeout);
+  }, [timeout]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handler = () => resetTimer();
+    resetTimer();
+
+    events.forEach((event) => {
+      window.addEventListener(event, handler, { passive: true });
+    });
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, handler);
+      });
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [events, resetTimer]);
+
+  return idle;
+}

--- a/src/hooks-d/use-queue.ts
+++ b/src/hooks-d/use-queue.ts
@@ -1,0 +1,157 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type QueueTask<T> = () => Promise<T>;
+
+export interface UseQueueOptions<T, E = Error> {
+  /** Max number of concurrent tasks. Default: 1 */
+  concurrency?: number;
+  /** Start processing immediately. Default: true */
+  autoStart?: boolean;
+  /** Called when a task resolves */
+  onSuccess?: (result: T) => void;
+  /** Called when a task rejects */
+  onError?: (error: E) => void;
+}
+
+export interface UseQueueReturn<T, E = Error> {
+  enqueue: (task: QueueTask<T>) => Promise<T>;
+  clear: () => void;
+  pause: () => void;
+  resume: () => void;
+  isPaused: boolean;
+  pending: number;
+  running: number;
+  size: number;
+  isIdle: boolean;
+  lastResult: T | null;
+  lastError: E | null;
+}
+
+/**
+ * Manages a simple async task queue with configurable concurrency.
+ */
+export function useQueue<T, E = Error>(
+  options: UseQueueOptions<T, E> = {}
+): UseQueueReturn<T, E> {
+  const {
+    concurrency = 1,
+    autoStart = true,
+    onSuccess,
+    onError,
+  } = options;
+
+  const queueRef = useRef<Array<QueueTask<T>>>([]);
+  const runningRef = useRef(0);
+  const concurrencyRef = useRef(Math.max(1, concurrency));
+  const pausedRef = useRef(!autoStart);
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  const [pending, setPending] = useState(0);
+  const [running, setRunning] = useState(0);
+  const [isPaused, setIsPaused] = useState(!autoStart);
+  const [lastResult, setLastResult] = useState<T | null>(null);
+  const [lastError, setLastError] = useState<E | null>(null);
+
+  useEffect(() => {
+    concurrencyRef.current = Math.max(1, concurrency);
+  }, [concurrency]);
+
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [onSuccess, onError]);
+
+  const processNext = useCallback(() => {
+    if (pausedRef.current) return;
+
+    while (
+      runningRef.current < concurrencyRef.current &&
+      queueRef.current.length > 0
+    ) {
+      const task = queueRef.current.shift();
+      if (!task) break;
+
+      runningRef.current += 1;
+      setRunning(runningRef.current);
+      setPending(queueRef.current.length);
+
+      Promise.resolve()
+        .then(() => task())
+        .then((result) => {
+          setLastResult(result);
+          onSuccessRef.current?.(result);
+          return result;
+        })
+        .catch((err) => {
+          setLastError(err as E);
+          onErrorRef.current?.(err as E);
+          throw err;
+        })
+        .finally(() => {
+          runningRef.current -= 1;
+          setRunning(runningRef.current);
+          if (!pausedRef.current) processNext();
+        });
+    }
+  }, []);
+
+  const enqueue = useCallback(
+    (task: QueueTask<T>) => {
+      return new Promise<T>((resolve, reject) => {
+        const wrapped = () =>
+          Promise.resolve()
+            .then(task)
+            .then((result) => {
+              resolve(result);
+              return result;
+            })
+            .catch((err) => {
+              reject(err);
+              throw err;
+            });
+
+        queueRef.current.push(wrapped);
+        setPending(queueRef.current.length);
+        processNext();
+      });
+    },
+    [processNext]
+  );
+
+  const clear = useCallback(() => {
+    queueRef.current = [];
+    setPending(0);
+  }, []);
+
+  const pause = useCallback(() => {
+    pausedRef.current = true;
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    pausedRef.current = false;
+    setIsPaused(false);
+    processNext();
+  }, [processNext]);
+
+  useEffect(() => {
+    if (!pausedRef.current) processNext();
+  }, [processNext]);
+
+  return {
+    enqueue,
+    clear,
+    pause,
+    resume,
+    isPaused,
+    pending,
+    running,
+    size: pending + running,
+    isIdle: pending === 0 && running === 0,
+    lastResult,
+    lastError,
+  };
+}


### PR DESCRIPTION
# PR: Add useQueue/useIdle hooks and batch API docs

## Summary
This PR introduces two new hooks in `src/hooks-d` and documents a new batch API endpoint. The hooks are focused, SSR-safe, and match existing hook patterns. The docs add a concise spec for `/api/batch` and surface it in the sidebar.

## What Changed
- Added `useQueue` hook for managing async task queues with configurable concurrency, pause/resume, and basic lifecycle state.
- Added `useIdle` hook for detecting user inactivity with configurable timeout and events.
- Documented `POST /api/batch` under `docs/routes-d/batch.mdx`.
- Linked the new route in the API Routes section of the sidebar.
- Added unit tests for both hooks.

## Issues
- Fixes #94
- Fixes #93
- Fixes #91

