### PR TITLE
docs: document telemetry command and flags

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -90,6 +90,44 @@ nextellar -v
 1.0.4
 ```
 
+## Telemetry Commands
+
+### telemetry
+
+Manage anonymous telemetry settings for the local CLI installation.
+
+```bash
+nextellar telemetry <action>
+```
+
+**Actions:**
+
+| Action    | Description                                      |
+| --------- | ------------------------------------------------ |
+| `status`  | Show whether telemetry is enabled or disabled    |
+| `enable`  | Persistently enable anonymous telemetry          |
+| `disable` | Persistently disable anonymous telemetry         |
+
+**Examples:**
+
+```bash
+# Check the current telemetry setting
+nextellar telemetry status
+
+# Enable telemetry for future CLI runs
+nextellar telemetry enable
+
+# Disable telemetry for future CLI runs
+nextellar telemetry disable
+```
+
+`nextellar telemetry status` also prints the local telemetry config path. If
+`NEXTELLAR_TELEMETRY_DISABLED` is set, telemetry is forced off for that
+environment even if the saved config says it is enabled.
+
+Telemetry commands only manage the local telemetry preference. They do not
+create a project or change an existing project.
+
 ## Project Creation Workflow
 
 When you run `nextellar my-app`, here's what happens:

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -98,12 +98,18 @@ These flags control how interactive or automated the CLI should be.
 | ---------------- | ----- | ----------------------------------------------- |
 | `--defaults`     | `-d`  | Use all default settings without prompting      |
 | `--skip-install` |       | Generate files but skip dependency installation |
+| `--no-telemetry` |       | Disable telemetry for the current CLI run       |
 
 **Example:**
 
 ```bash
 npx nextellar my-app --defaults --skip-install
+npx nextellar my-app --no-telemetry
 ```
+
+`--no-telemetry` applies only to that invocation. To persistently change the
+saved telemetry preference, use `nextellar telemetry enable` or
+`nextellar telemetry disable`.
 
 ---
 
@@ -111,17 +117,22 @@ npx nextellar my-app --defaults --skip-install
 
 These flags do not affect scaffolding but control CLI behavior.
 
-| Flag        | Alias | Description                               |
-| ----------- | ----- | ----------------------------------------- |
-| `--help`    | `-h`  | Show help text                            |
-| `--version` | `-v`  | Print the installed Nextellar CLI version |
+| Flag                              | Alias | Description                                             |
+| --------------------------------- | ----- | ------------------------------------------------------- |
+| `--help`                          | `-h`  | Show help text                                          |
+| `--version`                       | `-v`  | Print the installed Nextellar CLI version               |
+| `NEXTELLAR_TELEMETRY_DISABLED=1`  |       | Force telemetry off for the current shell or CI context |
 
 **Examples:**
 
 ```bash
 nextellar --help
 nextellar --version
+NEXTELLAR_TELEMETRY_DISABLED=1 nextellar my-app
 ```
+
+`NEXTELLAR_TELEMETRY_DISABLED` also accepts common truthy values such as
+`true`, `yes`, and `on`.
 
 ---
 


### PR DESCRIPTION
Closes #137

## Summary
- Documented `nextellar telemetry status`, `enable`, and `disable`.
- Added `--no-telemetry` to the scaffold flags reference.
- Documented `NEXTELLAR_TELEMETRY_DISABLED` as the environment-level override.

## Validation
- Checked behavior against `nextellar/bin/nextellar.ts` and the source telemetry docs.
- Ran `git diff --check`.