### PR TITLE
Feat/issues 231 238 docs guides

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -73,6 +73,10 @@ export const sidebarNav: SidebarSection[] = [
         href: '/docs/guides/diagram-image-style',
       },
       {
+        title: 'Offline Reading Export',
+        href: '/docs/guides/offline-reading',
+      },
+      {
         title: 'Internationalization',
         href: '/docs/guides/internationalization',
       },

--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -69,6 +69,10 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'Editor Setup', href: '/docs/guides/editor-setup' },
       { title: 'Add a Docs Page', href: '/docs/guides/add-docs-page' },
       {
+        title: 'Diagram & Image Style',
+        href: '/docs/guides/diagram-image-style',
+      },
+      {
         title: 'Internationalization',
         href: '/docs/guides/internationalization',
       },
@@ -142,7 +146,10 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'Contributing', href: '/docs/guides/contributing' },
       { title: 'Editor Setup', href: '/docs/guides/editor-setup' },
       { title: 'Testing (Vitest)', href: '/docs/guides/testing' },
-      { title: 'Internationalization', href: '/docs/guides/internationalization' },
+      {
+        title: 'Internationalization',
+        href: '/docs/guides/internationalization',
+      },
       { title: 'Deployment', href: '/docs/guides/deployment' },
       { title: 'Glossary', href: '/docs/guides/glossary' },
     ],

--- a/docs/guides/diagram-image-style.mdx
+++ b/docs/guides/diagram-image-style.mdx
@@ -1,0 +1,193 @@
+---
+title: Diagram and Image Style Guide
+description: Colors, sizing, labeling, and export settings for diagrams and images in Nextellar documentation.
+date: 2026-05-29
+---
+
+# Diagram and Image Style Guide
+
+Use this guide when you add or update diagrams, illustrations, and images in the Nextellar docs.
+It keeps visuals consistent with the site theme, readable in light and dark mode, and easy to maintain in the repository.
+
+## Color palette
+
+Diagrams and images should use the same neutral base as the docs UI defined in `src/app/globals.css`.
+
+### Core colors
+
+| Role          | Light theme               | Dark theme                | Usage                        |
+| ------------- | ------------------------- | ------------------------- | ---------------------------- |
+| Background    | `#FFFFFF`                 | `#000000`                 | Canvas and page fills        |
+| Foreground    | `#000000`                 | `#FFFFFF`                 | Text, strokes, icons         |
+| Muted surface | `#F5F5F5` (`--secondary`) | `#141414` (`--secondary`) | Secondary nodes, panels      |
+| Border        | `#000000` at 40% opacity  | `#FFFFFF` at 20% opacity  | Boxes and dividers           |
+| Accent        | `#533483`                 | `#533483`                 | Highlights, diagram emphasis |
+| Success       | `#22C55E`                 | `#16A34A`                 | Positive states only         |
+| Warning       | `#EAB308`                 | `#CA8A04`                 | Caution callouts only        |
+| Error         | `#EF4444`                 | `#DC2626`                 | Failure paths only           |
+
+Reserve semantic greens, yellows, and reds for status meaning.
+Do not use them as decorative fills on neutral architecture diagrams.
+
+### Mermaid diagrams
+
+Mermaid blocks render through `src/components/Mermaid.tsx` with a fixed dark theme.
+Use the built-in palette instead of custom hex values in diagram source when possible:
+
+| Token                | Hex       | Usage                  |
+| -------------------- | --------- | ---------------------- |
+| `primaryColor`       | `#1a1a2e` | Node backgrounds       |
+| `primaryBorderColor` | `#533483` | Node borders           |
+| `lineColor`          | `#e94560` | Connectors (sparingly) |
+| `secondaryColor`     | `#16213e` | Group backgrounds      |
+| `titleColor`         | `#ffffff` | Titles on dark canvas  |
+
+Embed Mermaid in MDX with a fenced `mermaid` code block:
+
+```mermaid
+flowchart LR
+  A[Reader] --> B[Docs page]
+  B --> C[Static asset]
+```
+
+### Example palette asset
+
+![Nextellar docs color palette for diagrams](/images/style-guide/color-palette.svg)
+
+## Sizing
+
+### Diagrams and illustrations
+
+| Asset type                | Recommended size          | Notes                                            |
+| ------------------------- | ------------------------- | ------------------------------------------------ |
+| Inline SVG                | `viewBox` up to `800×400` | Scales with prose width; prefer SVG for diagrams |
+| Wide architecture diagram | Max width `720px`         | Wider diagrams scroll on mobile                  |
+| Mermaid flowchart         | ≤ 6 nodes per row         | Split large flows into multiple diagrams         |
+| Labeled frame             | `480×280` to `640×360`    | Leave 24px padding inside the frame              |
+
+Set `width` and `height` on SVG exports only when the authoring tool requires them.
+Prefer a responsive `viewBox` so images scale in the docs layout.
+
+### Screenshots
+
+Component screenshots follow the [Screenshot Workflow](/docs/guides/screenshot-workflow):
+
+- Viewport: `1280 × 800 px` before crop
+- Format: PNG, lossless
+- Path: `public/screenshots/<component-slug>/<variant>.png`
+
+For retina clarity, export at 2× density only when the cropped region stays under `1440px` wide.
+
+### Inline images in MDX
+
+```mdx
+![Wallet connection flow](/images/style-guide/flowchart-example.svg)
+```
+
+Paths are relative to `public/`.
+Do not commit images wider than `1600px` unless they are full-page references.
+
+## Labeling
+
+### Text in diagrams
+
+- Use **sentence case** for node labels (`Wallet provider`, not `Wallet Provider`).
+- Use **monospace** for code identifiers (`useStellarWallet`, file paths, CLI flags).
+- Keep labels under **24 characters** when possible; wrap long names on a second line inside the node.
+- Number callout steps (`1`, `2`, `3`) only when the prose references them.
+
+### Captions and alt text
+
+Every image must include alt text that describes the content, not the file name.
+
+```mdx
+![Flowchart showing a reader opening a docs page and loading a static asset](/images/style-guide/flowchart-example.svg)
+```
+
+Optional captions use italic text on the line below the image:
+
+```mdx
+![Labeled diagram with numbered callouts for WalletProvider and useStellarWallet](/images/style-guide/labeled-frame-example.svg)
+
+_Figure 1. Provider wraps hooks at the app root._
+```
+
+### Example assets
+
+| File                                                                         | Purpose                       |
+| ---------------------------------------------------------------------------- | ----------------------------- |
+| [`color-palette.svg`](/images/style-guide/color-palette.svg)                 | Approved swatches             |
+| [`flowchart-example.svg`](/images/style-guide/flowchart-example.svg)         | Simple left-to-right flow     |
+| [`labeled-frame-example.svg`](/images/style-guide/labeled-frame-example.svg) | Numbered callouts and caption |
+
+![Example flowchart following Nextellar diagram style](/images/style-guide/flowchart-example.svg)
+
+![Example labeled diagram frame](/images/style-guide/labeled-frame-example.svg)
+
+## Export settings
+
+### SVG (Figma, Illustrator, Inkscape)
+
+| Setting           | Value                                          |
+| ----------------- | ---------------------------------------------- |
+| Format            | SVG 1.1                                        |
+| Outline text      | Yes (convert to paths if fonts may differ)     |
+| Decimal precision | 2                                              |
+| Embed images      | No (link or flatten separately)                |
+| Background        | Transparent or `#FFFFFF` for light-only assets |
+
+Run [SVGO](https://github.com/svg/svgo) or your editor’s “Optimize SVG” before commit when file size exceeds `20 KB`.
+
+### PNG (screenshots, raster diagrams)
+
+| Setting     | Value                             |
+| ----------- | --------------------------------- |
+| Color space | sRGB                              |
+| Bit depth   | 24-bit (no alpha unless needed)   |
+| Compression | Lossless PNG                      |
+| Scale       | 1× default; 2× for small UI crops |
+
+### Mermaid (source in MDX)
+
+| Setting           | Value                                                            |
+| ----------------- | ---------------------------------------------------------------- |
+| Direction         | `LR` for flows, `TD` for hierarchies                             |
+| Labels            | Plain text; avoid HTML in node text                              |
+| Export (optional) | [Mermaid Live Editor](https://mermaid.live) → SVG, then optimize |
+
+Do not commit rendered Mermaid PNGs when the source block is sufficient.
+The site renders Mermaid at build/runtime in the browser.
+
+### Dark mode assets
+
+When an image cannot use theme tokens (for example, a branded illustration), provide paired assets:
+
+```mdx
+<img
+  src="/images/example-light.svg"
+  alt="Architecture overview"
+  className="dark:hidden"
+/>
+<img
+  src="/images/example-dark.svg"
+  alt="Architecture overview"
+  className="hidden dark:block"
+/>
+```
+
+See [Theming and Dark Mode](/docs/theme) for token-based styling.
+
+## Checklist before opening a PR
+
+1. Colors match the palette above or the Mermaid defaults in `Mermaid.tsx`.
+2. SVGs include a `<title>` or descriptive `aria-labelledby` for accessibility.
+3. Alt text is present and describes the diagram.
+4. Files live under `public/images/` or `public/screenshots/` with kebab-case names.
+5. `pnpm build:content` completes without errors.
+
+## Related
+
+- [Screenshot Workflow](/docs/guides/screenshot-workflow)
+- [Theming and Dark Mode](/docs/theme)
+- [Contributing to Documentation](/docs/guides/contributing)
+- [Add a New Docs Page](/docs/guides/add-docs-page)

--- a/docs/guides/offline-reading.mdx
+++ b/docs/guides/offline-reading.mdx
@@ -1,0 +1,161 @@
+---
+title: Offline Reading Export
+description: Export the Nextellar documentation site for offline reading using a production build and local mirror.
+date: 2026-05-29
+---
+
+# Offline Reading Export
+
+This guide describes how to produce a local copy of the Nextellar docs you can read without network access.
+The recommended approach is a **production build** served locally, then a **static mirror** of that server into a folder you can open from disk or archive.
+
+## Export approach
+
+The docs site is a **Next.js** application with **Contentlayer** MDX content.
+It is not configured for `output: 'export'`, so there is no single pre-rendered HTML folder in the repository.
+
+Instead, offline reading works in two stages:
+
+1. **Build** — compile MDX and the Next.js app (`pnpm build`).
+2. **Mirror** — download pages and assets from the running production server into a local directory (`wget` or similar).
+
+After mirroring, open `index.html` entry points through the saved folder structure, or unpack the archive on a machine without Node.js installed.
+
+## Prerequisites
+
+- **Node.js** 18 or later (20.18.0+ recommended)
+- **pnpm** installed
+- **wget** (GNU wget 1.21+ on Linux/macOS; WSL on Windows)
+- Enough disk space for the build (`.next/`) and mirror output (~200–400 MB)
+
+## Steps to produce an offline bundle
+
+### 1. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 2. Build the content layer and site
+
+```bash
+pnpm build:content
+pnpm build
+```
+
+`pnpm build:content` validates MDX frontmatter and generates the Contentlayer output.
+`pnpm build` produces the optimized Next.js production bundle.
+
+### 3. Start the production server
+
+In a separate terminal:
+
+```bash
+pnpm start
+```
+
+By default the site listens on `http://localhost:3000`.
+
+### 4. Mirror the site to a local folder
+
+Create an output directory and mirror from the running server:
+
+```bash
+mkdir -p offline-bundle
+wget \
+  --mirror \
+  --convert-links \
+  --adjust-extension \
+  --page-requisites \
+  --no-parent \
+  --directory-prefix=offline-bundle \
+  http://localhost:3000/docs/getting-started/introduction
+```
+
+To include more sections, repeat with additional seed URLs or widen the path:
+
+```bash
+wget \
+  --mirror \
+  --convert-links \
+  --adjust-extension \
+  --page-requisites \
+  --no-parent \
+  --directory-prefix=offline-bundle \
+  http://localhost:3000/docs/
+```
+
+The mirror saves HTML, CSS, JavaScript, fonts, and images under `offline-bundle/`.
+
+### 5. Archive for transfer (optional)
+
+```bash
+tar -czf nextellar-docs-offline.tar.gz offline-bundle/
+```
+
+Copy `nextellar-docs-offline.tar.gz` to the offline machine and extract it there.
+
+### 6. Stop the server
+
+When mirroring finishes, stop `pnpm start` with `Ctrl+C`.
+
+## Verifying the export
+
+1. Open a mirrored page in the browser, for example:
+   `offline-bundle/localhost:3000/docs/getting-started/introduction.html`
+   (exact paths depend on your `wget` version and `--adjust-extension` behavior).
+2. Confirm styles load and navigation between mirrored pages works.
+3. Spot-check a page with a Mermaid diagram (for example [SDK Overview](/docs/sdk/overview)) after JavaScript loads.
+
+If styles or scripts are missing, re-run `wget` with `--page-requisites` and ensure the production server was running for the full mirror.
+
+## Alternative: local server only
+
+If you can run Node.js offline but do not need a static mirror:
+
+```bash
+pnpm build:content && pnpm build
+pnpm start
+```
+
+Visit `http://localhost:3000/docs` in the browser.
+This is the simplest workflow for contributors reviewing docs on a flight or at a conference with no upstream network after the initial `pnpm install` and build.
+
+## Formatting and feature limitations
+
+| Feature                    | Offline mirror        | Notes                                                      |
+| -------------------------- | --------------------- | ---------------------------------------------------------- |
+| MDX prose and code blocks  | Supported             | Static HTML and bundled JS                                 |
+| Internal `/docs/...` links | Supported if mirrored | Use `--convert-links`                                      |
+| Mermaid diagrams           | Partial               | Rendered client-side; requires JS in the mirror            |
+| Search dialog              | Limited               | Search index may not work without the full app runtime     |
+| Theme toggle               | Partial               | Depends on mirrored `_next` assets and `localStorage`      |
+| External links             | Requires network      | GitHub, npm, and Stellar network URLs stay remote          |
+| Dynamic Next.js routes     | Partial               | Only mirrored paths are available                          |
+| `pnpm check:links`         | N/A for mirror        | Validates against a live dev server, not the export folder |
+
+Plain Markdown or PDF exports of individual pages are **not** part of this workflow.
+Mermaid source in fenced blocks will appear as code, not diagrams, in non-HTML exports.
+
+## Troubleshooting
+
+**Mirror is empty or incomplete**
+
+- Confirm `pnpm start` is running before `wget`.
+- Remove `offline-bundle/` and mirror again with `--page-requisites`.
+
+**Broken styling**
+
+- Ensure `_next/static/` assets were downloaded; increase wget recursion if needed.
+- Avoid mirroring from `pnpm dev`; use the production server (`pnpm start`).
+
+**Mermaid diagrams show as code**
+
+- Open the page in a browser with JavaScript enabled.
+- If diagrams still fail, the mirror may have blocked `_next` chunks; re-mirror with `--page-requisites`.
+
+## Related
+
+- [Contributing to Documentation](/docs/guides/contributing)
+- [Diagram and Image Style Guide](/docs/guides/diagram-image-style)
+- [Deployment](/docs/guides/deployment)

--- a/public/images/style-guide/color-palette.svg
+++ b/public/images/style-guide/color-palette.svg
@@ -1,0 +1,19 @@
+<svg width="640" height="120" viewBox="0 0 640 120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="palette-title">
+  <title id="palette-title">Nextellar docs diagram color palette</title>
+  <rect width="640" height="120" fill="#FFFFFF"/>
+  <text x="16" y="24" font-family="system-ui, sans-serif" font-size="12" fill="#000000">Primary palette (light theme)</text>
+  <rect x="16" y="36" width="72" height="48" rx="4" fill="#000000"/>
+  <text x="28" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#FFFFFF">#000</text>
+  <rect x="100" y="36" width="72" height="48" rx="4" fill="#FFFFFF" stroke="#000000" stroke-opacity="0.4"/>
+  <text x="112" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#000000">#FFF</text>
+  <rect x="184" y="36" width="72" height="48" rx="4" fill="#F5F5F5" stroke="#000000" stroke-opacity="0.2"/>
+  <text x="196" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#000000">muted</text>
+  <rect x="268" y="36" width="72" height="48" rx="4" fill="#22C55E"/>
+  <text x="280" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#FFFFFF">success</text>
+  <rect x="352" y="36" width="72" height="48" rx="4" fill="#EAB308"/>
+  <text x="364" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#000000">warning</text>
+  <rect x="436" y="36" width="72" height="48" rx="4" fill="#EF4444"/>
+  <text x="448" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#FFFFFF">error</text>
+  <rect x="520" y="36" width="104" height="48" rx="4" fill="#533483"/>
+  <text x="532" y="66" font-family="system-ui, sans-serif" font-size="10" fill="#FFFFFF">diagram accent</text>
+</svg>

--- a/public/images/style-guide/flowchart-example.svg
+++ b/public/images/style-guide/flowchart-example.svg
@@ -1,0 +1,19 @@
+<svg width="560" height="200" viewBox="0 0 560 200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="flow-title">
+  <title id="flow-title">Example flowchart following Nextellar diagram style</title>
+  <rect width="560" height="200" fill="#FFFFFF"/>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0 0 L8 4 L0 8 Z" fill="#000000" fill-opacity="0.6"/>
+    </marker>
+  </defs>
+  <rect x="24" y="72" width="120" height="56" rx="6" fill="#FFFFFF" stroke="#000000" stroke-width="1.5"/>
+  <text x="84" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#000000">Reader</text>
+  <line x1="144" y1="100" x2="196" y2="100" stroke="#000000" stroke-opacity="0.6" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="170" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#000000" fill-opacity="0.6">opens</text>
+  <rect x="196" y="72" width="120" height="56" rx="6" fill="#F5F5F5" stroke="#000000" stroke-width="1.5"/>
+  <text x="256" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#000000">Docs page</text>
+  <line x1="316" y1="100" x2="368" y2="100" stroke="#000000" stroke-opacity="0.6" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="342" y="88" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" fill="#000000" fill-opacity="0.6">loads</text>
+  <rect x="368" y="72" width="168" height="56" rx="6" fill="#533483" fill-opacity="0.12" stroke="#533483" stroke-width="1.5"/>
+  <text x="452" y="106" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#000000">Static asset</text>
+</svg>

--- a/public/images/style-guide/labeled-frame-example.svg
+++ b/public/images/style-guide/labeled-frame-example.svg
@@ -1,0 +1,13 @@
+<svg width="480" height="280" viewBox="0 0 480 280" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="frame-title">
+  <title id="frame-title">Example labeled diagram frame with caption area</title>
+  <rect width="480" height="280" fill="#FFFFFF"/>
+  <rect x="24" y="24" width="432" height="200" rx="8" fill="#FAFAFA" stroke="#000000" stroke-opacity="0.2" stroke-width="1"/>
+  <rect x="48" y="64" width="160" height="48" rx="4" fill="#FFFFFF" stroke="#000000" stroke-width="1"/>
+  <text x="128" y="94" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" fill="#000000">WalletProvider</text>
+  <text x="248" y="94" font-family="system-ui, sans-serif" font-size="11" fill="#000000" fill-opacity="0.5">1</text>
+  <rect x="272" y="64" width="160" height="48" rx="4" fill="#FFFFFF" stroke="#000000" stroke-width="1"/>
+  <text x="352" y="94" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" fill="#000000">useStellarWallet</text>
+  <text x="448" y="94" font-family="system-ui, sans-serif" font-size="11" fill="#000000" fill-opacity="0.5">2</text>
+  <line x1="208" y1="88" x2="272" y2="88" stroke="#000000" stroke-opacity="0.4" stroke-width="1"/>
+  <text x="24" y="252" font-family="system-ui, sans-serif" font-size="12" fill="#000000" fill-opacity="0.7">Figure 1. Provider wraps hooks at the app root.</text>
+</svg>

--- a/routes-d/231-offline-reading-export.md
+++ b/routes-d/231-offline-reading-export.md
@@ -1,0 +1,20 @@
+# Issue #231 — Document a full offline reading export workflow
+
+Working draft for the docs change requested in issue #231.
+
+## Planned doc location
+
+- `docs/guides/offline-reading.mdx`
+
+## Scope
+
+- Describe mirroring the production build from a local server
+- Document prerequisites and step-by-step commands
+- Note limitations (Mermaid client render, search, external links)
+- Cross-link contributing and deployment guides
+
+## Validation
+
+- `pnpm build:content`
+- `pnpm check:links`
+- Workflow steps verified against `pnpm build` + `pnpm start`

--- a/routes-d/238-diagram-image-style-guide.md
+++ b/routes-d/238-diagram-image-style-guide.md
@@ -1,0 +1,27 @@
+# Issue #238 — Design a consistent diagram and image style guide
+
+Working draft for the docs change requested in issue #238.
+
+## Planned doc location
+
+- `docs/guides/diagram-image-style.mdx`
+
+## Example assets
+
+- `public/images/style-guide/flowchart-example.svg`
+- `public/images/style-guide/labeled-frame-example.svg`
+- `public/images/style-guide/color-palette.svg`
+
+## Scope
+
+- Define colors aligned with `src/app/globals.css` and `src/components/Mermaid.tsx`
+- Document sizing for diagrams, screenshots, and inline images
+- Document labeling, captions, and alt text
+- Provide export settings for SVG, PNG, and Mermaid
+- Link to [Screenshot Workflow](/docs/guides/screenshot-workflow) and theme guide
+
+## Validation
+
+- `pnpm build:content`
+- `pnpm check:links`
+- `pnpm validate:sidebar` (after sidebar entry)


### PR DESCRIPTION
## Summary

- **#238** — Adds a [Diagram and Image Style Guide](/docs/guides/diagram-image-style) covering colors, sizing, labeling, export settings, and three example SVG assets under `public/images/style-guide/`.
- **#231** — Adds an [Offline Reading Export](/docs/guides/offline-reading) guide documenting production build, local mirroring with `wget`, verification steps, and known formatting limitations.

Working drafts for both issues live in `routes-d/` as required by the issue templates.

## Changes

| Issue | Files |
|-------|-------|
| #238 | `docs/guides/diagram-image-style.mdx`, `public/images/style-guide/*.svg`, `routes-d/238-diagram-image-style-guide.md`, sidebar entry |
| #231 | `docs/guides/offline-reading.mdx`, `routes-d/231-offline-reading-export.md`, sidebar entry |

## Test plan

- [ ] `pnpm build:content` — confirm new guides are included (note: repo currently fails on 3 pre-existing component MDX files)
- [ ] `pnpm dev` then open `/docs/guides/diagram-image-style` — verify example SVGs and Mermaid sample render
- [ ] Open `/docs/guides/offline-reading` — confirm internal links resolve
- [ ] `pnpm check:links` with dev server running
- [ ] `pnpm validate:sidebar`
- [ ] Optional: follow offline guide (`pnpm build` → `pnpm start` → `wget` mirror) on a sample `/docs/` path

## Related issues

Closes #238  
Closes #231