### PR TITLE
docs: fix encoding corruption in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Your content here...
 - [NPM Package](https://www.npmjs.com/package/nextellar)
 - [Report Issues](https://github.com/nextellarlabs/nextellar/issues)
 
-## 📜 License
+## License
 
-MIT © 2025 [Nextellar Labs](https://github.com/nextellarlabs)
+MIT (c) 2025 [Nextellar Labs](https://github.com/nextellarlabs)
 
 ---
 
-**Built with ❤️ for the Stellar developer community**
+**Built with care for the Stellar developer community**


### PR DESCRIPTION
## Summary
- Replace mojibake in the README license heading and footer with clean ASCII text
- Keep the original meaning while avoiding corrupted glyph rendering

## Validation
- git diff --check
- README scan for common mojibake patterns returned no matches

Closes #129