### PR TITLE
Feat/issues 222 244 docs guides

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -70,6 +70,10 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'Add a Docs Page', href: '/docs/guides/add-docs-page' },
       { title: 'Search Experience', href: '/docs/guides/search' },
       {
+        title: 'Testing Docs Changes',
+        href: '/docs/guides/testing-docs-changes',
+      },
+      {
         title: 'Internationalization',
         href: '/docs/guides/internationalization',
       },

--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -68,6 +68,7 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'Contributing', href: '/docs/guides/contributing' },
       { title: 'Editor Setup', href: '/docs/guides/editor-setup' },
       { title: 'Add a Docs Page', href: '/docs/guides/add-docs-page' },
+      { title: 'Search Experience', href: '/docs/guides/search' },
       {
         title: 'Internationalization',
         href: '/docs/guides/internationalization',
@@ -142,7 +143,10 @@ export const sidebarNav: SidebarSection[] = [
       { title: 'Contributing', href: '/docs/guides/contributing' },
       { title: 'Editor Setup', href: '/docs/guides/editor-setup' },
       { title: 'Testing (Vitest)', href: '/docs/guides/testing' },
-      { title: 'Internationalization', href: '/docs/guides/internationalization' },
+      {
+        title: 'Internationalization',
+        href: '/docs/guides/internationalization',
+      },
       { title: 'Deployment', href: '/docs/guides/deployment' },
       { title: 'Glossary', href: '/docs/guides/glossary' },
     ],

--- a/docs/guides/search.mdx
+++ b/docs/guides/search.mdx
@@ -1,0 +1,190 @@
+---
+title: Search Experience
+description: How documentation search works, what gets indexed, and how to configure and verify search locally.
+date: 2026-05-29
+---
+
+# Search Experience
+
+The Nextellar docs include a built-in search dialog in the documentation header.
+Search runs entirely in the browser against Contentlayer-generated documents.
+There is no Algolia, Typesense, or other external search service to configure.
+
+## Search approach
+
+### Data source
+
+When you run `pnpm build:content`, Contentlayer processes every `.mdx` file under `docs/` and emits typed documents in `.contentlayer/generated`.
+
+The docs layout imports that collection and passes it to the search UI:
+
+```tsx
+import { allDocs } from 'contentlayer/generated';
+import SearchDialog from '@/components/search-dialog';
+
+// ...
+<SearchDialog searchData={allDocs} />;
+```
+
+Each indexed document includes:
+
+| Field                | Source                  | Used in search                 |
+| -------------------- | ----------------------- | ------------------------------ |
+| `title`              | Frontmatter             | Yes — primary match            |
+| `body.raw`           | MDX file content        | Yes — after markdown stripping |
+| `_raw.flattenedPath` | File path under `docs/` | Result URL only                |
+
+### Query behavior
+
+`SearchDialog` (`src/components/search-dialog.tsx`) implements client-side search:
+
+1. **Debounce** — waits 300ms after typing before querying.
+2. **Match** — case-insensitive substring on `title` and stripped body text.
+3. **Snippet** — shows ~40 characters of context around the first match.
+4. **Highlight** — wraps matched terms in the result list.
+5. **Navigation** — result links go to `/docs/<flattenedPath>`.
+
+Matching is substring-based, not fuzzy ranking.
+A page appears in results when the query appears in its title or body.
+
+### Keyboard shortcut
+
+Press **Cmd+K** (macOS) or **Ctrl+K** (Windows/Linux) anywhere on a docs page to open search.
+You can also click the search button in the header (visible on `sm` breakpoints and up).
+
+## Configuration steps
+
+Search requires no extra npm packages beyond what the repo already installs.
+Follow these steps when setting up a new environment or after changing content structure.
+
+### 1. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 2. Define indexable frontmatter
+
+Every searchable page must live under `docs/` and include required frontmatter in `contentlayer.config.ts`:
+
+```yaml
+---
+title: Page Title
+description: Short summary for metadata and discoverability.
+---
+```
+
+`title` is required and is the strongest search signal.
+`description` is optional in the schema but recommended for metadata; body text is still indexed from the MDX content.
+
+### 3. Build the content index
+
+```bash
+pnpm build:content
+```
+
+This step must succeed before search can reflect new or renamed pages.
+In development, restart `pnpm dev` after adding files if results do not update.
+
+### 4. Confirm layout wiring
+
+Search is mounted in `src/app/docs/layout.tsx` via `<SearchDialog searchData={allDocs} />`.
+No additional registration is needed per page.
+
+### 5. Optional UI customization
+
+To change highlighting, debounce timing, or result layout, edit `src/components/search-dialog.tsx`:
+
+| Function / area      | Purpose                                                       |
+| -------------------- | ------------------------------------------------------------- |
+| `stripMarkdown()`    | Removes code fences and markup before indexing body text      |
+| `highlightText()`    | Styles matched terms in titles and snippets                   |
+| `getSnippet()`       | Controls surrounding context length (default `40` characters) |
+| Debounce `useEffect` | Adjust the `300` ms delay if needed                           |
+
+Documentation-only contributors normally do not need to change these files.
+
+## Indexing requirements
+
+For a page to appear in search results, all of the following must be true:
+
+1. **File location** — the MDX file is under `docs/` (for example `docs/guides/search.mdx`).
+2. **Valid frontmatter** — includes `title` (required by Contentlayer).
+3. **Successful build** — `pnpm build:content` completes without errors for that file.
+4. **Discoverable text** — the query appears in `title` and/or the page body (headings, paragraphs, lists).
+
+### What is not indexed separately
+
+- Files outside `docs/` (for example `routes-d/` drafts or `src/content/`) are not in `allDocs`.
+- Sidebar entries in `config/sidebar.tsx` do not affect search; only MDX content does.
+- React components embedded in MDX are not searched as component names unless written in prose.
+
+### Rebuilding the index
+
+| Action                         | Command                                                   |
+| ------------------------------ | --------------------------------------------------------- |
+| Regenerate Contentlayer output | `pnpm build:content`                                      |
+| Development with hot reload    | `pnpm dev` (rebuilds content on change in most cases)     |
+| Production bundle              | `pnpm build` (runs content build as part of `next build`) |
+
+After renaming or moving a doc file, run `pnpm build:content` and verify the new URL path in search results.
+
+## Verify search works locally
+
+Use this checklist before opening a pull request that adds or renames documentation.
+
+### Step 1 — Build content
+
+```bash
+pnpm build:content
+```
+
+Fix any MDX or frontmatter errors reported for your new file before continuing.
+
+### Step 2 — Start the dev server
+
+```bash
+pnpm dev
+```
+
+Open `http://localhost:3000/docs` in the browser.
+
+### Step 3 — Open search
+
+- Press **Cmd+K** or **Ctrl+K**, or
+- Click the search control in the docs header.
+
+### Step 4 — Run smoke queries
+
+| Query                                  | Expected result                      |
+| -------------------------------------- | ------------------------------------ |
+| A unique word from your new page title | Your page listed near the top        |
+| A phrase from the page body only       | Your page listed with a body snippet |
+| `zzzznonexistent`                      | “No results found.”                  |
+
+### Step 5 — Follow a result
+
+Click a result and confirm it navigates to the correct `/docs/...` URL and closes the dialog.
+
+### Troubleshooting
+
+| Symptom                    | Likely cause                                 | Fix                                         |
+| -------------------------- | -------------------------------------------- | ------------------------------------------- |
+| Page missing from results  | Content build failed or file outside `docs/` | Run `pnpm build:content`; confirm file path |
+| Stale results after rename | Dev server cache                             | Restart `pnpm dev`                          |
+| Shortcut does nothing      | Focus in an input that captures the key      | Click the page background and retry         |
+| Empty body matches         | Query only in a code block                   | Add the term to prose or the title          |
+
+## Limitations
+
+- **No fuzzy search** — typos must be close to the stored substring to match.
+- **No section-level ranking** — all body text is treated equally after stripping.
+- **Client-only** — search data ships with the app bundle; very large doc sets increase payload size.
+- **Offline mirrors** — static HTML exports may not execute search JavaScript without the full Next.js runtime.
+
+## Related
+
+- [Contributing to Documentation](/docs/guides/contributing)
+- [Add a New Docs Page](/docs/guides/add-docs-page)
+- [Testing Documentation Changes](/docs/guides/testing-docs-changes)
+- [Search Bar (legacy reference)](/docs/search-bar)

--- a/docs/guides/testing-docs-changes.mdx
+++ b/docs/guides/testing-docs-changes.mdx
@@ -1,0 +1,211 @@
+---
+title: Testing Documentation Changes
+description: Build, link, sidebar, and visual checks to run before submitting documentation pull requests.
+date: 2026-05-29
+---
+
+# Testing Documentation Changes
+
+Use this guide when you edit MDX pages, navigation, or static assets in the Nextellar docs repository.
+It focuses on **documentation quality checks**, not application unit tests.
+For Vitest setup, see [Testing](/docs/guides/testing).
+
+## Overview
+
+A typical docs PR should pass automated checks and a short manual review.
+Run commands from the repository root after `pnpm install`.
+
+| Check           | Command                 | Requires dev server |
+| --------------- | ----------------------- | ------------------- |
+| Content build   | `pnpm build:content`    | No                  |
+| Formatting      | `pnpm format:check`     | No                  |
+| Lint            | `pnpm lint`             | No                  |
+| Sidebar paths   | `pnpm validate:sidebar` | No                  |
+| Internal links  | `pnpm check:links`      | Yes (`pnpm dev`)    |
+| Full site build | `pnpm build`            | No                  |
+| Visual / search | Browser + `pnpm dev`    | Yes                 |
+
+## Content build check
+
+Validates MDX syntax, frontmatter schema, and Contentlayer code generation.
+
+```bash
+pnpm build:content
+```
+
+### What success looks like
+
+```text
+Generated N documents in .contentlayer
+```
+
+### On failure
+
+| Error type                         | What to do                                                                               |
+| ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| Missing `title` in frontmatter     | Add `title` (and preferably `description`) at the top of the MDX file                    |
+| MDX parse error (unclosed JSX tag) | Close all MDX components (`<Tabs>`, `<TabsContent>`, etc.)                               |
+| Invalid import path                | Fix or remove the `import` in the MDX file                                               |
+| Error in an unrelated file         | Fix the reported file or coordinate with maintainers; the build processes all of `docs/` |
+
+Re-run `pnpm build:content` until it exits with code `0`.
+
+## Link check
+
+`pnpm check:links` requests docs URLs from a running local server and reports HTTP status codes.
+
+### Run the check
+
+Terminal 1:
+
+```bash
+pnpm dev
+```
+
+Terminal 2:
+
+```bash
+pnpm check:links
+```
+
+### What success looks like
+
+```text
+Passed: N/N
+ALL LINKS VALID!
+```
+
+### On failure
+
+| Symptom                     | What to do                                                                         |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| `ECONNREFUSED`              | Start `pnpm dev` on port 3000 first                                                |
+| `404` on `/docs/...`        | Confirm the MDX file exists and the href matches the path without `.mdx`           |
+| Wrong host in links         | Use absolute docs paths like `/docs/guides/contributing`, not relative `../` paths |
+| Component-only URLs failing | Ensure `sidebar-validation.json` matches real pages; run `pnpm validate:sidebar`   |
+
+Fix the broken `href` in MDX or `config/sidebar.tsx`, then re-run the check.
+
+## Sidebar validation
+
+Confirms sidebar and TOC entries for component docs point at real files.
+
+```bash
+pnpm validate:sidebar
+```
+
+### On failure
+
+- Remove or fix entries in `config/sidebar.tsx` (and `config/toc.tsx` if applicable) that reference missing `docs/components/*.mdx` files.
+- Add the missing MDX page if the link should exist.
+
+## Format and lint checks
+
+```bash
+pnpm format:check
+pnpm lint
+```
+
+### On failure
+
+| Command             | Fix                                              |
+| ------------------- | ------------------------------------------------ |
+| `pnpm format:check` | Run `pnpm format` to apply Prettier, then commit |
+| `pnpm lint`         | Resolve ESLint issues in reported files          |
+
+## Full production build
+
+Catches Next.js and TypeScript issues that the content build alone may miss.
+
+```bash
+pnpm build
+```
+
+### On failure
+
+- Read the first error in the log; fix the referenced file.
+- If Contentlayer failed inside `pnpm build`, run `pnpm build:content` separately for a clearer MDX error message.
+
+## Visual checks
+
+Automated scripts do not verify layout, images, or MDX components. Review these manually with `pnpm dev`.
+
+### Page rendering
+
+1. Open the page URL (for example `/docs/guides/testing-docs-changes`).
+2. Confirm the title, description, and headings render.
+3. Scroll the full page for broken MDX (raw JSX, empty code blocks).
+
+### Images and diagrams
+
+| Asset type           | Check                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `/public/...` images | Image loads; alt text is meaningful                                                |
+| Mermaid blocks       | Diagram renders after page load (client-side)                                      |
+| Screenshots          | Path matches [Screenshot Workflow](/docs/guides/screenshot-workflow) if applicable |
+
+### Navigation
+
+- New pages appear in `config/sidebar.tsx` when you added an entry.
+- Breadcrumbs and in-page anchor links work.
+
+### Theme
+
+Toggle light and dark mode.
+Confirm code blocks, callouts, and images remain readable.
+
+## Search smoke test
+
+After adding or renaming a page, confirm it is discoverable in the header search.
+
+1. Run `pnpm build:content` and `pnpm dev`.
+2. Press **Cmd+K** or **Ctrl+K**.
+3. Search for a unique word from your page title.
+4. Open the result and confirm the URL is correct.
+
+See [Search Experience](/docs/guides/search) for indexing requirements and troubleshooting.
+
+## Pre-submission checklist
+
+Copy this list into your PR test plan:
+
+```bash
+pnpm build:content
+pnpm format:check
+pnpm lint
+pnpm validate:sidebar
+pnpm build
+```
+
+With `pnpm dev` running in another terminal:
+
+```bash
+pnpm check:links
+```
+
+Manual:
+
+- [ ] Opened changed pages in the browser (light and dark)
+- [ ] Verified new internal links and sidebar entries
+- [ ] Search finds new or renamed pages (if applicable)
+- [ ] Images and diagrams display correctly
+
+## Quick reference on failure
+
+| Failed command          | First step                                                   |
+| ----------------------- | ------------------------------------------------------------ |
+| `pnpm build:content`    | Open the MDX file named in the error; fix frontmatter or JSX |
+| `pnpm check:links`      | Ensure `pnpm dev` is running; fix 404 paths                  |
+| `pnpm validate:sidebar` | Align `config/sidebar.tsx` with files under `docs/`          |
+| `pnpm format:check`     | `pnpm format`                                                |
+| `pnpm lint`             | Fix reported ESLint issues                                   |
+| `pnpm build`            | Fix TypeScript or Next.js error at the top of the log        |
+| Visual issue            | Hard-refresh; confirm `public/` asset path and MDX syntax    |
+
+## Related
+
+- [Contributing to Documentation](/docs/guides/contributing)
+- [Add a New Docs Page](/docs/guides/add-docs-page)
+- [Search Experience](/docs/guides/search)
+- [Editor Setup](/docs/guides/editor-setup)
+- [Testing (Vitest)](/docs/guides/testing)

--- a/routes-d/222-search-experience.md
+++ b/routes-d/222-search-experience.md
@@ -1,0 +1,20 @@
+# Issue #222 — Add a full search experience documentation and setup
+
+Working draft for the docs change requested in issue #222.
+
+## Planned doc location
+
+- `docs/guides/search.mdx`
+
+## Scope
+
+- Describe client-side search via Contentlayer `allDocs` and `SearchDialog`
+- Document configuration in `contentlayer.config.ts` and `src/app/docs/layout.tsx`
+- Explain indexing requirements (`title`, `description`, MDX body under `docs/`)
+- Include local verification steps (`pnpm build:content`, `pnpm dev`, Cmd/Ctrl+K)
+
+## Validation
+
+- `pnpm build:content`
+- `pnpm check:links`
+- Manual search smoke test in dev

--- a/routes-d/244-testing-docs-changes.md
+++ b/routes-d/244-testing-docs-changes.md
@@ -1,0 +1,19 @@
+# Issue #244 — Create a comprehensive testing guide for docs changes
+
+Working draft for the docs change requested in issue #244.
+
+## Planned doc location
+
+- `docs/guides/testing-docs-changes.mdx`
+
+## Scope
+
+- Cover content build, link, sidebar, format, lint, and full build checks
+- Document visual and search smoke tests
+- Note failure remediation per check type
+- Distinguish from Vitest guide at `docs/guides/testing.mdx`
+
+## Validation
+
+- `pnpm build:content`
+- `pnpm check:links`


### PR DESCRIPTION
## Summary

- **#222** — Adds [Search Experience](/docs/guides/search) documenting client-side search via Contentlayer `allDocs` and `SearchDialog`: indexing requirements, configuration steps, local verification (Cmd/Ctrl+K), and limitations.
- **#244** — Adds [Testing Documentation Changes](/docs/guides/testing-docs-changes) with a contributor-focused checklist covering `build:content`, `check:links`, `validate:sidebar`, format/lint, full `build`, visual review, and search smoke tests, including what to do when each step fails.

Working drafts are in `routes-d/222-search-experience.md` and `routes-d/244-testing-docs-changes.md`.

## Changes

| Issue | Files |
|-------|-------|
| #222 | `docs/guides/search.mdx`, `routes-d/222-search-experience.md`, sidebar entry |
| #244 | `docs/guides/testing-docs-changes.mdx`, `routes-d/244-testing-docs-changes.md`, sidebar entry |

## Test plan

- [ ] `pnpm build:content` (note: repo currently fails on 3 unrelated component MDX files)
- [ ] `pnpm dev` → open `/docs/guides/search` and `/docs/guides/testing-docs-changes`
- [ ] Search smoke test: Cmd/Ctrl+K, query a term from the new search guide title
- [ ] `pnpm validate:sidebar`
- [ ] With `pnpm dev` running: `pnpm check:links`
- [ ] `pnpm format:check` and `pnpm lint`

## Related issues

Closes #222  
Closes #244