### PR TITLE
docs: routes-d drafts for prerequisites, hook cross-links, components index, Mermaid guide

### DIFF
--- a/routes-d/161-prerequisites-note.md
+++ b/routes-d/161-prerequisites-note.md
@@ -1,0 +1,42 @@
+# Issue #161 — Add a short prerequisites note to the installation page
+
+Working draft for the docs change requested in issue #161.
+
+## Planned doc location
+
+- `docs/getting-started/installation.mdx`
+
+## Scope
+
+- Add a concise prerequisites section near the top of the installation page
+- List required tools with minimum versions
+- Keep it brief — 3–5 bullet points maximum
+
+## Draft content
+
+Place this block immediately after the page heading, before the Quick Install section:
+
+```mdx
+## Prerequisites
+
+Before you begin, make sure you have the following installed:
+
+| Tool | Minimum version | Notes |
+|------|----------------|-------|
+| **Node.js** | 20.18.0 | [Download](https://nodejs.org/) |
+| **npm / yarn / pnpm** | npm 9+ | Included with Node.js |
+| **Git** | any recent | Optional but recommended |
+
+Verify your Node version:
+
+```bash
+node --version  # should print v20.18.0 or higher
+```
+```
+
+## Notes
+
+- The installation page already has a partial Prerequisites section — this draft
+  proposes tightening it into a scannable table so readers can check requirements
+  at a glance before running any commands.
+- No changes required outside `installation.mdx`.

--- a/routes-d/193-cross-links-hooks.md
+++ b/routes-d/193-cross-links-hooks.md
@@ -1,0 +1,45 @@
+# Issue #193 — Add cross links between related hook pages
+
+Working draft for the docs change requested in issue #193.
+
+## Planned doc locations
+
+All files under `docs/hooks/`.
+
+## Scope
+
+- Identify natural groupings among the hook pages
+- Add a **Related hooks** section at the bottom of each page
+- Links should be accurate relative MDX paths
+
+## Hook relationship map
+
+| Hook | Related hooks |
+|------|--------------|
+| `useStellarWallet` | `useStellarBalances`, `useStellarPayment`, `WalletProvider`, `WalletConnectButton` |
+| `useStellarBalances` | `useStellarWallet`, `useTrustlines` |
+| `useStellarPayment` | `useStellarWallet`, `useTransactionHistory` |
+| `useSorobanContract` | `useSorobanEvents` |
+| `useSorobanEvents` | `useSorobanContract` |
+| `useTransactionHistory` | `useStellarPayment`, `useStellarWallet` |
+| `useTrustlines` | `useStellarBalances`, `useStellarWallet` |
+| `useOfferBook` | `useStellarWallet` |
+| `WalletProvider` | `useStellarWallet`, `WalletConnectButton` |
+| `WalletConnectButton` | `WalletProvider`, `useStellarWallet` |
+
+## Draft section to append to each hook page
+
+```mdx
+## Related hooks
+
+- [useStellarWallet](./use-stellar-wallet) — wallet connection and account management
+- [useStellarBalances](./use-stellar-balances) — fetch and refresh account balances
+```
+
+Adjust the list per the relationship map above for each individual page.
+
+## Notes
+
+- Use relative paths (e.g. `./use-stellar-wallet`) so links resolve correctly in
+  any deployment base path.
+- Run `pnpm check:links` after adding links to confirm no broken references.

--- a/routes-d/206-components-index.md
+++ b/routes-d/206-components-index.md
@@ -1,0 +1,43 @@
+# Issue #206 — Create a page listing all available components
+
+Working draft for the docs change requested in issue #206.
+
+## Planned doc location
+
+- `docs/components/index.mdx`
+
+## Scope
+
+- Single index page listing every available component
+- Each entry: component name, one-line description, link to its dedicated page
+- Group by category (UI, wallet, data display)
+
+## Draft content
+
+```mdx
+---
+title: Components
+description: A complete list of all Nextellar UI and wallet components
+---
+
+# Components
+
+Nextellar ships a set of pre-built React components designed for Stellar dApps.
+Each component is fully typed and works out of the box with `WalletProvider`.
+
+## Wallet
+
+| Component | Description |
+|-----------|-------------|
+| [WalletConnectButton](./wallet-connect-button) | One-click wallet connection modal |
+| [WalletProvider](./wallet-provider) | Context provider — wrap your app root |
+
+## Planned components
+
+Additional components are tracked in the [feature backlog](https://github.com/nextellarlabs/nextellar/issues).
+```
+
+## Notes
+
+- This page acts as the entry point for the `/docs/components/` section.
+- Expand the table as new components ship; keep descriptions to one line each.

--- a/routes-d/210-mermaid-diagrams-guide.md
+++ b/routes-d/210-mermaid-diagrams-guide.md
@@ -1,0 +1,70 @@
+# Issue #210 — Write a guide on adding diagrams with Mermaid
+
+Working draft for the docs change requested in issue #210.
+
+## Planned doc location
+
+- `docs/guides/mermaid-diagrams.mdx`
+
+## Scope
+
+- Show how to embed Mermaid diagrams in MDX pages
+- Cover the most useful diagram types for a docs site (flowchart, sequence)
+- Include a working code example
+
+## Draft content
+
+```mdx
+---
+title: Adding Diagrams with Mermaid
+description: Embed interactive diagrams in your Nextellar docs using Mermaid
+---
+
+# Adding Diagrams with Mermaid
+
+Nextellar docs supports [Mermaid](https://mermaid.js.org/) diagrams out of the box.
+Wrap your diagram code in a fenced code block tagged `mermaid`:
+
+````md
+```mermaid
+flowchart LR
+  A[User] -->|connect| B[WalletProvider]
+  B --> C[useStellarWallet]
+  C -->|sign tx| D[Stellar Network]
+```
+````
+
+### Rendered result
+
+```mermaid
+flowchart LR
+  A[User] -->|connect| B[WalletProvider]
+  B --> C[useStellarWallet]
+  C -->|sign tx| D[Stellar Network]
+```
+
+## Sequence diagrams
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Freighter
+  participant Horizon
+  App->>Freighter: requestAccess()
+  Freighter-->>App: publicKey
+  App->>Horizon: submitTransaction(xdr)
+  Horizon-->>App: result
+```
+
+## Tips
+
+- Keep diagrams narrow — very wide diagrams overflow on mobile.
+- Use `LR` (left-to-right) for flow diagrams and `TD` (top-down) for hierarchies.
+- Mermaid is rendered client-side; diagrams won't appear in RSS feeds or plain markdown exports.
+```
+
+## Notes
+
+- Confirm Mermaid is already wired into the MDX pipeline before merging.
+  Check `next.config.*` or the rehype plugins for `rehype-mermaid` / `remark-mermaidjs`.
+- If not wired, the setup steps should be added to the guide.


### PR DESCRIPTION
Closes #161
Closes #193
Closes #206
Closes #210

Adds four working drafts to the `routes-d/` folder per the contribution constraints:

- **`161-prerequisites-note.md`** — proposes tightening the installation page prerequisites into a scannable table (Node 20.18+, npm/yarn/pnpm, Git)
- **`193-cross-links-hooks.md`** — maps relationships between all hook pages and drafts the "Related hooks" section to append to each
- **`206-components-index.md`** — drafts `docs/components/index.mdx` listing all available components (WalletConnectButton, WalletProvider) grouped by category
- **`210-mermaid-diagrams-guide.md`** — drafts `docs/guides/mermaid-diagrams.mdx` with flowchart and sequence diagram examples