### PR TITLE
docs: add deploy command documentation

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -90,6 +90,42 @@ nextellar -v
 1.0.4
 ```
 
+## Deployment Commands
+
+### deploy
+
+Validate and prepare a deployment bundle from an existing Nextellar project.
+
+```bash
+nextellar deploy
+```
+
+Run this command from a built Next.js project root. The command validates that
+the current directory contains a `package.json`, that the project depends on
+Next.js, and that a production `.next` build exists. If validation passes,
+Nextellar creates a compressed bundle under `.nextellar/deploy/` and records
+the latest bundle metadata in `.nextellar/deploy/latest-bundle.json`.
+
+The bundle excludes large or local-only paths such as `node_modules`, `.git`,
+`.next/cache`, and previous `.nextellar/deploy` output.
+
+**Examples:**
+
+```bash
+# Build your app first
+npm run build
+
+# Create a deployment bundle
+nextellar deploy
+
+# Validate the project and preview the bundle path without writing a bundle
+nextellar deploy --dry-run
+```
+
+Nextellar Cloud upload is not available yet. After creating or validating the
+bundle, the CLI prints the current fallback recommendation to deploy with
+Vercel.
+
 ## Project Creation Workflow
 
 When you run `nextellar my-app`, here's what happens:

--- a/docs/cli/options.mdx
+++ b/docs/cli/options.mdx
@@ -209,6 +209,30 @@ nextellar my-app -d
 
 > **Note:** Currently, Nextellar doesn't have interactive prompts, so this flag is reserved for future use.
 
+## Deployment Options
+
+### --dry-run
+
+Validate deployment readiness without creating a bundle.
+
+```bash
+nextellar deploy --dry-run
+```
+
+- **Default:** `false`
+- **Type:** Boolean
+- **Applies To:** `nextellar deploy`
+
+When used with `nextellar deploy`, this option checks the project root and
+prints the bundle path that would be created. It does not write a bundle or
+update `.nextellar/deploy/latest-bundle.json`.
+
+**Use Cases:**
+
+- Check deployment readiness in local development
+- Validate a build before packaging
+- Preview the generated bundle location in CI logs
+
 ## Information Options
 
 ### --version, -v


### PR DESCRIPTION
## Summary
- documents the `nextellar deploy` command
- adds `nextellar deploy --dry-run` to the CLI options reference
- explains validation, bundle output, exclusions, and current Vercel fallback

## Validation
- Checked against `nextellarlabs/nextellar/bin/nextellar.ts` and `src/lib/deploy.ts`
- Ran `git diff --check`

Closes #139