### PR TITLE
docs: document telemetry command and flags

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -213,6 +213,43 @@ nextellar doctor --json
 
 The command exits with code `0` when all required checks pass, or `1` when one or more required checks fail. Optional check failures are reported but do not affect the exit code.
 
+### nextellar telemetry
+
+Manage anonymous telemetry settings for the local environment.
+
+```bash
+nextellar telemetry <action>
+```
+
+**Arguments:**
+
+| Argument | Type   | Required | Description                                  |
+| -------- | ------ | -------- | -------------------------------------------- |
+| `action` | string | Yes      | One of `status`, `enable`, or `disable`      |
+
+**Actions:**
+
+| Action    | Description                                                        |
+| --------- | ------------------------------------------------------------------ |
+| `status`  | Show whether telemetry is enabled and where the config is stored   |
+| `enable`  | Enable anonymous telemetry and save the preference locally         |
+| `disable` | Disable anonymous telemetry and save the preference locally        |
+
+**Examples:**
+
+```bash
+# Check the current telemetry setting
+nextellar telemetry status
+
+# Enable telemetry
+nextellar telemetry enable
+
+# Disable telemetry
+nextellar telemetry disable
+```
+
+If `NEXTELLAR_TELEMETRY_DISABLED` is set, the status output reports that telemetry is forced off for the current environment.
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -23,6 +23,7 @@ Use the table below to find the exact flag name, alias, default, and a short des
 | Installation | `--package-manager <pm>` |       | Auto-detected                         | Choose `npm`, `yarn`, or `pnpm` for install.                                 |
 | Installation | `--install-timeout <ms>` |       | `1200000`                             | Set dependency install timeout in milliseconds.                              |
 | Automation   | `--defaults`             | `-d`  | `false`                               | Skip prompts and use default settings.                                       |
+| Telemetry    | `--no-telemetry`         |       | `false`                               | Disable telemetry for the current scaffold invocation.                       |
 | Feature Add  | `--list`                 | `-l`  | `false`                               | List available features for `nextellar add`.                                 |
 | Feature Add  | `--force`                | `-f`  | `false`                               | Force feature addition, overwriting existing files.                          |
 | Deployment   | `--dry-run`              |       | `false`                               | Validate deployment without creating a final bundle.                         |
@@ -47,6 +48,12 @@ Deployment options are used with `nextellar deploy`:
 
 ```bash
 nextellar deploy --dry-run
+```
+
+Telemetry can be disabled for a single scaffold command:
+
+```bash
+npx nextellar my-app --no-telemetry
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- Add documentation for `nextellar telemetry status`, `enable`, and `disable`
- Explain the local telemetry preference behavior and environment override
- Add the scaffold `--no-telemetry` flag to the CLI flags reference

## Validation
- pnpm build:content
- rg -n 'nextellar telemetry (status|enable|disable)|--no-telemetry|NEXTELLAR_TELEMETRY_DISABLED' docs/cli/commands.mdx docs/cli/flags.mdx

Closes #137
