### PR TITLE
docs: add upgrade command documentation

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -213,6 +213,36 @@ nextellar doctor --json
 
 The command exits with code `0` when all required checks pass, or `1` when one or more required checks fail. Optional check failures are reported but do not affect the exit code.
 
+### nextellar upgrade
+
+Upgrade an existing Nextellar project to the latest template files.
+
+```bash
+nextellar upgrade [options]
+```
+
+Run this command from the root of an existing Nextellar project. Use a dry run first to review the files that would change, then run the upgrade when you are ready to apply updates.
+
+**Options:**
+
+| Option      | Description                                           |
+| ----------- | ----------------------------------------------------- |
+| `--dry-run` | Show what would change without applying the upgrade   |
+| `--yes`     | Apply changes without prompting for confirmation      |
+
+**Examples:**
+
+```bash
+# Preview upgrade changes
+nextellar upgrade --dry-run
+
+# Apply the upgrade interactively
+nextellar upgrade
+
+# Apply the upgrade without prompting
+nextellar upgrade --yes
+```
+
 ### nextellar deploy
 
 Validate and prepare your project for production deployment. This command checks that your Horizon and Soroban RPC endpoints are properly configured, and builds a optimized production bundle of your Stellar dApp.

--- a/docs/cli/options.mdx
+++ b/docs/cli/options.mdx
@@ -244,6 +244,38 @@ nextellar add freighter -f
 
 ---
 
+## Upgrade Options
+
+The following options apply to the `nextellar upgrade` command:
+
+### --dry-run
+
+Show which template files would change without applying the upgrade.
+
+```bash
+nextellar upgrade --dry-run
+```
+
+**Default:** `false`
+**Type:** Boolean
+**Status:** Supported
+
+---
+
+### --yes
+
+Apply upgrade changes without prompting for confirmation.
+
+```bash
+nextellar upgrade --yes
+```
+
+**Default:** `false`
+**Type:** Boolean
+**Status:** Supported
+
+---
+
 ## Deployment Options
 
 The following options apply to the `nextellar deploy` command:


### PR DESCRIPTION
## Summary
- Add `nextellar upgrade` to the CLI command reference
- Document the `--dry-run` and `--yes` upgrade options
- Include the basic preview-then-apply workflow with CLI examples

## Validation
- pnpm build:content
- rg -n 'nextellar upgrade( --dry-run| --yes)?|--yes|Upgrade Options' docs/cli/commands.mdx docs/cli/options.mdx

Closes #138
