### PR TITLE
docs: update CLI docs for interactive prompting

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -325,9 +325,11 @@ Increases installation timeout to 1 hour (useful for slow networks).
 
 ## Interactive Mode
 
-Currently, Nextellar runs in non-interactive mode. All configuration is done via CLI flags.
+Nextellar can prompt for scaffold configuration when it runs in a suitable interactive terminal.
 
-**Future Enhancement:** Interactive prompts for configuration (coming soon).
+Prompts are shown when standard input and output are both TTYs, the `CI` environment variable is not set, and `--defaults` is not provided. If any of those conditions are not met, the CLI uses provided flags and default values instead.
+
+Flags still take precedence over prompts. For example, passing `--wallets`, `--horizon-url`, `--soroban-url`, `--package-manager`, or `--skip-install` keeps those values fixed and skips prompting for that setting.
 
 ## Command Aliases
 

--- a/docs/cli/options.mdx
+++ b/docs/cli/options.mdx
@@ -207,7 +207,7 @@ nextellar my-app -d
 - Quick testing
 - Non-interactive environments
 
-> **Note:** Currently, Nextellar doesn't have interactive prompts, so this flag is reserved for future use.
+> **Note:** In an interactive terminal, Nextellar can prompt for scaffold configuration. Use `--defaults` to skip prompts and apply default values instead.
 
 ## Feature Add Options
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -44,6 +44,12 @@ The Nextellar CLI works with all standard terminal emulators:
 - Terminal color output requires ANSI support (most modern terminals support this)
 - Interactive prompts work best in terminals with full UTF-8 support
 
+### Interactive Prompting
+
+When the CLI runs in a suitable terminal, it can prompt for scaffold settings such as project configuration, network endpoints, wallet adapters, package manager, and whether to skip dependency installation.
+
+Prompting is enabled only when standard input and output are both TTYs, the `CI` environment variable is not set, and `--defaults` is not provided. In CI, scripted, or redirected environments, Nextellar uses explicit flags and default values instead. Any flag you pass keeps that setting fixed and skips prompting for it.
+
 ### Method 1: npx (Recommended)
 
 No installation required. Run directly:


### PR DESCRIPTION
## Summary
- Replace outdated non-interactive CLI wording with the current prompting behavior
- Explain when prompts appear and when the CLI falls back to flags/defaults
- Clarify that explicit flags keep individual scaffold settings fixed

## Validation
- pnpm build:content
- rg -n 'non-interactive mode|doesn.t have interactive prompts|Future Enhancement|coming soon' docs/cli/commands.mdx docs/cli/options.mdx docs/cli/overview.mdx
- rg -n 'suitable interactive terminal|standard input and output are both TTYs|--defaults' docs/cli/commands.mdx docs/cli/options.mdx docs/cli/overview.mdx

Closes #142
