### PR TITLE
Add formatting conventions and documentation contributing checklist

### DIFF
--- a/docs/components/checkbox.mdx
+++ b/docs/components/checkbox.mdx
@@ -56,7 +56,6 @@ The **Checkbox** component is a flexible, accessible checkbox built using Tailwi
       );
     }
     ```
-```
 
   </TabsContent>
 </Tabs>

--- a/docs/components/folder-tree.mdx
+++ b/docs/components/folder-tree.mdx
@@ -48,7 +48,6 @@ The `FolderTree` component is a customizable folder structure UI component that 
       </Folder>
     </FolderTree>
     ```
-```
   </TabsContent>
 </Tabs>
 

--- a/docs/components/label.mdx
+++ b/docs/components/label.mdx
@@ -50,7 +50,6 @@ The **Label** component is a lightweight, theme-aware, and variant-powered text 
       );
     }
     ```
-```
 
   </TabsContent>
 </Tabs>

--- a/docs/guides/contributing-checklist.mdx
+++ b/docs/guides/contributing-checklist.mdx
@@ -1,0 +1,27 @@
+---
+title: Documentation Contributing Checklist
+description: Short checklist for documentation contributions covering formatting, links, and build verification.
+---
+
+# Documentation Contributing Checklist
+
+- [ ] Add a new file in the appropriate `docs/` folder.
+- [ ] Include required frontmatter:
+  - `title`
+  - `description`
+- [ ] Use one `#` heading per page.
+- [ ] Keep headings sentence case and concise.
+- [ ] Use `-` bulleted lists and short list items.
+- [ ] Format inline code with backticks.
+- [ ] Use fenced code blocks with a language label.
+- [ ] Use absolute internal links like `/docs/...`.
+- [ ] Keep examples simple and copy/paste ready.
+- [ ] Run `pnpm build:content`.
+- [ ] Run `pnpm check:links`.
+- [ ] Preview your changes with `pnpm dev` if possible.
+
+## Notes
+
+- Use consistent terminology across docs.
+- Avoid mixing markdown emphasis markers in the same phrase.
+- Verify that new pages render cleanly in the dev server.

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -16,18 +16,21 @@ Nextellar documentation uses **Contentlayer** to process MDX files into structur
 The content build process (`pnpm build:content`) performs several important tasks:
 
 **Content Processing**
+
 - Converts MDX files into structured JavaScript objects
 - Validates frontmatter schema and required fields
 - Processes embedded React components and imports
 - Generates type definitions for content objects
 
 **Navigation & Search**
+
 - Creates navigation tree from file structure and frontmatter
 - Builds search index for documentation content
 - Generates sitemap and internal link mappings
 - Validates cross-references between documents
 
 **Optimization**
+
 - Optimizes images and static assets referenced in content
 - Bundles and tree-shakes unused code from MDX components
 - Creates efficient data structures for fast page loading
@@ -36,20 +39,23 @@ The content build process (`pnpm build:content`) performs several important task
 ### Running the Content Build
 
 **Basic Command**
+
 ```bash
 pnpm build:content
 ```
 
 **What happens during the build:**
+
 ```bash
 ✓ Generated 47 documents in .contentlayer
-✓ Validated frontmatter for all MDX files  
+✓ Validated frontmatter for all MDX files
 ✓ Built navigation tree (4 sections, 23 pages)
 ✓ Generated search index (1,247 searchable items)
 ✓ Validated 156 internal links
 ```
 
 **Integration with Development**
+
 ```bash
 # Full development build
 pnpm build          # Runs build:content + next build
@@ -61,17 +67,20 @@ pnpm dev           # Watches for MDX changes
 ### When You Must Run the Content Build
 
 **Required Scenarios**
+
 - **Adding new MDX files**: New pages need to be processed and indexed
 - **Modifying frontmatter**: Changes to title, description, or metadata
 - **Updating internal links**: Cross-references need validation
 - **Before production build**: Always runs as part of `pnpm build`
 
 **Automatic Rebuilds**
+
 - **Development mode**: Content rebuilds automatically when MDX files change
 - **CI/CD pipeline**: Runs during automated builds and deployments
 - **Pre-commit hooks**: Validates content before commits (optional)
 
 **Manual Rebuilds Needed**
+
 - **After git pull**: When pulling changes that include new content
 - **Troubleshooting**: When content seems out of sync
 - **Before testing**: To ensure latest content is available
@@ -81,7 +90,7 @@ pnpm dev           # Watches for MDX changes
 The build process is configured in `contentlayer.config.ts`:
 
 ```typescript
-import { defineDocumentType, makeSource } from 'contentlayer2/source-files'
+import { defineDocumentType, makeSource } from 'contentlayer2/source-files';
 
 const Doc = defineDocumentType(() => ({
   name: 'Doc',
@@ -99,7 +108,7 @@ const Doc = defineDocumentType(() => ({
     },
     // Navigation and search fields...
   },
-}))
+}));
 
 export default makeSource({
   contentDirPath: 'docs',
@@ -108,51 +117,59 @@ export default makeSource({
     remarkPlugins: [remarkGfm],
     rehypePlugins: [rehypeSlug, rehypeHighlight],
   },
-})
+});
 ```
 
 ### Troubleshooting Content Build Issues
 
 **Common Error: Invalid Frontmatter**
+
 ```bash
 Error: Missing required field "description" in docs/guides/example.mdx
 ```
 
 **Solution**: Ensure all MDX files have required frontmatter:
+
 ```yaml
 ---
-title: "Page Title"
-description: "Page description for SEO and navigation"
+title: 'Page Title'
+description: 'Page description for SEO and navigation'
 ---
 ```
 
 **Common Error: Broken Internal Links**
+
 ```bash
 Error: Link target not found: /docs/nonexistent-page
 ```
 
 **Solution**: Verify link targets exist and use correct paths:
+
 ```markdown
 <!-- Correct -->
+
 [CLI Commands](/docs/cli/commands)
 
 <!-- Incorrect -->
+
 [CLI Commands](/docs/cli/nonexistent)
 ```
 
 **Common Error: MDX Syntax Issues**
+
 ```bash
 Error: Unexpected token in docs/guides/example.mdx:15:3
 ```
 
 **Solution**: Check MDX syntax, especially JSX components:
+
 ```mdx
 {/* Correct */}
-<div className="grid grid-cols-2">
-  Content here
-</div>
+
+<div className="grid grid-cols-2">Content here</div>
 
 {/* Incorrect - missing closing tag */}
+
 <div className="grid grid-cols-2">
   Content here
 ```
@@ -162,15 +179,17 @@ Error: Unexpected token in docs/guides/example.mdx:15:3
 The build process includes several validation steps:
 
 **Frontmatter Validation**
+
 ```typescript
 // Required fields for all documents
 interface DocumentFrontmatter {
-  title: string        // Page title
-  description: string  // SEO description
+  title: string; // Page title
+  description: string; // SEO description
 }
 ```
 
 **Link Validation**
+
 ```bash
 # Check all internal links
 pnpm check:links
@@ -183,6 +202,7 @@ pnpm check:links
 ```
 
 **Content Structure Validation**
+
 - Ensures proper heading hierarchy (h1 → h2 → h3)
 - Validates code block language specifications
 - Checks for required sections in specific document types
@@ -192,6 +212,7 @@ pnpm check:links
 ### Setting Up for Development
 
 1. **Clone and Install**
+
 ```bash
 git clone https://github.com/nextellarlabs/nextellar-docs.git
 cd nextellar-docs
@@ -199,11 +220,13 @@ pnpm install
 ```
 
 2. **Initial Content Build**
+
 ```bash
 pnpm build:content
 ```
 
 3. **Start Development Server**
+
 ```bash
 pnpm dev
 ```
@@ -211,17 +234,20 @@ pnpm dev
 ### Making Content Changes
 
 **For New Pages**
+
 1. Create MDX file in appropriate `docs/` subdirectory
 2. Add required frontmatter
 3. Run `pnpm build:content` to process new file
 4. Verify page appears in navigation
 
 **For Existing Pages**
+
 1. Edit MDX file (auto-rebuilds in dev mode)
 2. Check browser for immediate updates
 3. Validate changes with `pnpm check:links`
 
 **For Navigation Changes**
+
 1. Update file structure or frontmatter
 2. Run `pnpm build:content` to regenerate navigation
 3. Test navigation in browser
@@ -235,7 +261,7 @@ Before submitting a pull request:
 pnpm build:content
 
 # 2. Validate all links
-pnpm check:links  
+pnpm check:links
 
 # 3. Check formatting
 pnpm format:check
@@ -249,14 +275,17 @@ pnpm build
 
 **All commands should complete without errors.**
 
+For a quick ready-to-use checklist, see [Documentation Contributing Checklist](/docs/guides/contributing-checklist).
+
 ## Content Guidelines
 
 ### File Organization
+
 ```
 docs/
 ├── index.mdx              # Homepage
 ├── getting-started/       # Installation, quick start
-├── cli/                   # CLI documentation  
+├── cli/                   # CLI documentation
 ├── hooks/                 # React hooks reference
 ├── guides/               # How-to guides
 ├── examples/             # Code examples
@@ -264,22 +293,26 @@ docs/
 ```
 
 ### Frontmatter Requirements
+
 ```yaml
 ---
-title: "Descriptive Page Title"
-description: "Clear description for SEO and navigation (50-160 chars)"
+title: 'Descriptive Page Title'
+description: 'Clear description for SEO and navigation (50-160 chars)'
 ---
 ```
 
 ### Writing Style
+
 - Use clear, concise language
 - Include code examples for technical concepts
 - Structure content with proper headings
 - Add internal links to related documentation
 
 ### Component Usage
+
 ```mdx
 {/* Use project components for consistency */}
+
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
   <a href="/docs/cli/commands" className="block p-4 border rounded-lg">
     <h4 className="font-semibold">CLI Commands</h4>
@@ -293,16 +326,19 @@ description: "Clear description for SEO and navigation (50-160 chars)"
 ## Getting Help
 
 **Build Issues**
+
 - Check the terminal output for specific error messages
 - Verify MDX syntax and frontmatter format
 - Ensure all internal links are valid
 
 **Content Questions**
+
 - Review existing documentation for patterns
 - Check the [style guide](/docs/guides/style-guide) for writing conventions
 - Ask in [GitHub Discussions](https://github.com/nextellarlabs/nextellar/discussions)
 
 **Technical Problems**
+
 - Clear `.contentlayer` directory and rebuild
 - Restart development server
 - Check Node.js version compatibility (requires Node 18+)

--- a/docs/guides/formatting-conventions.mdx
+++ b/docs/guides/formatting-conventions.mdx
@@ -1,0 +1,81 @@
+---
+title: Formatting Conventions
+description: Common heading, list, code, link, and inline formatting conventions used across Nextellar documentation.
+---
+
+# Formatting Conventions
+
+Use consistent formatting so docs are easy to scan and render cleanly. This page documents the conventions used for headings, lists, code, links, and emphasis.
+
+## Headings
+
+- Use a single `#` heading at the top of each page.
+- Use sentence case and keep headings short.
+- Avoid punctuation at the end of headings.
+- Use nested headings only for structure: `##`, `###`, etc.
+
+Example:
+
+```md
+# Formatting Conventions
+
+## Headings
+```
+
+## Lists
+
+- Use hyphens `-` for bulleted lists.
+- Keep list items short and focused.
+- Start each item with a capital letter.
+- Use nested lists only when a second level improves clarity.
+
+Example:
+
+```md
+- Use a single H1 per page.
+- Keep list items concise.
+```
+
+## Code formatting
+
+- Wrap inline code with backticks: `` `command` ``.
+- Use fenced code blocks with a language label.
+- Keep code examples simple and copy/paste ready.
+- Do not add trailing punctuation inside code fences.
+
+Example:
+
+```bash
+pnpm build:content
+```
+
+## Inline emphasis
+
+- Use `**bold**` for strong emphasis.
+- Use `*italic*` for lighter emphasis.
+- Do not mix `*` and `_` markers in the same phrase.
+- Prefer plain language over emphasis when possible.
+
+Example:
+
+```md
+Use **bold** text for important terms and _italic_ text for emphasis.
+```
+
+## Links
+
+- Use absolute internal links that start with `/docs/`.
+- Use descriptive link text instead of "click here".
+- Keep external links clear and short.
+
+Example:
+
+```md
+[Read the contributing guide](/docs/guides/contributing)
+```
+
+## Keep it easy to scan
+
+- Use short paragraphs with one or two sentences.
+- Add examples for rules that might be unclear.
+- Avoid long blocks of uninterrupted text.

--- a/docs/guides/mdx-custom-components.mdx
+++ b/docs/guides/mdx-custom-components.mdx
@@ -9,59 +9,47 @@ MDX lets you embed React components directly in Markdown. Nextellar docs registe
 
 ## Available components
 
-| Component | Purpose |
-| --- | --- |
-| `Note` | Callout box for tips, warnings, and info |
-| `Tabs`, `TabsList`, `Tab`, `TabsContent` | Tabbed content panels |
-| `Steps`, `Step`, `StepTitle`, `StepContent` | Numbered step sequences |
-| `FolderTree`, `Folder`, `File` | Visual directory trees |
-| `Button` | Styled action button |
-| `Mermaid` | Render Mermaid diagrams |
-| `CodeTabs` | Syntax-highlighted code with language tabs |
-| `Dialog`, `DialogTrigger`, `DialogContent` | Modal dialog |
-| `Popover`, `PopoverTrigger`, `PopoverContent` | Floating popover |
-| `Select`, `SelectContent`, `SelectItem`, `SelectValue` | Dropdown select |
-| `Checkbox`, `Label`, `Input` | Form controls |
-| `Menu`, `MenuItem`, `MenuTrigger`, `PopMenu` | Dropdown menu |
+| Component                                              | Purpose                                    |
+| ------------------------------------------------------ | ------------------------------------------ |
+| `Note`                                                 | Callout box for tips, warnings, and info   |
+| `Tabs`, `TabsList`, `Tab`, `TabsContent`               | Tabbed content panels                      |
+| `Steps`, `Step`, `StepTitle`, `StepContent`            | Numbered step sequences                    |
+| `FolderTree`, `Folder`, `File`                         | Visual directory trees                     |
+| `Button`                                               | Styled action button                       |
+| `Mermaid`                                              | Render Mermaid diagrams                    |
+| `CodeTabs`                                             | Syntax-highlighted code with language tabs |
+| `Dialog`, `DialogTrigger`, `DialogContent`             | Modal dialog                               |
+| `Popover`, `PopoverTrigger`, `PopoverContent`          | Floating popover                           |
+| `Select`, `SelectContent`, `SelectItem`, `SelectValue` | Dropdown select                            |
+| `Checkbox`, `Label`, `Input`                           | Form controls                              |
+| `Menu`, `MenuItem`, `MenuTrigger`, `PopMenu`           | Dropdown menu                              |
 
 ## Note
 
 Use `Note` to highlight important information.
 
 ```mdx
-<Note>
-  Run `pnpm build:content` after adding any new MDX file.
-</Note>
+<Note>Run `pnpm build:content` after adding any new MDX file.</Note>
 ```
 
 **Renders as:**
 
-<Note>
-  Run `pnpm build:content` after adding any new MDX file.
-</Note>
+<Note>Run `pnpm build:content` after adding any new MDX file.</Note>
 
 ## Tabs
 
 Use `Tabs` to show alternative content side by side.
 
-```mdx
+````mdx
 <Tabs defaultValue="npm">
   <TabsList>
     <Tab value="npm">npm</Tab>
     <Tab value="pnpm">pnpm</Tab>
   </TabsList>
-  <TabsContent value="npm">
-    ```bash
-    npm install
-    ```
-  </TabsContent>
-  <TabsContent value="pnpm">
-    ```bash
-    pnpm install
-    ```
-  </TabsContent>
+  <TabsContent value="npm">```bash npm install ```</TabsContent>
+  <TabsContent value="pnpm">```bash pnpm install ```</TabsContent>
 </Tabs>
-```
+````
 
 ## Steps
 
@@ -88,10 +76,14 @@ Use `FolderTree` to illustrate project or file structures.
 <FolderTree>
   <Folder element="src" defaultOpen={true}>
     <Folder element="hooks">
-      <File><p>useStellarWallet.ts</p></File>
+      <File>
+        <p>useStellarWallet.ts</p>
+      </File>
     </Folder>
     <Folder element="components">
-      <File><p>WalletConnectButton.tsx</p></File>
+      <File>
+        <p>WalletConnectButton.tsx</p>
+      </File>
     </Folder>
   </Folder>
 </FolderTree>
@@ -102,10 +94,14 @@ Use `FolderTree` to illustrate project or file structures.
 <FolderTree>
   <Folder element="src" defaultOpen={true}>
     <Folder element="hooks">
-      <File><p>useStellarWallet.ts</p></File>
+      <File>
+        <p>useStellarWallet.ts</p>
+      </File>
     </Folder>
     <Folder element="components">
-      <File><p>WalletConnectButton.tsx</p></File>
+      <File>
+        <p>WalletConnectButton.tsx</p>
+      </File>
     </Folder>
   </Folder>
 </FolderTree>
@@ -129,8 +125,8 @@ Use `CodeTabs` to show the same snippet in multiple languages.
 ```mdx
 <CodeTabs
   tabs={{
-    tsx: { syntax: "const { address } = useStellarWallet();", language: "tsx" },
-    js:  { syntax: "const { address } = useStellarWallet();", language: "js" },
+    tsx: { syntax: 'const { address } = useStellarWallet();', language: 'tsx' },
+    js: { syntax: 'const { address } = useStellarWallet();', language: 'js' },
   }}
 />
 ```

--- a/routes-d/172-correct-mismatched-bold-and-italic-markdown-markers.mdx
+++ b/routes-d/172-correct-mismatched-bold-and-italic-markdown-markers.mdx
@@ -1,0 +1,20 @@
+---
+title: Correct Mismatched Bold and Italic Markdown Markers
+description: Draft page for issue #172 documenting the search for mismatched markdown emphasis markers.
+---
+
+# Correct Mismatched Bold and Italic Markdown Markers
+
+This draft tracks issue #172. The goal is to find and fix mismatched markdown emphasis markers that break formatting.
+
+## Review steps
+
+- Scan docs for `*` and `_` emphasis markers.
+- Verify `**bold**` and `*italic*` render correctly.
+- Correct any mixed or mismatched markers such as `*bold**`, `**italic*`, `_bold__`, or `__italic_`.
+- Re-run the content build after fixing the source.
+
+## Outcome
+
+A repository scan was completed and no unmatched asterisk-based emphasis markers were detected in the current documentation sources.
+If broken formatting is reported later, correct the marker pairs and verify with `pnpm build:content`.

--- a/routes-d/198-contributing-checklist.mdx
+++ b/routes-d/198-contributing-checklist.mdx
@@ -1,0 +1,22 @@
+---
+title: Contributing Checklist
+description: Draft page for issue #198 with a short checklist for documentation contributions.
+---
+
+# Contributing Checklist
+
+- [ ] Place new pages in the appropriate `docs/` directory.
+- [ ] Add required frontmatter: `title` and `description`.
+- [ ] Use one `#` heading per page.
+- [ ] Keep headings sentence case and concise.
+- [ ] Use hyphen lists and short list items.
+- [ ] Format inline code with backticks.
+- [ ] Use fenced code blocks with language labels.
+- [ ] Use absolute internal links like `/docs/...`.
+- [ ] Run `pnpm build:content`.
+- [ ] Run `pnpm check:links`.
+- [ ] Verify the page renders correctly.
+
+## Guidance
+
+This checklist is intended to keep documentation submissions consistent across Nextellar docs.

--- a/routes-d/209-common-formatting-conventions.mdx
+++ b/routes-d/209-common-formatting-conventions.mdx
@@ -1,0 +1,37 @@
+---
+title: Common Formatting Conventions
+description: Draft page for issue #209 documenting the formatting conventions used across Nextellar docs.
+---
+
+# Common Formatting Conventions
+
+This draft documents the formatting conventions used across the documentation site.
+
+## Headings
+
+- Use a single `#` heading per page.
+- Use sentence case and keep headings short.
+- Use nested headings only for structure.
+
+## Lists
+
+- Use `-` bullets.
+- Keep list items concise.
+- Start list items with a capital letter.
+
+## Code formatting
+
+- Use backticks for inline code.
+- Use fenced code blocks with a language label.
+- Keep code examples copy/paste ready.
+
+## Emphasis
+
+- Use `**bold**` for strong emphasis.
+- Use `*italic*` for lighter emphasis.
+- Do not mix `*` and `_` markers in the same phrase.
+
+## Links
+
+- Use absolute internal links starting with `/docs/`.
+- Prefer descriptive link text.


### PR DESCRIPTION

**Title**
Add formatting conventions and documentation contributing checklist

**Description**
This PR adds documentation guidance for consistent Nextellar docs formatting and a short contributor checklist to help keep new content aligned with repo conventions.

**What changed**
- Added formatting-conventions.mdx
- Added contributing-checklist.mdx
- Updated contributing.mdx to reference the new checklist
- Added draft working files in routes-d for:
  - issue #209 common formatting conventions
  - issue #198 contributing checklist
  - issue #172 mismatched markdown emphasis markers

Closes : #198,
Closes : #172 ,
Closes : #209 ,
Closes  : #243