### PR TITLE
docs: examples intro, npm casing, date-format note, and heading-level a11y fix

### DIFF
--- a/docs/customization/toc.mdx
+++ b/docs/customization/toc.mdx
@@ -121,7 +121,7 @@ Simply delete the corresponding key from `TocData`.
 
 The TOC is used in the `toc.tsx` component, which dynamically retrieves TOC data based on the `slug` value of the active page.
 
-#### TOC Component (`src/components/toc.tsx`)
+### TOC Component (`src/components/toc.tsx`)
 
 <FolderTree className="overflow-hidden p-2">
   <Folder element="project-root" defaultOpen={true}>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -180,7 +180,7 @@ That's it! No manual transaction building, no XDR encoding, no wallet adapter co
 ## Community & Support
 
 - **GitHub**: [nextellarlabs/nextellar](https://github.com/nextellarlabs/nextellar)
-- **NPM**: [nextellar](https://www.npmjs.com/package/nextellar)
+- **npm**: [nextellar](https://www.npmjs.com/package/nextellar)
 - **Issues**: [Report a bug](https://github.com/nextellarlabs/nextellar/issues)
 - **Discussions**: [Ask questions](https://github.com/nextellarlabs/nextellar/discussions)
 

--- a/routes-b/162-examples-intro-draft.mdx
+++ b/routes-b/162-examples-intro-draft.mdx
@@ -1,0 +1,23 @@
+---
+title: Examples
+description: Complete code examples for building Stellar dApps with Nextellar
+---
+
+# Examples
+
+Working draft for issue #162 — "Replace placeholder lorem text in the examples intro".
+
+> Status: the live page at `docs/examples/index.mdx` no longer contains any
+> placeholder/lorem text; its introduction already reads as real, relevant
+> content. This draft is kept here per the issue constraint (working drafts in a
+> routes folder at the repo root) and is intentionally outside `docs/`, so it is
+> not picked up by Contentlayer and does not affect the production build.
+
+## Proposed introduction copy
+
+Browse complete, runnable examples that show how to wire Nextellar into a real
+Stellar dApp — from connecting a wallet to sending payments and reading
+contract state. Each example is copy-paste ready and links to the hooks it uses.
+
+This keeps the intro short, relevant, and consistent with the tone of the
+surrounding documentation.

--- a/routes-b/168-frontmatter-date-format.md
+++ b/routes-b/168-frontmatter-date-format.md
@@ -1,0 +1,25 @@
+# Issue #168 — Unify date formats in frontmatter across docs
+
+Working draft / decision record. Lives outside `docs/` so it does not affect the
+Contentlayer build.
+
+## Chosen format
+
+**ISO 8601 calendar date — `YYYY-MM-DD`** (unquoted), e.g. `date: 2025-03-12`.
+
+Rationale:
+
+- It is the format Contentlayer's `date` field parses natively
+  (`contentlayer.config.ts` declares `date: { type: 'date' }`).
+- It is unambiguous and sorts lexicographically.
+- It already matches the majority convention in the repo.
+
+## Audit result
+
+All 25 pages that currently declare a `date:` in frontmatter already use the
+`YYYY-MM-DD` format — there are no `MM/DD/YYYY`, month-name, or quoted variants
+remaining. The acceptance criteria (parses without errors, builds via
+`pnpm build:content`) are therefore already satisfied on `main`.
+
+Files without a `date:` field were left untouched: dates are optional in the
+schema and inventing values would violate the "keep values accurate" constraint.

--- a/routes-b/221-accessibility-audit.md
+++ b/routes-b/221-accessibility-audit.md
@@ -1,0 +1,27 @@
+# Issue #221 — Accessibility audit (docs content)
+
+Working draft documenting the audit findings. Lives outside `docs/` so it does
+not affect the Contentlayer build. Scope is limited to documentation content, as
+required by the issue.
+
+## Method
+
+Static scan of every `*.mdx` / `*.md` file under `docs/` for:
+
+- heading hierarchy (missing/duplicate `h1`, skipped levels)
+- image alternative text (`![]()` and `<img>` without `alt`)
+- non-descriptive link text ("click here", "read more", etc.)
+
+## Findings
+
+| Area      | Finding                                                                                                                                         | Action                                                              |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Headings  | `docs/customization/toc.mdx` skipped from an `h2` ("Where is the TOC Rendered?") straight to an `h4` ("TOC Component").                         | **Fixed** — promoted the `h4` to `h3` so the outline is sequential. |
+| Alt text  | Only one content image exists (`docs/search-bar.mdx`), and it already has descriptive alt text ("Search Bar Demo").                             | No change needed.                                                   |
+| Link text | No non-descriptive link text found in docs.                                                                                                     | No change needed.                                                   |
+| Contrast  | Color contrast is governed by the theme/CSS (`src/app/globals.css`), not documentation content, so it is out of scope for this docs-only issue. | Tracked separately.                                                 |
+
+## Result
+
+The highest-impact, in-scope issue (the heading-level skip) is fixed in
+`docs/customization/toc.mdx`. Remaining content was already conformant.


### PR DESCRIPTION
## Summary
- **#162** – Examples intro: the live page (`docs/examples/index.mdx`) already contains real introductory copy (no lorem remains), so the reviewed intro is added as a working draft under `routes-b/`.
- **#166** – Use lowercase `npm` in the Community & Support links on the docs home page (the only genuine miscased code keyword in prose; other candidates were brand names inside URLs/paths or CLI flag names).
- **#168** – All frontmatter `date:` fields already use ISO 8601 (`YYYY-MM-DD`); the format decision and audit result are recorded as a working draft under `routes-b/`.
- **#221** – Fix a skipped heading level on the TOC customization page (`h2` → `h4` corrected to `h3`) so the document outline is sequential for assistive technology; audit findings included under `routes-b/`.

Working drafts live in `routes-b/` at the repo root, outside Contentlayer's `docs/` content dir, so they do not affect the production build or the live site.

## Closes
closes #162
closes #166
closes #168
closes #221

## Test plan
- [x] `pnpm build:content` succeeds (60 documents generated, no errors)
- [x] `pnpm validate:sidebar` passes (2/2 sidebar, 1/1 TOC, 0 broken)
- [x] No internal links or heading anchor slugs changed by these edits
- [x] Verified scope: only `docs/index.mdx`, `docs/customization/toc.mdx`, and new `routes-b/` files touched