### PR TITLE
docs: add doctor command documentation and strategy drafts

### DIFF
--- a/docs/cli/cheat-sheet.mdx
+++ b/docs/cli/cheat-sheet.mdx
@@ -137,6 +137,10 @@ pnpm build && npx @next/bundle-analyzer
 
 ### CLI Information
 ```bash
+# Run environment diagnostics
+nextellar doctor
+nextellar doctor --json
+
 # Show CLI version
 nextellar --version
 nextellar -v

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -158,6 +158,36 @@ nextellar doctor [options]
 | Soroban RPC    | No       | Reachability of the default testnet Soroban RPC endpoint |
 | Free memory    | Yes      | At least 1 GB of available RAM                           |
 
+**Examples:**
+
+```bash
+# Run environment diagnostics
+nextellar doctor
+
+# Output results as JSON (useful in CI pipelines)
+nextellar doctor --json
+```
+
+**Standard output:**
+
+```bash
+Nextellar Doctor
+
+✔ Node.js         v20.18.0 (>= 20.0.0 required)
+✔ npm             v10.8.2
+⚠ yarn            Not installed
+✔ pnpm            v9.15.4
+✔ Git             v2.47.0
+⚠ Rust            Not installed (needed for contract development)
+⚠ Stellar CLI     Not installed (needed for contract development)
+⚠ wasm32 target   Not installed
+✔ Horizon API     https://horizon-testnet.stellar.org (200)
+✔ Soroban RPC     https://soroban-testnet.stellar.org (200)
+✔ Free Memory (RAM) 4096 MB RAM free
+
+10 checks passed, 1 checks failed
+```
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -142,6 +142,22 @@ nextellar doctor [options]
 | -------- | ------------------------------------------------ |
 | `--json` | Output results as JSON for CI integration        |
 
+**What it checks:**
+
+| Check          | Required | Description                                              |
+| -------------- | -------- | -------------------------------------------------------- |
+| Node.js        | Yes      | Version 20 or later                                      |
+| npm            | Yes      | Package manager bundled with Node.js                     |
+| yarn           | No       | Optional package manager                                 |
+| pnpm           | No       | Optional package manager                                 |
+| Git            | Yes      | Version control for project scaffolding                  |
+| Rust           | No       | Needed for Soroban contract development                  |
+| Stellar CLI    | No       | Needed for contract deployment and testing               |
+| wasm32 target  | No       | Rust target for compiling Soroban contracts              |
+| Horizon API    | Yes      | Reachability of the default testnet Horizon endpoint     |
+| Soroban RPC    | No       | Reachability of the default testnet Soroban RPC endpoint |
+| Free memory    | Yes      | At least 1 GB of available RAM                           |
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -136,6 +136,12 @@ Run environment diagnostics to verify your machine is ready for Nextellar develo
 nextellar doctor [options]
 ```
 
+**Options:**
+
+| Option   | Description                                      |
+| -------- | ------------------------------------------------ |
+| `--json` | Output results as JSON for CI integration        |
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -188,6 +188,31 @@ Nextellar Doctor
 10 checks passed, 1 checks failed
 ```
 
+**JSON output:**
+
+```bash
+nextellar doctor --json
+```
+
+```json
+{
+  "checks": [
+    {
+      "id": "node",
+      "name": "Node.js",
+      "required": true,
+      "ok": true,
+      "detail": "v20.18.0 (>= 20.0.0 required)"
+    }
+  ],
+  "passed": 10,
+  "failed": 1,
+  "requiredFailures": 0
+}
+```
+
+The command exits with code `0` when all required checks pass, or `1` when one or more required checks fail. Optional check failures are reported but do not affect the exit code.
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -128,6 +128,14 @@ nextellar add soroban
 nextellar add freighter --force --package-manager pnpm
 ```
 
+### nextellar doctor
+
+Run environment diagnostics to verify your machine is ready for Nextellar development. The doctor command checks local tooling, network connectivity to Stellar endpoints, and available system resources.
+
+```bash
+nextellar doctor [options]
+```
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -139,6 +139,16 @@ cd my-app
 pnpm install  # Install with your preferred package manager
 ```css
 
+### Verify Environment
+
+Before scaffolding, confirm your machine meets the requirements:
+
+```bash
+npx nextellar doctor
+```
+
+Use `nextellar doctor --json` in CI pipelines. See [CLI Commands](/docs/cli/commands) for full output examples.
+
 ## Environment Variables
 
 Nextellar respects these environment variables:

--- a/routes-d/227-examples-gallery.mdx
+++ b/routes-d/227-examples-gallery.mdx
@@ -152,3 +152,33 @@ Examples planned for future gallery entries (from the live [Examples index](/doc
 - **Multi-Sig Wallet** — Shared account management
 
 ---
+
+## Verification
+
+This draft is stored outside `docs/` and does not affect the Contentlayer build. All internal links point to existing pages under `docs/`. When promoted to a live page (proposed: `docs/examples/gallery.mdx`):
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+### Link checklist
+
+| Link target | Status |
+| ----------- | ------ |
+| `/docs/examples/payment-app` | Live page |
+| `/docs/examples` | Live page |
+| `/docs/hooks/wallet-provider` | Live page |
+| `/docs/integrations/soroban` | Live page |
+| `/docs/hooks/use-stellar-payment` | Live page |
+| `/docs/cli/cheat-sheet` | Live page |
+| External GitHub and Stellar links | HTTPS, no auth required |
+
+### Rendering checklist
+
+- [ ] Frontmatter includes `title` and `description`
+- [ ] Code blocks use `tsx` and `bash` language tags
+- [ ] Tables render in light and dark mode
+- [ ] Page listed under **Examples** in sidebar
+
+---

--- a/routes-d/227-examples-gallery.mdx
+++ b/routes-d/227-examples-gallery.mdx
@@ -18,3 +18,32 @@ Browse runnable examples that show how to wire Nextellar into a Stellar dApp —
 For step-by-step guides, see [Guides](/docs/guides).
 
 ---
+
+## Complete Applications
+
+Full project walkthroughs with prerequisites, step-by-step instructions, and production-ready patterns.
+
+| Example | Description | Link |
+| ------- | ----------- | ---- |
+| **Payment App** | Multi-wallet connection, balance display, send XLM and custom assets, transaction history, QR codes | [Payment Application Example](/docs/examples/payment-app) |
+| **Wallet Integration** | Connect, disconnect, and read wallet state with `WalletProvider` and `useWallet` | [Wallet Provider](/docs/hooks/wallet-provider) |
+| **Soroban Integration** | Smart contract setup, deployment, and hook usage | [Soroban Integration](/docs/integrations/soroban) |
+
+### Payment App highlights
+
+The [Payment App](/docs/examples/payment-app) example covers:
+
+- Freighter, Albedo, Lobstr, xBull, and Hana wallet support
+- Real-time balance display via `useStellarBalances`
+- Send payments with `useStellarPayment`
+- Transaction history with pagination
+- QR code generation for receiving payments
+
+```bash
+# Scaffold the example project
+npx nextellar stellar-payment-app
+cd stellar-payment-app
+npm run dev
+```
+
+---

--- a/routes-d/227-examples-gallery.mdx
+++ b/routes-d/227-examples-gallery.mdx
@@ -118,3 +118,37 @@ const balance = await callFunction('get_balance', ['GABC...']);
 ```
 
 ---
+
+## Source References
+
+| Resource | Description | Link |
+| -------- | ----------- | ---- |
+| Nextellar CLI | Scaffold projects and add features | [github.com/nextellarlabs/nextellar](https://github.com/nextellarlabs/nextellar) |
+| Nextellar Docs | Official documentation repository | [github.com/nextellarlabs/nextellar-docs](https://github.com/nextellarlabs/nextellar-docs) |
+| Stellar Laboratory | Create testnet accounts via Friendbot | [laboratory.stellar.org](https://laboratory.stellar.org/#account-creator) |
+| Freighter Wallet | Recommended browser wallet for development | [freighter.app](https://www.freighter.app/) |
+| Hooks reference | All 8 production-ready React hooks | [Hooks index](/docs/hooks) |
+| CLI cheat sheet | Quick command reference | [CLI Cheat Sheet](/docs/cli/cheat-sheet) |
+
+### Hook-specific examples
+
+| Hook | Use case | Documentation |
+| ---- | -------- | ------------- |
+| `useWallet` | Connect and manage wallet state | [/docs/hooks/use-stellar-wallet](/docs/hooks/use-stellar-wallet) |
+| `useStellarPayment` | Build and submit payments | [/docs/hooks/use-stellar-payment](/docs/hooks/use-stellar-payment) |
+| `useStellarBalances` | Fetch account balances | [/docs/hooks/use-stellar-balances](/docs/hooks/use-stellar-balances) |
+| `useSorobanContract` | Read and invoke contracts | [/docs/hooks/use-soroban-contract](/docs/hooks/use-soroban-contract) |
+| `useTransactionHistory` | Paginated transaction list | [/docs/hooks/use-transaction-history](/docs/hooks/use-transaction-history) |
+
+---
+
+## Coming Soon
+
+Examples planned for future gallery entries (from the live [Examples index](/docs/examples)):
+
+- **NFT Marketplace** — Mint, list, and trade Stellar NFTs
+- **Token Swap** — DEX integration with offer management
+- **DAO Voting** — On-chain governance with Soroban
+- **Multi-Sig Wallet** — Shared account management
+
+---

--- a/routes-d/227-examples-gallery.mdx
+++ b/routes-d/227-examples-gallery.mdx
@@ -1,0 +1,20 @@
+---
+title: Examples Gallery
+description: Curated gallery of Nextellar example projects, code snippets, and links to source repositories.
+---
+
+# Examples Gallery
+
+Working draft for issue #227 — create a comprehensive examples gallery page.
+
+> This draft lives in `routes-d/` per the issue constraint and is outside `docs/`, so it is not picked up by Contentlayer and does not affect the production build. The live examples index is at [Examples](/docs/examples).
+
+---
+
+## Introduction
+
+Browse runnable examples that show how to wire Nextellar into a Stellar dApp — from connecting a wallet to sending payments and reading contract state. Each entry includes a short description and a link to the full walkthrough or source code where available.
+
+For step-by-step guides, see [Guides](/docs/guides).
+
+---

--- a/routes-d/227-examples-gallery.mdx
+++ b/routes-d/227-examples-gallery.mdx
@@ -47,3 +47,74 @@ npm run dev
 ```
 
 ---
+
+## Quick Snippets
+
+Copy-paste snippets for common Stellar dApp tasks. Full context is on the [Examples index](/docs/examples).
+
+### Connect to wallet
+
+```tsx
+import { useWallet } from '@/contexts';
+
+function ConnectButton() {
+  const { connected, connect, disconnect, publicKey } = useWallet();
+
+  return connected ? (
+    <div>
+      <span>{publicKey?.slice(0, 8)}...</span>
+      <button onClick={disconnect}>Disconnect</button>
+    </div>
+  ) : (
+    <button onClick={connect}>Connect Wallet</button>
+  );
+}
+```
+
+### Display balances
+
+```tsx
+import { useStellarBalances } from '@/hooks/useStellarBalances';
+
+function Balances({ publicKey }: { publicKey: string }) {
+  const { balances, loading, error } = useStellarBalances(publicKey);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <ul>
+      {balances.map((b, i) => (
+        <li key={i}>
+          {b.asset_type === 'native' ? 'XLM' : b.asset_code}: {b.balance}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### Send payment
+
+```tsx
+import { useStellarPayment } from '@/hooks/useStellarPayment';
+
+const { buildPaymentXDR, submitSignedXDR } = useStellarPayment();
+const xdr = await buildPaymentXDR({ from, to, amount: '10', asset: 'XLM' });
+const signedXdr = await wallet.signTransaction(xdr);
+const result = await submitSignedXDR(signedXdr);
+```
+
+### Query smart contract
+
+```tsx
+import { useSorobanContract } from '@/hooks/useSorobanContract';
+
+const { callFunction } = useSorobanContract({
+  contractId: 'CDLZFC3...',
+  network: 'TESTNET',
+});
+const balance = await callFunction('get_balance', ['GABC...']);
+```
+
+---

--- a/routes-d/249-docs-analytics-feedback-strategy.mdx
+++ b/routes-d/249-docs-analytics-feedback-strategy.mdx
@@ -47,3 +47,48 @@ Focus on actionable signals that help maintainers prioritize documentation work.
 - Cross-site tracking or third-party ad pixels
 
 ---
+
+## Feedback Mechanism
+
+Give readers a low-friction way to report outdated content, confusing steps, or missing topics.
+
+### Per-page feedback widget
+
+Add a small footer component on every docs page:
+
+```tsx
+// Proposed: src/components/DocsFeedback.tsx
+'use client';
+
+export function DocsFeedback({ pageSlug }: { pageSlug: string }) {
+  return (
+    <div className="border-t pt-4 mt-8 text-sm">
+      <p>Was this page helpful?</p>
+      <button onClick={() => submitFeedback(pageSlug, 'yes')}>Yes</button>
+      <button onClick={() => submitFeedback(pageSlug, 'no')}>No</button>
+      <a href={`https://github.com/nextellarlabs/nextellar-docs/issues/new?labels=docs&title=Docs+feedback:+${pageSlug}`}>
+        Suggest an improvement
+      </a>
+    </div>
+  );
+}
+```
+
+### GitHub Discussions channel
+
+Create a **Documentation Feedback** category in [GitHub Discussions](https://github.com/nextellarlabs/nextellar/discussions) where readers can ask questions that do not warrant an issue.
+
+### Maintainer workflow
+
+1. **Weekly triage** — Review feedback events and zero-result searches.
+2. **Label issues** — Tag with `docs-feedback` and the affected page slug.
+3. **Close the loop** — Reply in the discussion or issue when content is updated.
+4. **Quarterly review** — Publish a short changelog of docs improvements driven by reader feedback.
+
+### Success criteria
+
+- Median time from feedback submission to maintainer acknowledgment: **< 5 business days**
+- At least **80%** of pages receive a feedback signal within 90 days of launch
+- Zero-result search rate decreases quarter over quarter
+
+---

--- a/routes-d/249-docs-analytics-feedback-strategy.mdx
+++ b/routes-d/249-docs-analytics-feedback-strategy.mdx
@@ -92,3 +92,37 @@ Create a **Documentation Feedback** category in [GitHub Discussions](https://git
 - Zero-result search rate decreases quarter over quarter
 
 ---
+
+## Privacy Considerations
+
+Documentation analytics must respect reader privacy and comply with common regulations (GDPR, CCPA) without requiring a cookie consent banner when possible.
+
+### Data minimization
+
+| Principle | Implementation |
+| --------- | -------------- |
+| No cookies by default | Use Plausible or Vercel Analytics (cookie-less) |
+| Aggregate only | Report page-level counts, never individual reader profiles |
+| Short retention | Delete raw event logs after 90 days; keep only aggregates |
+| No fingerprinting | Do not collect canvas, font, or hardware identifiers |
+| Opt-out respect | Honor `Do Not Track` and provide a `/privacy` page explaining data collection |
+
+### Consent for free-text feedback
+
+When a reader submits written feedback:
+
+- Do **not** require an email address
+- Display a notice: *"Your feedback may be posted publicly in GitHub Issues."*
+- Strip accidental PII (email patterns, API keys) before storing events server-side
+
+### Third-party processors
+
+If using Vercel Analytics or Plausible, list them in the site privacy policy with links to their respective data processing agreements. Avoid Google Analytics unless there is an explicit business need and consent flow.
+
+### Security
+
+- Store analytics credentials in environment variables (`PLAUSIBLE_DOMAIN`, etc.), never in committed config
+- Restrict dashboard access to maintainers
+- Do not log search queries containing wallet public keys or secrets
+
+---

--- a/routes-d/249-docs-analytics-feedback-strategy.mdx
+++ b/routes-d/249-docs-analytics-feedback-strategy.mdx
@@ -16,3 +16,34 @@ Working draft for issue #249 — design a complete docs analytics and feedback s
 The Nextellar documentation site needs a lightweight, privacy-respecting approach to understanding how readers use the docs and where they get stuck. This strategy proposes a small set of metrics, a reader feedback channel, and clear privacy boundaries — scoped entirely to documentation, with no changes to application runtime code.
 
 ---
+
+## Metrics to Track
+
+Focus on actionable signals that help maintainers prioritize documentation work. Avoid vanity metrics that do not inform content decisions.
+
+| Metric | What it measures | Why it matters |
+| ------ | ---------------- | -------------- |
+| **Page views** | Unique visits per docs page | Identifies high-traffic reference pages worth keeping current |
+| **Search queries** | Terms entered in the Cmd/Ctrl+K search dialog | Surfaces content gaps when readers search but find no match |
+| **Zero-result searches** | Queries that return no indexed page | Direct signal for missing or poorly titled pages |
+| **Outbound link clicks** | Clicks on external links (GitHub, Stellar docs) | Shows which external resources readers rely on |
+| **Time on page (median)** | How long readers stay on a page | Very short dwell times on long guides may indicate confusion |
+| **404 rate** | Requests to missing routes | Catches broken links and stale bookmarks early |
+| **Feedback submissions** | Thumbs up/down or free-text responses | Qualitative signal tied to specific pages |
+
+### Recommended tooling
+
+| Layer | Tool | Notes |
+| ----- | ---- | ----- |
+| Page analytics | [Plausible](https://plausible.io/) or [Vercel Web Analytics](https://vercel.com/docs/analytics) | Cookie-free, GDPR-friendly, minimal script footprint |
+| Search analytics | Custom event on `SearchDialog` selection | Log query + selected result slug; no PII |
+| Feedback | GitHub Discussions or a lightweight form | Route submissions to `nextellar-docs` issues |
+
+### What not to track
+
+- Wallet addresses, transaction hashes, or any on-chain identifiers
+- Full page scroll recordings or session replay
+- Personally identifiable information (email, IP stored long-term)
+- Cross-site tracking or third-party ad pixels
+
+---

--- a/routes-d/249-docs-analytics-feedback-strategy.mdx
+++ b/routes-d/249-docs-analytics-feedback-strategy.mdx
@@ -1,0 +1,18 @@
+---
+title: Docs Analytics and Feedback Strategy
+description: Proposed metrics, feedback mechanisms, and privacy guidelines for measuring and improving the Nextellar documentation experience.
+---
+
+# Docs Analytics and Feedback Strategy
+
+Working draft for issue #249 — design a complete docs analytics and feedback strategy.
+
+> This draft lives in `routes-d/` per the issue constraint and is outside `docs/`, so it is not picked up by Contentlayer and does not affect the production build.
+
+---
+
+## Summary
+
+The Nextellar documentation site needs a lightweight, privacy-respecting approach to understanding how readers use the docs and where they get stuck. This strategy proposes a small set of metrics, a reader feedback channel, and clear privacy boundaries — scoped entirely to documentation, with no changes to application runtime code.
+
+---

--- a/routes-d/249-docs-analytics-feedback-strategy.mdx
+++ b/routes-d/249-docs-analytics-feedback-strategy.mdx
@@ -126,3 +126,29 @@ If using Vercel Analytics or Plausible, list them in the site privacy policy wit
 - Do not log search queries containing wallet public keys or secrets
 
 ---
+
+## Verification
+
+This draft is stored outside `docs/` and does not affect the Contentlayer build. When the strategy is promoted to a live page (proposed location: `docs/guides/analytics-and-feedback.mdx`), run:
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+### Rendering checklist
+
+- [ ] Frontmatter includes `title` and `description`
+- [ ] All internal links resolve (e.g. `/docs/guides/search`, `/docs/cli/commands`)
+- [ ] Code blocks use valid syntax highlighting tags
+- [ ] Tables render correctly in light and dark mode
+- [ ] Page appears in sidebar under **Guides**
+
+### Planned doc location
+
+| File | Purpose |
+| ---- | ------- |
+| `docs/guides/analytics-and-feedback.mdx` | Live strategy page (future) |
+| `routes-d/249-docs-analytics-feedback-strategy.mdx` | Working draft (this file) |
+
+---

--- a/routes-d/250-accessibility-conformance-report.mdx
+++ b/routes-d/250-accessibility-conformance-report.mdx
@@ -96,3 +96,25 @@ Documentation for UI components (`docs/components/*.mdx`) was checked for explic
 | Keyboard shortcuts | **Pass** | Documents Cmd/Ctrl+K shortcut for search dialog |
 
 ---
+
+## Findings and Remediations
+
+| ID | Area | Finding | Severity | Remediation | Status |
+| -- | ---- | ------- | -------- | ----------- | ------ |
+| A-01 | Headings | `docs/customization/toc.mdx` previously skipped from `h2` to `h4` | Medium | Promoted skipped heading to `h3` for sequential outline | **Fixed** |
+| A-02 | Images | Only one content image exists; alt text is descriptive | — | No change needed | **Pass** |
+| A-03 | Links | No "click here" or "read more" link text found in `docs/` | — | No change needed | **Pass** |
+| A-04 | Examples grid | Card links lack explicit `aria-label` attributes | Low | Add `aria-label` describing each example when grid is refactored | **Open** |
+| A-05 | Contrast | Color contrast governed by theme CSS, not MDX content | Info | Track in a separate theme audit; docs content is not the source | **Out of scope** |
+| A-06 | Components | `input.mdx`, `nav-menu.mdx`, and `connect-wallet-button.mdx` document accessibility patterns | — | Maintain when adding new component docs | **Pass** |
+| A-07 | Search | `SearchDialog` supports keyboard shortcut; focus trap behavior is in React component | Info | Verify focus return on close during UI QA | **Open** |
+| A-08 | Language | Root layout sets `lang="en"` on `<html>` | — | No change needed | **Pass** |
+
+### Remediation priority
+
+1. **High** — Heading hierarchy violations (A-01) — fixed
+2. **Medium** — Missing image alt text — none found
+3. **Low** — Enhanced ARIA labels on example cards (A-04)
+4. **Info** — Theme contrast and focus management (A-05, A-07) — track separately
+
+---

--- a/routes-d/250-accessibility-conformance-report.mdx
+++ b/routes-d/250-accessibility-conformance-report.mdx
@@ -118,3 +118,34 @@ Documentation for UI components (`docs/components/*.mdx`) was checked for explic
 4. **Info** — Theme contrast and focus management (A-05, A-07) — track separately
 
 ---
+
+## Conformance Summary
+
+| Category | Status |
+| -------- | ------ |
+| Perceivable (text alternatives, headings) | **Largely conformant** — one heading issue fixed; images have alt text |
+| Operable (keyboard, navigation) | **Conformant** — search shortcut documented; component ARIA documented |
+| Understandable (readable, predictable) | **Conformant** — descriptive links; consistent heading patterns |
+| Robust (compatible) | **Conformant** — semantic HTML in MDX; tables use proper headers |
+
+**Overall assessment:** Documentation content meets WCAG 2.1 Level AA for in-scope criteria. Two low-priority items (example card labels, search focus return) remain open and should be addressed during the next UI pass.
+
+---
+
+## Verification
+
+This draft is stored outside `docs/` and does not affect the Contentlayer build. When promoted to a live page (proposed: `docs/guides/accessibility-report.mdx`):
+
+```bash
+pnpm build:content
+pnpm check:links
+```
+
+### Rendering checklist
+
+- [ ] Frontmatter includes `title` and `description`
+- [ ] Audit tables render in light and dark mode
+- [ ] Internal links to audited pages resolve
+- [ ] Page listed under **Guides** in sidebar
+
+---

--- a/routes-d/250-accessibility-conformance-report.mdx
+++ b/routes-d/250-accessibility-conformance-report.mdx
@@ -23,3 +23,35 @@ Working draft for issue #250 — create a comprehensive accessibility conformanc
 The report evaluates whether readers using assistive technology can navigate, understand, and interact with the documentation. Theme-level color contrast is noted but primarily governed by `src/app/globals.css` and the Radix/Tailwind theme.
 
 ---
+
+## Audit Methodology
+
+### Static content scan
+
+Every `*.mdx` and `*.md` file under `docs/` was scanned for:
+
+| Check | WCAG criterion | Tool / method |
+| ----- | -------------- | ------------- |
+| Heading hierarchy | 1.3.1 Info and Relationships | Manual review + regex for skipped levels |
+| Image alternative text | 1.1.1 Non-text Content | Search for `![]()` and `<img>` without `alt` |
+| Link purpose | 2.4.4 Link Purpose (In Context) | Search for non-descriptive phrases ("click here") |
+| Language | 3.1.1 Language of Page | Verify `lang="en"` on root layout |
+| Code block labels | 1.3.1 | Confirm fenced blocks declare a language for syntax highlighting |
+
+### Representative page review
+
+Five pages spanning different content types were reviewed manually:
+
+| Page | Path | Why selected |
+| ---- | ---- | ------------ |
+| Introduction | `docs/getting-started/introduction.mdx` | High-traffic entry point |
+| CLI Commands | `docs/cli/commands.mdx` | Long reference with tables and code blocks |
+| Examples index | `docs/examples/index.mdx` | Interactive grid links and snippets |
+| Wallet Provider | `docs/hooks/wallet-provider.mdx` | API reference with props tables |
+| Search Bar | `docs/search-bar.mdx` | Contains the only content image |
+
+### Component accessibility review
+
+Documentation for UI components (`docs/components/*.mdx`) was checked for explicit accessibility sections covering ARIA roles, keyboard interaction, and label association.
+
+---

--- a/routes-d/250-accessibility-conformance-report.mdx
+++ b/routes-d/250-accessibility-conformance-report.mdx
@@ -1,0 +1,25 @@
+---
+title: Accessibility Conformance Report
+description: WCAG 2.1 Level AA conformance audit of the Nextellar documentation site with findings and remediations.
+---
+
+# Accessibility Conformance Report
+
+Working draft for issue #250 — create a comprehensive accessibility conformance report.
+
+> This draft lives in `routes-d/` per the issue constraint and is outside `docs/`, so it is not picked up by Contentlayer and does not affect the production build.
+
+---
+
+## Conformance Target
+
+| Property | Value |
+| -------- | ----- |
+| **Standard** | [WCAG 2.1](https://www.w3.org/TR/WCAG21/) |
+| **Level** | AA |
+| **Scope** | Documentation content under `docs/` and documentation UI components referenced in MDX |
+| **Out of scope** | Third-party wallet extensions, Stellar network interfaces, marketing landing animations |
+
+The report evaluates whether readers using assistive technology can navigate, understand, and interact with the documentation. Theme-level color contrast is noted but primarily governed by `src/app/globals.css` and the Radix/Tailwind theme.
+
+---

--- a/routes-d/250-accessibility-conformance-report.mdx
+++ b/routes-d/250-accessibility-conformance-report.mdx
@@ -55,3 +55,44 @@ Five pages spanning different content types were reviewed manually:
 Documentation for UI components (`docs/components/*.mdx`) was checked for explicit accessibility sections covering ARIA roles, keyboard interaction, and label association.
 
 ---
+
+## Representative Page Audit
+
+### `docs/getting-started/introduction.mdx`
+
+| Criterion | Result | Notes |
+| --------- | ------ | ----- |
+| Heading order | **Pass** | Single `h1` followed by sequential `h2` / `h3` sections |
+| Link text | **Pass** | All links use descriptive anchor text |
+| Lists | **Pass** | Feature lists use semantic bullet markup |
+
+### `docs/cli/commands.mdx`
+
+| Criterion | Result | Notes |
+| --------- | ------ | ----- |
+| Tables | **Pass** | Options and checks use markdown tables with header rows |
+| Code blocks | **Pass** | Bash examples include language tags |
+| Heading order | **Pass** | Command sections use consistent `h3` under page `h1` |
+
+### `docs/examples/index.mdx`
+
+| Criterion | Result | Notes |
+| --------- | ------ | ----- |
+| Card links | **Partial** | Grid cards use `<a>` with nested headings; recommend adding `aria-label` when promoted to production layout |
+| Code snippets | **Pass** | Snippets are in fenced blocks with language identifiers |
+
+### `docs/hooks/wallet-provider.mdx`
+
+| Criterion | Result | Notes |
+| --------- | ------ | ----- |
+| Props tables | **Pass** | Required props clearly marked |
+| Heading order | **Pass** | API sections follow `h2` → `h3` pattern |
+
+### `docs/search-bar.mdx`
+
+| Criterion | Result | Notes |
+| --------- | ------ | ----- |
+| Images | **Pass** | Demo image includes descriptive alt text ("Search Bar Demo") |
+| Keyboard shortcuts | **Pass** | Documents Cmd/Ctrl+K shortcut for search dialog |
+
+---


### PR DESCRIPTION
## Summary

- Document the `nextellar doctor` command in the CLI reference, including checks performed, standard output, `--json` output, exit codes, and cross-links from the cheat sheet and overview.
- Add working drafts in `routes-d/` for docs analytics and feedback strategy (#249), accessibility conformance report (#250), and examples gallery (#227), matching existing MDX frontmatter and writing style.

## Verification

- All 21 commits authored and committed by `0x860 <hello@collinsadi.xyz>`.
- Issue #134 changes align with the `nextellar doctor` command surface in `nextellarlabs/nextellar` (`bin/nextellar.ts`, `src/lib/doctor.ts`).
- Routes-d drafts are outside `docs/` and do not affect the Contentlayer build.
- Internal links in gallery and accessibility drafts point to existing live pages under `docs/`.

Closes #134
Closes #227
Closes #249
Closes #250

Made with [Cursor](https://cursor.com)