### PR TITLE
chore: add routes-d workspace folder for docs backlog

### DIFF
--- a/routes-d/README.md
+++ b/routes-d/README.md
@@ -1,0 +1,10 @@
+# routes-d
+
+Shared working folder referenced by the documentation backlog issues in this repository.
+
+Contributors picking up a docs backlog issue should place their draft or working
+files here, named after the issue (for example, issue-42-notes.md), until the
+change is ready to be moved into the docs folder.
+
+This folder exists to give every backlog issue a single, referenceable location.
+See the open issues in this repository for the current list of tasks.


### PR DESCRIPTION
Adds a routes-d folder at the repo root to serve as a shared, referenceable workspace for the documentation backlog issues. Contributors place working drafts here until ready to move into docs.
