### PR TITLE
docs: fix encoding corruption in integrations documentation

### DIFF
--- a/docs/integrations/horizon.mdx
+++ b/docs/integrations/horizon.mdx
@@ -134,10 +134,10 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon.stellar.org
 NEXT_PUBLIC_NETWORK=PUBLIC
 ```
 
-````tsx
+```tsx
 // Access in your app
 const horizonUrl = process.env.NEXT_PUBLIC_HORIZON_URL;
-```css
+```
 
 ## Error Handling
 
@@ -157,7 +157,7 @@ const { error, refresh } = useStellarBalances(publicKey);
 if (error?.message.includes('404')) {
   return <p>Account not funded yet</p>;
 }
-````
+```
 
 ## Rate Limiting
 
@@ -167,11 +167,11 @@ Stellar's public Horizon servers have rate limits. For production:
 2. **Consider self-hosting** - Run your own Horizon instance
 3. **Use caching** - Implement client-side caching
 
-````tsx
+```tsx
 const { balances } = useStellarBalances(publicKey, {
   pollIntervalMs: 15000, // Poll every 15 seconds
 });
-```typescript
+```
 
 ## Related
 
@@ -180,4 +180,3 @@ const { balances } = useStellarBalances(publicKey, {
 - [useStellarBalances](/docs/hooks/use-stellar-balances) - Balance fetching hook
 - [useStellarPayment](/docs/hooks/use-stellar-payment) - Payment transactions
 - [useTransactionHistory](/docs/hooks/use-transaction-history) - Transaction queries
-````

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -88,7 +88,7 @@ Nextellar integrations are powered by these libraries:
 
 ## Architecture Overview
 
-````
+```text
 
                   Your Application
 
@@ -105,8 +105,7 @@ WalletConnectButton            useStellarWallet
 
                  Stellar Network
        Horizon API            Soroban RPC
-�
-```typescript
+```
 
 ---
 
@@ -128,7 +127,7 @@ export default function RootLayout({ children }) {
     </WalletProvider>
   );
 }
-````
+```
 
 ### 2. Use Pre-built Components
 
@@ -156,7 +155,7 @@ function Dashboard() {
 
 ### 4. Interact with Smart Contracts
 
-````tsx
+```tsx
 import { useSorobanContract } from '@/hooks/useSorobanContract';
 
 function TokenBalance({ contractId }) {
@@ -167,7 +166,7 @@ function TokenBalance({ contractId }) {
     console.log('Token balance:', balance);
   };
 }
-```typescript
+```
 
 ---
 
@@ -185,4 +184,3 @@ function TokenBalance({ contractId }) {
 - [SDK Overview](/docs/sdk/overview) - Full SDK documentation
 - [Hooks Reference](/docs/hooks) - All 8 production hooks
 - [Components](/docs/components/connect-wallet-button) - UI components
-````

--- a/docs/integrations/soroban.mdx
+++ b/docs/integrations/soroban.mdx
@@ -108,12 +108,12 @@ const result = await submitTransaction(signedXdr);
 
 For testing only - sign with secret key:
 
-````tsx
+```tsx
 const { submitInvokeWithSecret } = useSorobanContract({ contractId });
 
 // DEV ONLY - Never use in production!
 const result = await submitInvokeWithSecret(xdr, 'SABC123...');
-```css
+```
 
 ## Type Conversion
 
@@ -131,11 +131,11 @@ The hook automatically converts between JavaScript and Soroban types:
 ```tsx
 // Automatic conversion
 await callFunction('transfer', [
-  'GABC...', // �ScvAddress
-  1000, // �ScvI128
-  true, // �ScvBool
+  'GABC...', // -> ScvAddress
+  1000, // -> ScvI128
+  true, // -> ScvBool
 ]);
-````
+```
 
 ## Configuration
 
@@ -227,11 +227,11 @@ try {
 
 ## Environment Variables
 
-````bash
+```bash
 # .env.local
 NEXT_PUBLIC_SOROBAN_RPC=https://soroban-rpc.stellar.org
 NEXT_PUBLIC_NETWORK=PUBLIC
-```bash
+```
 
 ## Related
 
@@ -240,4 +240,3 @@ NEXT_PUBLIC_NETWORK=PUBLIC
 - [useSorobanContract](/docs/hooks/use-soroban-contract) - Full hook documentation
 - [useSorobanEvents](/docs/hooks/use-soroban-events) - Event listening hook
 - [Stellar Horizon](/docs/integrations/horizon) - Standard Stellar operations
-````

--- a/docs/integrations/testing.mdx
+++ b/docs/integrations/testing.mdx
@@ -23,9 +23,9 @@ This guide covers how to add MSW to your Nextellar project for testing Stellar A
 
 ### 1. Install MSW
 
-````bash
+```bash
 npm install msw --save-dev
-```typescript
+```
 
 ### 2. Create Mock Handlers
 
@@ -68,7 +68,7 @@ export const handlers = [
     return new HttpResponse(null, { status: 404 });
   }),
 ];
-```typescript
+```
 
 ### 3. Create Server Setup
 
@@ -79,7 +79,7 @@ import { setupServer } from 'msw/node';
 import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);
-```typescript
+```
 
 ### 4. Configure Jest
 
@@ -91,7 +91,7 @@ import { server } from './src/mocks/server';
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
-````
+```
 
 ## Example Test
 
@@ -207,13 +207,13 @@ import { handlers } from './handlers';
 export const worker = setupWorker(...handlers);
 ```
 
-````typescript
+```typescript
 // Start in development
 if (process.env.NODE_ENV === 'development') {
   const { worker } = await import('./mocks/browser');
   await worker.start();
 }
-```typescript
+```
 
 ## Related
 
@@ -223,4 +223,3 @@ if (process.env.NODE_ENV === 'development') {
 - [MSW Documentation](https://mswjs.io/docs)
 - [Stellar Horizon](/docs/integrations/horizon) - APIs to mock
 - [Soroban](/docs/integrations/soroban) - Smart contract testing
-````

--- a/docs/integrations/walletconnect.mdx
+++ b/docs/integrations/walletconnect.mdx
@@ -103,10 +103,10 @@ stellar_wallet_name: 'Freighter';
 
 Pre-built button component with loading states and theme support:
 
-````tsx
+```tsx
 <WalletConnectButton theme="light" />
 <WalletConnectButton theme="dark" />
-```json
+```
 
 [Full component documentation](/docs/components/connect-wallet-button)
 
@@ -118,7 +118,7 @@ Context provider for global wallet state:
 <WalletProvider horizonUrl="https://horizon.stellar.org" network="PUBLIC">
   <App />
 </WalletProvider>
-```json
+```
 
 [Full provider documentation](/docs/hooks/wallet-provider)
 
@@ -137,7 +137,7 @@ interface WalletState {
   refreshBalances: () => Promise<void>;
   sendPayment?: (opts) => Promise<TransactionResponse>;
 }
-```typescript
+```
 
 ## Supported Wallets
 
@@ -162,7 +162,7 @@ const kit = new StellarWalletsKit({
     new xBullModule(), // Add new wallet
   ],
 });
-````
+```
 
 ## Error Handling
 

--- a/docs/integrations/wallets.mdx
+++ b/docs/integrations/wallets.mdx
@@ -141,7 +141,7 @@ const { signedTxXdr } = await kit.signTransaction(unsignedXdr, {
 
 Most hooks handle signing internally:
 
-````tsx
+```tsx
 const { sendPayment } = useWallet();
 
 // sendPayment automatically builds, prompts wallet for signing, and submits
@@ -150,7 +150,7 @@ await sendPayment({
   amount: '10',
   asset: 'XLM',
 });
-```typescript
+```
 
 ## Adding More Wallets
 
@@ -175,7 +175,7 @@ const kit = new StellarWalletsKit({
     new xBullModule(), // Add to array
   ],
 });
-````
+```
 
 ## Network Configuration
 
@@ -257,7 +257,7 @@ try {
 
 The `useWallet` hook provides:
 
-````typescript
+```typescript
 interface WalletState {
   connected: boolean; // Is wallet connected?
   publicKey?: string; // Stellar G-address
@@ -268,7 +268,7 @@ interface WalletState {
   refreshBalances: () => Promise<void>;
   sendPayment?: (opts) => Promise<TransactionResponse>;
 }
-```json
+```
 
 ## Freighter-Specific Notes
 
@@ -286,4 +286,3 @@ Freighter is the most popular Stellar wallet. Some specific notes:
 - [WalletProvider](/docs/hooks/wallet-provider) - Context provider docs
 - [useStellarWallet](/docs/hooks/use-stellar-wallet) - Standalone hook docs
 - [Wallet Integration Guide](/docs/sdk/wallet-integration) - Advanced setup
-````


### PR DESCRIPTION
## Summary
- Clean up malformed code fences in the integrations documentation
- Remove visible replacement characters from the integrations overview and Soroban examples
- Preserve code samples while restoring readable MDX formatting

## Validation
- pnpm build:content
- rg -n '�|Ã|Â|â|```css|```json|````' docs/integrations

Closes #131
