### PR TITLE
docs: add routes-d drafts for issues #332, #333, #334, and #337

### DIFF
--- a/routes-d/332-migration-script-documentation-guide.mdx
+++ b/routes-d/332-migration-script-documentation-guide.mdx
@@ -1,0 +1,193 @@
+---
+title: Writing Migration Script Documentation
+description: Expected structure, template, and testing expectations for migration guides and upgrade scripts in Nextellar docs.
+---
+
+# Writing Migration Script Documentation
+
+Working draft for issue #332 — document how to write clear migration script documentation.
+
+> This draft lives in `routes-d/` per the issue constraint. Contentlayer reads only `docs/`, so this file does not affect `pnpm build:content`.
+
+---
+
+## When to write a migration guide
+
+Publish migration documentation when a release includes any of the following:
+
+- Breaking API or CLI flag changes
+- Renamed environment variables or hooks
+- Minimum Node.js or dependency version bumps
+- Steps that require manual data or config changes
+
+Companion pages already exist for product upgrades; use [Migration Guide](/docs/guides/migration) as the canonical published example. Use this guide when authoring **new** migration content or shell scripts that readers must run.
+
+---
+
+## Expected structure
+
+Use a consistent outline so readers can scan for risk and effort quickly.
+
+| Section                        | Purpose                                                     |
+| ------------------------------ | ----------------------------------------------------------- |
+| **Summary**                    | One paragraph: who is affected, from which version to which |
+| **Prerequisites**              | Node version, package manager, backups, maintenance window  |
+| **Breaking changes**           | Table of old → new behavior with links to reference docs    |
+| **Upgrade steps**              | Numbered commands in order; one action per step             |
+| **Automated migration script** | Optional script path, what it modifies, idempotency note    |
+| **Manual follow-up**           | Steps the script cannot perform                             |
+| **Verification**               | Commands and UI checks that prove success                   |
+| **Rollback**                   | How to revert if upgrade fails                              |
+| **Troubleshooting**            | Common errors with fixes                                    |
+
+### Writing rules
+
+- Use sentence-case headings and a single `#` title per page.
+- Prefer tables for breaking changes; use fenced blocks with language tags for commands.
+- State whether each command is safe to re-run.
+- Never embed secrets, private keys, or real account IDs in examples.
+
+---
+
+## Short template
+
+Copy and adapt this skeleton when opening a new migration doc (published path typically `docs/guides/migration.mdx` or a version-specific page).
+
+````markdown
+---
+title: Migrating to vX.Y
+description: Upgrade from vA.B to vX.Y for Nextellar projects and documentation consumers.
+---
+
+# Migrating to vX.Y
+
+## Summary
+
+This guide covers upgrading from vA.B to vX.Y. Allow approximately N minutes for a typical project.
+
+## Prerequisites
+
+- Node.js >= 20.18.0
+- pnpm installed
+- Git working tree clean (commit or stash changes)
+
+## Breaking changes
+
+| Area     | Before (vA.B) | After (vX.Y)        |
+| -------- | ------------- | ------------------- |
+| CLI flag | `--wallets`   | `--wallet-adapters` |
+| Hook     | `address`     | `publicKey`         |
+
+## Upgrade steps
+
+1. Update the CLI dependency:
+
+   ```bash
+   pnpm add -D nextellar@^X.Y.0
+   ```
+````
+
+2. Run the migration script (optional):
+
+   ```bash
+   node scripts/migrate-to-vXY.mjs
+   ```
+
+3. Search the codebase for deprecated symbols and update call sites.
+
+## Verification
+
+```bash
+pnpm build
+pnpm test:unit
+```
+
+- App starts with `pnpm dev`
+- Wallet connect and one sample transaction still work
+
+## Rollback
+
+```bash
+git checkout -- .
+pnpm install
+```
+
+Restore `package.json` from the previous release tag if dependencies were upgraded.
+
+## Troubleshooting
+
+| Error                | Fix                                       |
+| -------------------- | ----------------------------------------- |
+| `Cannot find module` | Delete `node_modules`, run `pnpm install` |
+
+````
+
+---
+
+## Documenting an automated migration script
+
+When the upgrade includes a script (for example `scripts/migrate-to-v2.mjs`), document:
+
+| Item | What readers need |
+| ---- | ----------------- |
+| **Location** | Path from repository root |
+| **Inputs** | Flags, env vars, config files read |
+| **Side effects** | Files created, renamed, or deleted |
+| **Idempotency** | Safe to run twice or not |
+| **Dry run** | `--dry-run` flag if supported |
+| **Exit codes** | `0` success; non-zero meanings |
+
+Example invocation block:
+
+```bash
+node scripts/migrate-to-v2.mjs --project ./my-app --dry-run
+node scripts/migrate-to-v2.mjs --project ./my-app
+````
+
+Describe each flag in a table below the block.
+
+---
+
+## Testing expectations
+
+Before requesting review on migration documentation:
+
+### Content and links
+
+```bash
+pnpm build:content
+pnpm format:check
+```
+
+### Script accuracy (if applicable)
+
+1. Run the script against a **fresh scaffold** from the prior major version (or a fixture repo).
+2. Run the script a **second time** and confirm idempotent behavior matches what you documented.
+3. Run documented verification commands (`pnpm build`, tests, manual wallet smoke).
+4. Execute rollback steps on a throwaway branch and confirm the app returns to the pre-upgrade state.
+
+### Reader testing
+
+1. Ask another contributor to follow only the guide (no verbal hints).
+2. Note any step that required tribal knowledge; add it to the doc.
+3. Preview the page in the browser (light and dark) after promoting to `docs/`.
+
+### CI alignment
+
+Migration docs should reference the same checks maintainers use in [Testing Documentation Changes](/docs/guides/testing-docs-changes). Release notes should link to the migration page per [Release Notes Workflow](/docs/guides/release-notes-workflow).
+
+---
+
+## Related references
+
+- [Migration Guide](/docs/guides/migration) — published upgrade reference
+- [Versioned Docs Strategy](/docs/guides/versioned-docs-strategy) — when to fork docs by version
+- [Contributing to Documentation](/docs/guides/contributing) — content build and PR workflow
+
+---
+
+## Verification
+
+1. Template and tables render without MDX parse errors.
+2. `pnpm build:content` passes (this draft does not add files under `docs/`).
+3. Internal `/docs/guides/...` links resolve when checked with `pnpm dev` and `pnpm check:links` after promotion.

--- a/routes-d/333-docs-site-slo-definition.mdx
+++ b/routes-d/333-docs-site-slo-definition.mdx
@@ -1,0 +1,119 @@
+---
+title: Documentation Site Service Level Objectives
+description: Target metrics, measurement methods, and response procedures for the Nextellar documentation site.
+---
+
+# Documentation Site Service Level Objectives
+
+Working draft for issue #333 — define service level objectives for the docs site and document them.
+
+> This draft lives in `routes-d/` per the issue constraint. Contentlayer reads only `docs/`, so this file does not affect `pnpm build:content`.
+
+---
+
+## Purpose
+
+These service level objectives (SLOs) describe what “healthy” means for the **Nextellar documentation site** as a reader-facing product. They are documentation-only targets for maintainers and contributors; they do not replace SLAs for the Stellar network, Horizon, or third-party wallets.
+
+---
+
+## Target metrics
+
+| SLO                                | Target                                                    | Measurement window | Error budget (monthly)                      |
+| ---------------------------------- | --------------------------------------------------------- | ------------------ | ------------------------------------------- |
+| **Availability**                   | 99.9% of successful HTTP responses for public docs routes | 30 days            | ~43 minutes downtime                        |
+| **Time to first byte (TTFB)**      | p95 under 800 ms for cached HTML on production            | 30 days            | 5% of requests may exceed                   |
+| **Largest Contentful Paint (LCP)** | p75 under 2.5 s on production (mobile, 4G throttling)     | 30 days            | Track in RUM; no hard penalty for draft PRs |
+| **Build success rate**             | 99% of `main` branch production builds succeed            | 30 days            | 1 failed deploy per ~100 merges             |
+| **Content build on PR**            | 100% of merged docs PRs pass `pnpm build:content` on CI   | Per PR             | Zero merges with broken MDX                 |
+| **Broken internal links**          | Zero known broken sidebar component links at merge        | Per PR             | Fix before merge                            |
+| **Docs incident response**         | Acknowledge sev-1 within 4 business hours                 | Per incident       | Escalate if missed                          |
+
+### Supporting indicators (not SLOs)
+
+- Median time from docs issue opened to first maintainer reply: **5 business days**
+- Search zero-result rate: trending down quarter over quarter (see analytics draft patterns in sibling `routes-d/` work)
+- Number of open `docs` labeled issues: reviewed weekly
+
+---
+
+## Measurement methods
+
+| Metric         | How to measure                                           | Tool / source                                                 |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| Availability   | Synthetic checks every 5 minutes against `/docs` and `/` | Hosting provider uptime (for example Vercel) or external ping |
+| TTFB / LCP     | Real user monitoring on production                       | Vercel Analytics, Plausible, or Lighthouse CI on schedule     |
+| Build success  | CI workflow conclusion on `main`                         | GitHub Actions (or host build logs)                           |
+| Content build  | `pnpm build:content` in PR checks                        | Contributor runs locally; maintainers enforce in review       |
+| Internal links | `pnpm check:links` with `pnpm dev` running               | `scripts/check-links.cjs`                                     |
+| Response time  | Timestamp on incident issue or status page update        | GitHub Issues                                                 |
+
+### Baseline commands (contributors)
+
+From the repository root:
+
+```bash
+pnpm build:content
+pnpm build
+```
+
+Production deploy steps are summarized in [Deployment](/docs/guides/deployment).
+
+### Data retention
+
+- Keep raw uptime and RUM samples for **90 days**.
+- Keep monthly SLO rollups for **12 months**.
+- Do not store wallet addresses or reader PII in docs analytics.
+
+---
+
+## Response procedures
+
+### Severity definitions
+
+| Severity  | Example                                                     | Target response                                               |
+| --------- | ----------------------------------------------------------- | ------------------------------------------------------------- |
+| **Sev-1** | Site returns 5xx for all readers; docs homepage unreachable | Acknowledge within 4 business hours; mitigate ASAP            |
+| **Sev-2** | Major section 404 for all readers; search broken site-wide  | Acknowledge within 1 business day; fix within 3 business days |
+| **Sev-3** | Single page broken formatting; broken external link         | Normal issue triage via GitHub                                |
+| **Sev-4** | Typo or outdated snippet                                    | Docs PR workflow                                              |
+
+### Sev-1 playbook (site down)
+
+1. Confirm the outage (synthetic check + manual load of production URL).
+2. Open a GitHub issue labeled `incident` and `docs` with start time and symptoms.
+3. Check latest deploy on `main`; if the deploy correlates with failure, roll back per [Deployment and Rollback Runbook](/docs/guides/deployment) procedures (draft in `routes-d/247-deployment-rollback-runbook.mdx` until promoted).
+4. Post status in the issue until HTTP 200 is restored.
+5. Write a short post-incident note: cause, duration, and preventive action (for example add CI check).
+
+### Sev-2 playbook (major feature broken)
+
+1. Reproduce in Chrome and one secondary browser (see `routes-d/334-browser-support-matrix.mdx`).
+2. Bisect recent merges to `main`.
+3. Ship a fix or revert via pull request; run full build checklist from [Testing Documentation Changes](/docs/guides/testing-docs-changes).
+
+### When SLO error budget is exhausted
+
+If availability drops below 99.9% in a calendar month:
+
+1. Pause non-urgent docs feature work for one week.
+2. Prioritize reliability tasks: CI hardening, caching, rollback drills.
+3. Review SLO targets with maintainers at the next monthly docs sync.
+
+---
+
+## Roles
+
+| Role                | Responsibility                                                |
+| ------------------- | ------------------------------------------------------------- |
+| **Docs maintainer** | Owns SLO review, approves deploys, triages sev-1/2            |
+| **Contributor**     | Runs `build:content` and link checks before requesting review |
+| **Hosting admin**   | Restores service, provides deploy logs                        |
+
+---
+
+## Verification
+
+1. Confirm metric tables render in MDX (no unescaped JSX issues).
+2. Run `pnpm build:content` — should pass unchanged because this file is outside `docs/`.
+3. Validate internal links in this draft point to existing guides under `/docs/guides/...`.

--- a/routes-d/334-browser-support-matrix.mdx
+++ b/routes-d/334-browser-support-matrix.mdx
@@ -1,0 +1,97 @@
+---
+title: Browser Support Matrix
+description: Supported browsers and versions for the Nextellar documentation site, known issues, and how compatibility is tested.
+---
+
+# Browser Support Matrix
+
+Working draft for issue #334 — publish a browser support matrix for the docs site.
+
+> This draft lives in `routes-d/` per the issue constraint. Contentlayer reads only `docs/`, so this file does not affect `pnpm build:content`.
+
+---
+
+## Scope
+
+This matrix applies to **readers of the documentation site** (for example [docs.nextellar.dev](https://docs.nextellar.dev)) and to **local preview** at `http://localhost:3000` when running `pnpm dev`. It does not define support for wallet extensions or dApps built with the Nextellar CLI; see [Supported Wallets](/docs/integrations/wallets) for wallet-specific behavior.
+
+The site is a **Next.js 16** application with **React 19**, client-side search, theme toggling, and MDX-rendered content. Support targets **evergreen desktop and mobile browsers** that run current ECMAScript and CSS features used by Next.js and Tailwind CSS v4.
+
+---
+
+## Supported browsers
+
+| Browser                       | Minimum supported versions  | Support tier |
+| ----------------------------- | --------------------------- | ------------ |
+| **Google Chrome**             | Last two major releases     | Full         |
+| **Mozilla Firefox**           | Last two major releases     | Full         |
+| **Apple Safari** (macOS)      | Last two major releases     | Full         |
+| **Safari** (iOS)              | Last two major iOS releases | Full         |
+| **Microsoft Edge** (Chromium) | Last two major releases     | Full         |
+| **Samsung Internet**          | Last two major releases     | Best effort  |
+
+### Not supported
+
+| Environment                       | Notes                                                            |
+| --------------------------------- | ---------------------------------------------------------------- |
+| Internet Explorer 11              | Not supported by Next.js 16                                      |
+| Legacy Edge (non-Chromium)        | Not supported                                                    |
+| Browsers with JavaScript disabled | Search, theme toggle, and some MDX components require JavaScript |
+| End-of-life browser versions      | Security patches no longer provided by the vendor                |
+
+---
+
+## Known issues by browser
+
+| Browser                  | Known issue                                                        | Impact                                  | Mitigation                                                                                             |
+| ------------------------ | ------------------------------------------------------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Safari (macOS / iOS)** | Occasional layout shift when toggling dark mode during navigation  | Cosmetic                                | Refresh the page                                                                                       |
+| **Firefox**              | `backdrop-filter` on overlays may render differently than Chromium | Minor visual difference                 | None required for docs readability                                                                     |
+| **Mobile Safari**        | Virtual keyboard can obscure the bottom of long code blocks        | UX on small screens                     | Scroll the page after focusing inputs                                                                  |
+| **All**                  | Wallet extension popups (Freighter, etc.) are third-party          | Not a docs-site defect                  | Document in integration guides, not this matrix                                                        |
+| **All**                  | Very slow networks                                                 | Long time to interactive on first visit | Normal for static + JS hydration; see [Offline Reading](/docs/guides/offline-reading) for alternatives |
+
+If a page fails only in one browser, capture the browser version, OS, and console errors when filing a docs issue.
+
+---
+
+## Testing approach
+
+### Manual smoke testing (required for UI-affecting PRs)
+
+1. Run `pnpm install`, `pnpm build:content`, and `pnpm dev`.
+2. Open `http://localhost:3000/docs` in each target browser (or use browser devtools device emulation for mobile).
+3. Verify:
+   - Sidebar navigation and internal links
+   - Light and dark theme toggle
+   - Cmd/Ctrl+K search dialog opens and returns results
+   - Code blocks and tables render without horizontal overflow on a 375px-wide viewport
+4. Spot-check changed pages listed in the pull request.
+
+Document results in the PR test plan (browser + version).
+
+### Automated and CI checks
+
+| Check              | What it validates                   | Browser involved                               |
+| ------------------ | ----------------------------------- | ---------------------------------------------- |
+| `pnpm build`       | Production bundle compiles          | Node only                                      |
+| `pnpm check:links` | HTTP 200 for sidebar component URLs | Whatever hosts `localhost:3000` during the run |
+| `pnpm test:unit`   | Vitest + jsdom for selected units   | Simulated DOM, not a real browser              |
+
+Screenshot workflows that use Playwright are described in [Screenshot Workflow](/docs/guides/screenshot-workflow). Use Playwright when validating visual regressions; use the matrix above for reader-facing compatibility expectations.
+
+### Release verification
+
+After deployment to production:
+
+1. Load the homepage and one changed docs path in Chrome and Safari.
+2. Confirm no console errors on first load.
+3. Confirm theme toggle and search still work.
+
+---
+
+## Verification
+
+1. Read through the tables above in a local MDX preview or after promoting the page to `docs/`.
+2. Run `pnpm build:content` from the repo root (unchanged by this `routes-d/` draft).
+3. For link validation workflow, see [Testing Documentation Changes](/docs/guides/testing-docs-changes).

--- a/routes-d/337-husky-lint-staged-interplay.mdx
+++ b/routes-d/337-husky-lint-staged-interplay.mdx
@@ -1,0 +1,134 @@
+---
+title: Husky and lint-staged Interplay
+description: How Git pre-commit hooks and staged-file formatting work together in the Nextellar docs repository.
+---
+
+# Husky and lint-staged Interplay
+
+Working draft for issue #337 — explain how Husky and lint-staged work together in this project.
+
+> This draft lives in `routes-d/` per the issue constraint. Contentlayer reads only `docs/`, so this file does not affect `pnpm build:content`.
+
+---
+
+## Overview
+
+The repository uses **Husky** to install Git hooks and **lint-staged** to run commands only on files you have staged for commit. Together they keep formatting consistent without running Prettier on the entire tree on every commit.
+
+| Tool            | Role in this repo                                                  |
+| --------------- | ------------------------------------------------------------------ |
+| **Husky**       | Wires the `pre-commit` hook to run when you run `git commit`       |
+| **lint-staged** | Reads staged paths and runs the matching tasks from `package.json` |
+
+Husky does not format files itself. It delegates to lint-staged, which in turn runs Prettier on the staged paths that match its glob patterns.
+
+---
+
+## How they connect
+
+### 1. Install time (`prepare`)
+
+After `pnpm install`, the `prepare` script runs Husky:
+
+```json
+"prepare": "husky"
+```
+
+This registers hooks from the `.husky/` directory so Git knows to run them on commit.
+
+### 2. Pre-commit hook
+
+`.husky/pre-commit` contains a single command:
+
+```bash
+pnpm lint-staged
+```
+
+When you commit, Git runs that script before the commit is created.
+
+### 3. lint-staged configuration
+
+`package.json` defines what runs on staged files:
+
+```json
+"lint-staged": {
+  "*.{js,jsx,ts,tsx,json,css,md,mdx}": [
+    "prettier --write"
+  ]
+}
+```
+
+For each staged file that matches the glob, lint-staged runs `prettier --write`. Prettier reformats the file in place; you may need to `git add` again if the hook modified files (lint-staged usually re-stages them automatically).
+
+### End-to-end flow
+
+```text
+git commit
+  → .husky/pre-commit
+    → pnpm lint-staged
+      → prettier --write (per staged *.js, *.ts, *.mdx, …)
+  → commit completes (if hook exits 0)
+```
+
+---
+
+## Commands triggered
+
+| When            | Command                   | What runs                         |
+| --------------- | ------------------------- | --------------------------------- |
+| `pnpm install`  | `husky` (via `prepare`)   | Installs Git hooks from `.husky/` |
+| `git commit`    | `pnpm lint-staged`        | Prettier on staged matching files |
+| Per staged file | `prettier --write <file>` | Formats that file only            |
+
+What is **not** run on pre-commit:
+
+- `pnpm build:content`
+- `pnpm lint`
+- `pnpm check:links`
+
+Run those manually before opening a pull request. See [Testing Documentation Changes](/docs/guides/testing-docs-changes).
+
+---
+
+## Common failures
+
+| Symptom                               | Likely cause                              | What to do                                                       |
+| ------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| Hook never runs                       | Husky not installed (`prepare` skipped)   | Run `pnpm install` from the repo root                            |
+| `lint-staged: command not found`      | Dependencies missing                      | Run `pnpm install`                                               |
+| Commit blocked after Prettier changes | Formatter updated staged content          | Review the diff, `git add` updated files, commit again           |
+| Only some files formatted             | lint-staged runs on **staged** files only | Stage all files you intend to commit (`git add`)                 |
+| MDX still fails `build:content`       | Prettier does not validate MDX structure  | Run `pnpm build:content` locally                                 |
+| Intentional skip                      | `git commit --no-verify`                  | Avoid unless maintainers agree; CI may still fail `format:check` |
+
+If formatting fails in CI but passed locally, run:
+
+```bash
+pnpm format:check
+pnpm format
+```
+
+Then stage and commit the result.
+
+---
+
+## Related checks before a PR
+
+Pre-commit formatting complements, but does not replace, docs validation:
+
+```bash
+pnpm build:content
+pnpm format:check
+pnpm check:links   # requires pnpm dev in another terminal
+```
+
+For performance tips while iterating, see [Docs Build Performance Tips](/docs/guides/docs-build-performance-tips).
+
+---
+
+## Verification
+
+1. Confirm `.husky/pre-commit` exists and calls `pnpm lint-staged`.
+2. Stage a small formatting change in an `.mdx` file under `routes-d/` or `docs/`.
+3. Run `git commit` and confirm Prettier runs on the staged file.
+4. Preview this draft locally if needed (file is outside Contentlayer; open the raw MDX or copy into a scratch page under `docs/` for a full render check).


### PR DESCRIPTION
closes #337 
closes #334 
closes #333 
closes #332 

## Summary

Adds four documentation drafts under `routes-d/`, scoped to the Stellar Wave issues. Contentlayer only reads `docs/`, so these drafts do not affect the production docs build.

| Issue | Title | Draft file |
| ----- | ----- | ---------- |
| #337 | Document the husky lint-staged interplay | `routes-d/337-husky-lint-staged-interplay.mdx` |
| #334 | Add a section on browser support matrix | `routes-d/334-browser-support-matrix.mdx` |
| #333 | Add a complete docs SLO definition | `routes-d/333-docs-site-slo-definition.mdx` |
| #332 | Add a guide on writing migration script docs | `routes-d/332-migration-script-documentation-guide.mdx` |

### #337 — Husky and lint-staged

- Describes how `prepare` → Husky → `.husky/pre-commit` → `lint-staged` → Prettier connect
- Lists commands triggered on install and commit
- Documents common failures and what is not run on pre-commit
- Links to existing testing and performance guides

### #334 — Browser support matrix

- Lists supported browsers and minimum versions (evergreen, last two major releases)
- Notes known issues per browser and out-of-scope environments (IE11, JS disabled)
- Describes manual smoke testing, CI checks, and post-deploy verification

### #333 — Docs site SLOs

- Proposes target metrics (availability, TTFB, LCP, build success, link checks, incident response)
- Documents measurement methods and data retention
- Defines severity levels and response playbooks

### #332 — Migration script documentation

- Defines expected structure for migration guides
- Includes a copy-paste template
- Documents testing expectations for scripts and reader validation
- Links to published `/docs/guides/migration` and related guides

## Constraints met

- Documentation-only changes
- Drafts placed in `routes-d/` and named by issue number
- MDX frontmatter (`title`, `description`) matches existing `routes-d/` style

## Test plan

- [x] `pnpm build:content` — passes
- [x] `pnpm prettier --write` on the four new files
- [ ] `pnpm dev` + `pnpm check:links` (optional; drafts are outside `docs/` and are not indexed by Contentlayer)
- [ ] Maintainer review of content accuracy and tone

