### PR TITLE
docs: add frontmatter reference, data flow diagrams, wallet comparison table and wallet connection guide

### DIFF
--- a/routes-d/184-supported-wallets-comparison.mdx
+++ b/routes-d/184-supported-wallets-comparison.mdx
@@ -1,0 +1,157 @@
+---
+title: Supported Wallets Comparison
+description: Comparison table of every wallet supported by Nextellar, including type, platform availability, key features, and known limitations.
+---
+
+# Supported Wallets Comparison
+
+Nextellar uses [@creit.tech/stellar-wallets-kit](https://github.com/AhaLabs/stellar-wallets-kit) to support multiple Stellar wallets through a single unified API. The table below compares the wallets included out of the box so you can choose the right one for your users.
+
+---
+
+## Feature comparison table
+
+| Wallet        | Type              | Browser Extension | Mobile App | No Install Required | Transaction Signing | Testnet Support | Mainnet Support | Notes                                              |
+| ------------- | ----------------- | :---------------: | :--------: | :-----------------: | :-----------------: | :-------------: | :-------------: | -------------------------------------------------- |
+| **Freighter** | Browser Extension | ✅                | ❌         | ❌                  | ✅                  | ✅              | ✅              | Most widely used; recommended default              |
+| **Albedo**    | Web-based         | ❌                | ❌         | ✅                  | ✅                  | ✅              | ✅              | Opens in a popup tab; no download needed           |
+| **Lobstr**    | Browser Extension | ✅                | ✅         | ❌                  | ✅                  | ✅              | ✅              | Companion to the Lobstr mobile app                 |
+| **xBull**     | Browser Extension | ✅                | ❌         | ❌                  | ✅                  | ✅              | ✅              | Advanced features; supports hardware wallet pairing |
+| **Hana**      | Browser Extension | ✅                | ❌         | ❌                  | ✅                  | ✅              | ✅              | Stellar ecosystem wallet; newer adoption base      |
+
+---
+
+## Wallet details
+
+### Freighter
+
+- **Developed by:** Stellar Development Foundation
+- **Install:** [Chrome Web Store](https://chromewebstore.google.com/detail/freighter/bcacfldlkkdogcmkkibnjlakofdplcbk) / [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/freighter-wallet/)
+- **Platforms:** Chrome, Firefox, Brave, Edge (Chromium)
+- **Key features:**
+  - Full transaction inspection before signing
+  - Multiple account support (switch active account in extension)
+  - Direct network toggle between testnet and mainnet inside the extension
+- **Platform limitations:**
+  - Desktop browsers only — no native mobile app
+  - Safari not officially supported
+
+### Albedo
+
+- **Developed by:** Ultra Stellar
+- **Install:** None — runs at [albedo.link](https://albedo.link)
+- **Platforms:** Any modern browser, including mobile
+- **Key features:**
+  - Zero installation friction for new users
+  - Works on mobile browsers (iOS Safari, Android Chrome)
+  - Transactions open in a popup window for signing
+- **Platform limitations:**
+  - Requires internet access to open the signing popup
+  - Popup blockers may interfere; users must allow popups for your domain
+
+### Lobstr
+
+- **Developed by:** Ultra Stellar
+- **Install:** [Chrome Web Store](https://chromewebstore.google.com/detail/lobstr/hnhfhnkajgfmjjmgelpgkijneehajhnk) and the [Lobstr mobile app](https://lobstr.co)
+- **Platforms:** Chrome extension (desktop) + iOS and Android app
+- **Key features:**
+  - Integrated with the Lobstr exchange and portfolio tracker
+  - Mobile-friendly: QR code pairing between browser and mobile app
+  - Supports SEP-0007 payment links
+- **Platform limitations:**
+  - Browser extension is Chrome-only; Firefox not supported
+  - Mobile signing requires the Lobstr mobile app to be installed
+
+### xBull
+
+- **Developed by:** xBull Wallet team
+- **Install:** [Chrome Web Store](https://chromewebstore.google.com/detail/xbull-wallet/omajpeaffjgmlpmhbfdjekmgfbnoacjf)
+- **Platforms:** Chrome, Brave, Edge (Chromium)
+- **Key features:**
+  - Hardware wallet support (Ledger integration)
+  - Multi-signature transaction support
+  - Custom network configuration (point to private Horizon/Soroban nodes)
+- **Platform limitations:**
+  - Desktop only
+  - Firefox not supported
+
+### Hana
+
+- **Developed by:** Script3
+- **Install:** [Chrome Web Store](https://chromewebstore.google.com/detail/hana-wallet/aomjjhallfgjeglblehebfpbcfeobpgk)
+- **Platforms:** Chrome, Brave, Edge (Chromium)
+- **Key features:**
+  - Designed for Soroban smart contract interactions
+  - DeFi-focused UX
+  - Supports multiple Stellar addresses
+- **Platform limitations:**
+  - Desktop only; smaller install base than Freighter
+
+---
+
+## Platform support summary
+
+| Wallet        | Chrome | Firefox | Safari | Edge | iOS | Android |
+| ------------- | :----: | :-----: | :----: | :--: | :-: | :-----: |
+| **Freighter** | ✅     | ✅      | ❌     | ✅   | ❌  | ❌      |
+| **Albedo**    | ✅     | ✅      | ✅     | ✅   | ✅  | ✅      |
+| **Lobstr**    | ✅     | ❌      | ❌     | ✅   | ✅  | ✅      |
+| **xBull**     | ✅     | ❌      | ❌     | ✅   | ❌  | ❌      |
+| **Hana**      | ✅     | ❌      | ❌     | ✅   | ❌  | ❌      |
+
+---
+
+## Choosing a default wallet
+
+The Nextellar scaffold sets `FREIGHTER_ID` as the default selected wallet:
+
+```typescript
+const kit = new StellarWalletsKit({
+  network: WalletNetwork.TESTNET,
+  selectedWalletId: FREIGHTER_ID,
+  modules: [
+    new FreighterModule(),
+    new AlbedoModule(),
+    new LobstrModule(),
+    new xBullModule(),
+    new HanaModule(),
+  ],
+});
+```
+
+**Recommendation:** Keep Freighter as the default for maximum developer familiarity. If your audience includes non-technical users or mobile users, consider presenting Albedo prominently in the wallet selection modal.
+
+---
+
+## Adding or removing wallets
+
+To add a wallet, import and instantiate its module in `src/lib/stellar-wallet-kit.ts`:
+
+```typescript
+import { WarpModule } from '@creit.tech/stellar-wallets-kit';
+
+modules: [
+  // existing modules...
+  new WarpModule(),
+],
+```
+
+To remove a wallet, delete its module from the array. The Stellar Wallets Kit modal only shows wallets that have a corresponding module registered.
+
+---
+
+## Validate your changes
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+---
+
+## Related documentation
+
+- [Wallet Integration](/docs/integrations/wallets) — wallet module setup and code examples
+- [WalletConnect Integration](/docs/integrations/walletconnect) — WalletConnect protocol support
+- [Connecting a Wallet Step-by-Step](/docs/guides/connect-wallet) — user-facing connection guide
+- [Data Flow Diagrams](/docs/guides/data-flow-diagrams) — visual overview of the connection flow

--- a/routes-d/185-connect-wallet-guide.mdx
+++ b/routes-d/185-connect-wallet-guide.mdx
@@ -1,0 +1,265 @@
+---
+title: Connecting a Wallet
+description: Step-by-step guide for connecting a Stellar wallet to a Nextellar application, including code examples and common pitfalls.
+---
+
+# Connecting a Wallet
+
+This guide walks through every step needed to let a user connect their Stellar wallet to a Nextellar application — from installing the SDK to handling errors gracefully.
+
+---
+
+## Prerequisites
+
+- A Nextellar project scaffolded with `npx nextellar my-app` (or the packages installed manually).
+- Node 18+ and pnpm installed.
+- A Stellar wallet extension installed in your browser (see [Supported Wallets](/docs/integrations/wallets) for options). [Freighter](https://www.freighter.app/) is recommended for development.
+
+---
+
+## Step 1 — Wrap your app with `WalletProvider`
+
+`WalletProvider` is the React context that holds wallet state and makes it available throughout your component tree. Add it once at the root layout.
+
+```tsx
+// app/layout.tsx
+import { WalletProvider } from '@/contexts';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <WalletProvider>{children}</WalletProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+> **Note:** `WalletProvider` initialises `StellarWalletsKit` internally and checks localStorage for an existing session on mount, so users who have connected before are restored automatically.
+
+---
+
+## Step 2 — Add a connect button
+
+Use the pre-built `WalletConnectButton` for zero-effort UI:
+
+```tsx
+// components/Header.tsx
+import WalletConnectButton from '@/components/WalletConnectButton';
+
+export default function Header() {
+  return (
+    <header>
+      <WalletConnectButton theme="dark" />
+    </header>
+  );
+}
+```
+
+Or wire up the `connect` and `disconnect` functions from `useWallet` to your own button:
+
+```tsx
+// components/MyConnectButton.tsx
+'use client';
+
+import { useWallet } from '@/contexts';
+
+export default function MyConnectButton() {
+  const { connected, publicKey, walletName, connect, disconnect } = useWallet();
+
+  return (
+    <button onClick={connected ? disconnect : connect}>
+      {connected
+        ? `Disconnect ${walletName} (${publicKey?.slice(0, 6)}…)`
+        : 'Connect Wallet'}
+    </button>
+  );
+}
+```
+
+---
+
+## Step 3 — Call `connect()`
+
+When the user clicks your button, `connect()` opens the Stellar Wallets Kit modal so the user can pick their wallet:
+
+```tsx
+const { connect } = useWallet();
+
+await connect();
+// After this resolves, `connected` is true and `publicKey` is populated.
+```
+
+The full connection sequence is:
+
+1. `connect()` is called.
+2. The Stellar Wallets Kit modal opens.
+3. The user picks a wallet (e.g. Freighter).
+4. The wallet extension shows a permission prompt.
+5. The user approves.
+6. `publicKey` is returned and stored in context and localStorage.
+
+---
+
+## Step 4 — Read wallet state
+
+Once connected, use the values exposed by `useWallet`:
+
+```tsx
+'use client';
+
+import { useWallet } from '@/contexts';
+
+export default function AccountInfo() {
+  const { connected, publicKey, walletName, balances } = useWallet();
+
+  if (!connected) return <p>No wallet connected.</p>;
+
+  return (
+    <div>
+      <p>Wallet: {walletName}</p>
+      <p>Address: {publicKey}</p>
+      <ul>
+        {balances.map((b) => (
+          <li key={b.asset_code ?? 'XLM'}>
+            {b.balance} {b.asset_code ?? 'XLM'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+---
+
+## Step 5 — Disconnect
+
+Call `disconnect()` to clear the session from context and localStorage:
+
+```tsx
+const { disconnect } = useWallet();
+
+<button onClick={disconnect}>Disconnect</button>
+```
+
+---
+
+## Minimal working example
+
+The snippet below is a self-contained page that demonstrates the full connect/disconnect cycle:
+
+```tsx
+// app/page.tsx
+'use client';
+
+import { useWallet } from '@/contexts';
+
+export default function Home() {
+  const { connected, publicKey, walletName, connect, disconnect } = useWallet();
+
+  const handleClick = async () => {
+    try {
+      if (connected) {
+        disconnect();
+      } else {
+        await connect();
+      }
+    } catch (err) {
+      console.error('Wallet action failed:', err);
+    }
+  };
+
+  return (
+    <main>
+      <h1>Nextellar Wallet Demo</h1>
+      <button onClick={handleClick}>
+        {connected ? `Disconnect ${walletName}` : 'Connect Wallet'}
+      </button>
+      {connected && <p>Connected: {publicKey}</p>}
+    </main>
+  );
+}
+```
+
+---
+
+## Common pitfalls
+
+### Wallet extension not installed
+
+If the user selects a wallet that is not installed, the kit throws an error with a message containing `"not installed"`.
+
+```tsx
+try {
+  await connect();
+} catch (err: unknown) {
+  if (err instanceof Error && err.message.includes('not installed')) {
+    alert('Please install a Stellar wallet extension first.');
+  }
+}
+```
+
+### User rejects the permission prompt
+
+The wallet extension may return a rejection if the user clicks "Deny."
+
+```tsx
+try {
+  await connect();
+} catch (err: unknown) {
+  if (
+    err instanceof Error &&
+    (err.message.includes('rejected') || err.message.includes('cancelled'))
+  ) {
+    console.log('User cancelled the connection request.');
+  }
+}
+```
+
+### Wrong network selected in the wallet
+
+If your app targets testnet but the wallet extension is set to mainnet (or vice versa), transactions will fail with a network passphrase mismatch. Remind users to switch networks inside the wallet extension.
+
+Add a visible banner when a mismatch is detected:
+
+```tsx
+const { connected, network } = useWallet();
+const expectedNetwork = process.env.NEXT_PUBLIC_NETWORK; // "TESTNET" or "PUBLIC"
+
+if (connected && network !== expectedNetwork) {
+  return <Banner>Switch your wallet to {expectedNetwork} and reconnect.</Banner>;
+}
+```
+
+### `WalletProvider` missing from the tree
+
+Calling `useWallet()` outside of a `WalletProvider` throws a context error. Always ensure `WalletProvider` wraps every page that uses wallet hooks (placing it in `app/layout.tsx` covers all routes automatically).
+
+### Popup blockers blocking Albedo
+
+Albedo opens in a popup tab. If the browser's popup blocker is active, the signing window will not open. Ask users to allow popups from your domain, or display a notice when Albedo is selected.
+
+---
+
+## Validate your changes
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+---
+
+## Related documentation
+
+- [Supported Wallets Comparison](/docs/integrations/wallets-comparison) — feature and platform table for each wallet
+- [Wallet Integration](/docs/integrations/wallets) — low-level wallet kit configuration
+- [WalletConnect Integration](/docs/integrations/walletconnect) — WalletConnect protocol support
+- [Data Flow Diagrams](/docs/guides/data-flow-diagrams) — visual overview of the connection sequence
+- [useStellarWallet](/docs/hooks/use-stellar-wallet) — standalone hook (no provider required)

--- a/routes-d/207-frontmatter-fields-reference.mdx
+++ b/routes-d/207-frontmatter-fields-reference.mdx
@@ -1,0 +1,149 @@
+---
+title: Frontmatter Fields Reference
+description: Quick reference for every supported MDX frontmatter field in Nextellar docs, including type, purpose, and whether the field is required.
+---
+
+# Frontmatter Fields Reference
+
+Every MDX file in the `docs/` directory is processed by Contentlayer. The fields below are the only frontmatter keys that Contentlayer reads and validates. Any key not listed here is silently ignored.
+
+> **Scope:** Applies to all `.mdx` files under `docs/`. Field definitions live in `contentlayer.config.ts`.
+
+## Quick reference
+
+| Field         | Type     | Required | Purpose                                                    |
+| ------------- | -------- | -------- | ---------------------------------------------------------- |
+| `title`       | `string` | **Yes**  | Page title shown in the browser tab and navigation sidebar |
+| `description` | `string` | No       | Short summary used for SEO meta tags and search results    |
+| `date`        | `date`   | No       | Publication or last-updated date (ISO 8601 format)         |
+
+---
+
+## Field details
+
+### `title`
+
+**Type:** `string` — **Required**
+
+The human-readable name of the page. Used in:
+
+- The `<title>` element of the rendered HTML page.
+- Navigation sidebar and breadcrumb links.
+- Search index entries.
+
+**Example:**
+
+```yaml
+---
+title: Frontmatter Fields Reference
+---
+```
+
+Keep titles concise (under 60 characters) so they display cleanly in the browser tab and sidebar.
+
+---
+
+### `description`
+
+**Type:** `string` — Optional
+
+A plain-text summary of the page. Used in:
+
+- The `<meta name="description">` SEO tag.
+- Open Graph `og:description` for social sharing.
+- The search index excerpt shown under each result.
+
+**Example:**
+
+```yaml
+---
+title: Frontmatter Fields Reference
+description: Quick reference for every supported MDX frontmatter field in Nextellar docs.
+---
+```
+
+Aim for 50–160 characters so the description is neither truncated nor padded in search results.
+
+---
+
+### `date`
+
+**Type:** `date` — Optional
+
+An ISO 8601 date string (`YYYY-MM-DD`). Contentlayer parses it into a JavaScript `Date` object available as a computed field. Not currently rendered in the UI by default, but it is available for pages that want to show a "last updated" timestamp.
+
+**Example:**
+
+```yaml
+---
+title: Frontmatter Fields Reference
+date: 2024-11-15
+---
+```
+
+---
+
+## Computed fields (read-only)
+
+Contentlayer also generates the following fields automatically. You do **not** set these in frontmatter — they are derived from the file path:
+
+| Computed field | Type     | Description                                       |
+| -------------- | -------- | ------------------------------------------------- |
+| `url`          | `string` | Absolute URL path: `/docs/<flattenedPath>`        |
+| `slug`         | `string` | The file's relative path without the extension    |
+
+---
+
+## Minimal valid frontmatter
+
+```yaml
+---
+title: My Page Title
+---
+```
+
+## Recommended frontmatter
+
+```yaml
+---
+title: My Page Title
+description: A clear description of what this page covers (50–160 chars).
+---
+```
+
+---
+
+## Common errors
+
+**Missing required field**
+
+```
+Error: Missing required field "title" in docs/guides/example.mdx
+```
+
+Fix: add a `title` key to the frontmatter block.
+
+**Wrong date format**
+
+```
+Error: Invalid date value "15/11/2024" in docs/guides/example.mdx
+```
+
+Fix: use ISO 8601 format — `2024-11-15`.
+
+---
+
+## Validate your changes
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+---
+
+## Related documentation
+
+- [Contributing to Documentation](/docs/guides/contributing) — full contributor workflow
+- [MDX Custom Components](/docs/guides/mdx-custom-components) — using JSX inside MDX files
+- [Environment Options Reference](/docs/cli/environment-options) — CLI and runtime variables

--- a/routes-d/228-data-flow-diagrams.mdx
+++ b/routes-d/228-data-flow-diagrams.mdx
@@ -1,0 +1,160 @@
+---
+title: Data Flow Diagrams
+description: End-to-end diagrams illustrating how data moves through a Nextellar application, from user action through wallet signing to the Stellar network.
+---
+
+# Data Flow Diagrams
+
+This page shows the main data paths in a Nextellar application using Mermaid diagrams. Each diagram covers a distinct flow: wallet connection, transaction signing, balance fetching, and the full end-to-end payment path.
+
+---
+
+## 1. Wallet connection flow
+
+When a user clicks "Connect Wallet," the following sequence takes place between the browser, the Stellar Wallets Kit, the chosen wallet extension, and the Nextellar provider.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App as Nextellar App
+    participant Kit as StellarWalletsKit
+    participant Wallet as Wallet Extension
+    participant LS as localStorage
+
+    User->>App: clicks "Connect Wallet"
+    App->>Kit: openModal()
+    Kit-->>User: displays wallet selection modal
+    User->>Kit: selects wallet (e.g. Freighter)
+    Kit->>Wallet: requestAccess()
+    Wallet-->>User: permission prompt
+    User->>Wallet: approves
+    Wallet-->>Kit: publicKey
+    Kit-->>App: publicKey
+    App->>LS: store connected=true, publicKey, walletId
+    App-->>User: wallet connected, shows address
+```
+
+*Caption: The wallet connection sequence. The app never sees the private key — only the public key is returned.*
+
+---
+
+## 2. Transaction signing and submission flow
+
+Signing a transaction requires the wallet extension to approve it before it is submitted to the Stellar network via Horizon.
+
+```mermaid
+sequenceDiagram
+    participant App as Nextellar App
+    participant Hook as useWallet hook
+    participant Kit as StellarWalletsKit
+    participant Wallet as Wallet Extension
+    participant Horizon as Horizon API
+
+    App->>Hook: sendPayment({ to, amount, asset })
+    Hook->>Hook: build TransactionBuilder XDR
+    Hook->>Kit: signTransaction(unsignedXdr, { address, networkPassphrase })
+    Kit->>Wallet: sign request
+    Wallet-->>Kit: signedXdr
+    Kit-->>Hook: signedTxXdr
+    Hook->>Horizon: POST /transactions (signedXdr)
+    Horizon-->>Hook: transaction result
+    Hook-->>App: { success, hash }
+```
+
+*Caption: Transaction signing stays inside the wallet extension. The app only passes the unsigned XDR and receives the signed XDR back.*
+
+---
+
+## 3. Balance fetching flow
+
+Balances are fetched from Horizon after connection and refreshed on demand.
+
+```mermaid
+flowchart LR
+    A([Wallet Connected]) --> B[WalletProvider]
+    B --> C{publicKey available?}
+    C -- Yes --> D[fetch /accounts/:publicKey via Horizon]
+    D --> E[parse balances array]
+    E --> F[store in WalletContext]
+    F --> G([Components read balances via useWallet])
+    C -- No --> H([show disconnected state])
+```
+
+*Caption: Balance fetching is triggered automatically on connection and when `refreshBalances()` is called.*
+
+---
+
+## 4. Full end-to-end data flow
+
+This diagram combines all major paths: wallet connection, balance fetch, transaction build, sign, and submit.
+
+```mermaid
+flowchart TD
+    User([User]) --> ConnectBtn[WalletConnectButton]
+    ConnectBtn --> Kit[StellarWalletsKit]
+    Kit --> Wallet[Wallet Extension]
+    Wallet -- publicKey --> Provider[WalletProvider / WalletContext]
+    Provider -- publicKey --> Horizon[(Horizon API)]
+    Horizon -- balances --> Provider
+    Provider -- balances / state --> Components[App Components]
+
+    Components -- sendPayment --> Hook[useWallet hook]
+    Hook -- build XDR --> Builder[TransactionBuilder]
+    Builder -- unsigned XDR --> Kit
+    Kit -- sign request --> Wallet
+    Wallet -- signed XDR --> Kit
+    Kit -- signed XDR --> Hook
+    Hook -- submit --> Horizon
+    Horizon -- tx result --> Hook
+    Hook -- result --> Components
+```
+
+*Caption: Full end-to-end data flow. `WalletProvider` is the central state hub; Horizon is the only network endpoint the app talks to directly.*
+
+---
+
+## 5. Session restore flow
+
+On page reload, the provider checks localStorage for an existing session before prompting the user again.
+
+```mermaid
+flowchart TD
+    Start([Page Load]) --> Check{localStorage has connected=true?}
+    Check -- No --> Disconnected([Show Connect Button])
+    Check -- Yes --> ReadLS[read walletId + publicKey from localStorage]
+    ReadLS --> Reconnect[Kit.setWallet walletId]
+    Reconnect --> Horizon[(Horizon API)]
+    Horizon -- fresh balances --> Provider[WalletProvider]
+    Provider --> Connected([Show wallet address + balances])
+```
+
+*Caption: Auto-reconnect on page load avoids asking users to connect every time they visit.*
+
+---
+
+## Diagram style notes
+
+- All diagrams use [Mermaid](https://mermaid.js.org/) and render in the Nextellar docs pipeline via the configured rehype plugin.
+- Use `sequenceDiagram` for time-ordered interactions between named actors.
+- Use `flowchart LR` (left-to-right) or `flowchart TD` (top-down) for data and state flows.
+- Keep node labels short; add a *Caption* line below each diagram for context.
+
+See [Diagram and Image Style Guide](/docs/guides/diagram-image-style) for visual conventions.
+
+---
+
+## Validate your changes
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+---
+
+## Related documentation
+
+- [Wallet Integration](/docs/integrations/wallets) — wallet module setup and configuration
+- [Horizon Integration](/docs/integrations/horizon) — Horizon REST API usage
+- [useStellarWallet](/docs/hooks/use-stellar-wallet) — standalone wallet hook reference
+- [Diagram and Image Style Guide](/docs/guides/diagram-image-style) — style rules for diagrams


### PR DESCRIPTION
## Summary

Adds four documentation pages to `routes-d/` covering frontmatter fields, end-to-end data flow diagrams, a wallet comparison table, and a step-by-step wallet connection guide.

---

## Changes

### #207 — Frontmatter Fields Reference

Adds `routes-d/207-frontmatter-fields-reference.mdx`.

Authors had no single place to look up which frontmatter keys Contentlayer accepts. This page provides a quick-reference table of all three supported fields (`title`, `description`, `date`), documents each field's type, purpose, and whether it is required, lists the auto-generated computed fields (`url`, `slug`), shows minimal and recommended frontmatter examples, and covers the two most common frontmatter errors with fixes.

Closes #207

---

### #228 — Data Flow Diagrams

Adds `routes-d/228-data-flow-diagrams.mdx`.

The codebase lacked any visual explanation of how data moves through the system. This page adds five Mermaid diagrams — wallet connection sequence, transaction signing and submission sequence, balance fetching flowchart, full end-to-end data flowchart, and session restore flowchart — each with a plain-English caption explaining what is shown. Diagram style notes link to the existing style guide.

Closes #228

---

### #184 — Supported Wallets Comparison Table

Adds `routes-d/184-supported-wallets-comparison.mdx`.

Users and maintainers had no structured way to compare wallet options. This page adds a feature comparison table (Freighter, Albedo, Lobstr, xBull, Hana) with columns for type, browser extension availability, mobile support, no-install option, transaction signing, and testnet/mainnet support. A second table summarises browser and OS platform support. Per-wallet sections list the install link, supported platforms, key features, and known limitations. A code snippet shows how to add or remove a wallet module.

Closes #184

---

### #185 — Step-by-Step Wallet Connection Guide

Adds `routes-d/185-connect-wallet-guide.mdx`.

No guide existed for connecting a wallet end to end. This page walks through five numbered steps: wrapping the app with `WalletProvider`, adding a connect button (pre-built or custom), calling `connect()`, reading wallet state, and disconnecting. A minimal self-contained page example demonstrates the full cycle. A dedicated pitfalls section covers wallet-not-installed errors, user rejection, network mismatch, missing provider context, and Albedo popup blocker issues — each with a code fix.

Closes #185

---

## Validation

All pages follow existing MDX frontmatter conventions (`title` + `description`) and end with the standard validation block:

```bash
pnpm build:content
pnpm check:links
