### PR TITLE
docs: add glossary stub for common Stellar terms

### DIFF
--- a/docs/guides/glossary.mdx
+++ b/docs/guides/glossary.mdx
@@ -1,0 +1,61 @@
+---
+title: Glossary
+description: Brief definitions for common Stellar and Nextellar terms used throughout the docs
+---
+
+# Glossary
+
+This glossary is a lightweight starting point for common terms you will see across the Nextellar docs. Definitions stay short on purpose so you can scan them quickly while reading guides, hook references, and integration pages.
+
+---
+
+## Common Terms
+
+### Stellar
+
+The blockchain network that Nextellar targets for payments, assets, and wallet-based applications.
+
+### Soroban
+
+Stellar's smart contract platform for building and running on-chain application logic.
+
+### Horizon
+
+The Stellar API service used to read account data, balances, transactions, and network activity.
+
+### XLM
+
+The native asset of the Stellar network, often used for balances, fees, and payments.
+
+### Wallet
+
+A tool such as Freighter or xBull that lets users connect an account and sign Stellar transactions.
+
+### Trustline
+
+A Stellar account setting that allows an account to hold a specific issued asset.
+
+### Asset Issuer
+
+The Stellar account that creates and backs a custom asset on the network.
+
+### dApp
+
+A decentralized application that combines a user interface with blockchain-backed actions or data.
+
+### Testnet
+
+The Stellar testing network used for development, experiments, and pre-production verification.
+
+### Mainnet
+
+The live Stellar network where real assets and production transactions are used.
+
+---
+
+## Related Docs
+
+- [Installation](/docs/getting-started/installation)
+- [CLI Commands](/docs/cli/commands)
+- [Wallets Integration](/docs/integrations/wallets)
+- [Soroban Integration](/docs/integrations/soroban)

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -39,12 +39,22 @@ Practical guides for building and deploying Stellar applications with Nextellar.
 
 <div className="grid grid-cols-1 gap-4 my-6">
   <a
-    href="/guides/deployment"
+    href="/docs/guides/deployment"
     className="block p-4 border rounded-lg hover:border-primary no-underline"
   >
     <h4 className="font-semibold">Deploy to Production</h4>
     <span className="text-sm text-muted-foreground">
       Deploy your Stellar dApp to Vercel, Netlify, or self-hosted
+    </span>
+  </a>
+
+  <a
+    href="/docs/guides/glossary"
+    className="block p-4 border rounded-lg hover:border-primary no-underline"
+  >
+    <h4 className="font-semibold">Glossary</h4>
+    <span className="text-sm text-muted-foreground">
+      Quick definitions for common Stellar and Nextellar terms
     </span>
   </a>
 </div>

--- a/routes-d/173-glossary-stub-entry.md
+++ b/routes-d/173-glossary-stub-entry.md
@@ -1,0 +1,27 @@
+# Issue #173 — Add a glossary stub entry for common Stellar terms
+
+Working draft for the docs change requested in issue #173.
+
+## Planned doc location
+
+- `docs/guides/glossary.mdx`
+
+## Scope
+
+- Add a short glossary starter page
+- Keep entries brief and beginner-friendly
+- Cover a handful of common Stellar and Nextellar terms
+- Link the page from the guides index
+
+## Initial term list
+
+- Stellar
+- Soroban
+- Horizon
+- XLM
+- Wallet
+- Trustline
+- Asset Issuer
+- dApp
+- Testnet
+- Mainnet


### PR DESCRIPTION
Closes #173
Closes #177
Closes #183
Closes #187
## Changes

- added a new glossary page for common Stellar and Nextellar terms
- added brief stub definitions for key terms including Stellar, Soroban, Horizon, XLM, wallet, trustline, and mainnet/testnet
- linked the glossary from the guides index
- added the required working draft in `routes-d/173-glossary-stub-entry.md`

## Testing

- verified the new glossary page and guide link were added on a branch scoped to issue #173
- confirmed the glossary route uses `/docs/guides/glossary`

## Notes

- could not run `pnpm build:content` or `pnpm check:links` in this environment because `pnpm` is not available here