### PR TITLE
docs: add glossary entries, federation note, Friendbot limits, ledger streaming guide

### DIFF
--- a/routes-d/458-glossary-stroop-validator.md
+++ b/routes-d/458-glossary-stroop-validator.md
@@ -1,0 +1,28 @@
+---
+title: "Glossary: Stroop and Validator"
+description: Short definitions for Stroop and Validator as used in the Stellar network and Nextellar docs
+---
+
+# Glossary: Stroop and Validator
+
+Two terms you will see frequently when working with Stellar fees and network consensus.
+
+---
+
+## Stroop
+
+The smallest unit of XLM, equal to one ten-millionth (0.0000001 XLM).
+
+Stellar denominated fees and minimum balances in stroops. For example, the base transaction fee is 100 stroops (0.00001 XLM). When reading fee fields from Horizon, values are returned in stroops.
+
+**Related:** `base_fee`, transaction fee, XLM
+
+---
+
+## Validator
+
+A node that participates in the Stellar Consensus Protocol (SCP) to agree on which transactions are valid and in what order they are applied to the ledger.
+
+Each validator operates independently and casts votes. A transaction reaches finality when a quorum of validators agrees. Nextellar apps connect to Horizon, which itself relies on a network of validators running in the background.
+
+**Related:** Horizon, quorum, Stellar Consensus Protocol (SCP), ledger

--- a/routes-d/464-federation-address-resolution.md
+++ b/routes-d/464-federation-address-resolution.md
@@ -1,0 +1,49 @@
+---
+title: Stellar Address Resolution via Federation
+description: How Stellar federation maps human-readable addresses to public keys
+---
+
+# Stellar Address Resolution via Federation
+
+Federation is a Stellar protocol that lets users share a short, human-readable address instead of a long public key.
+
+---
+
+## Address Format
+
+A federated address looks like an email address:
+
+```
+alice*example.com
+```
+
+The part before `*` is the user identifier and the part after is the domain hosting the federation server.
+
+---
+
+## How Lookups Work
+
+1. The client queries the domain's `stellar.toml` file to find the federation server URL.
+2. It sends an HTTP GET request to that server with the address as a parameter.
+3. The server responds with the Stellar public key (and optionally a memo) linked to that address.
+
+```
+GET https://federation.example.com/?q=alice*example.com&type=name
+```
+
+A successful response returns the account ID:
+
+```json
+{
+  "stellar_address": "alice*example.com",
+  "account_id": "GABC...XYZ"
+}
+```
+
+---
+
+## Using Federation in Nextellar
+
+Pass the resolved `account_id` wherever a public key is required. Nextellar does not resolve federated addresses automatically — perform the lookup before calling hooks like `useStellarPayment`.
+
+**Related:** [Horizon Integration](/docs/integrations/horizon), [Wallets](/docs/integrations/wallets)

--- a/routes-d/465-friendbot-rate-limits.md
+++ b/routes-d/465-friendbot-rate-limits.md
@@ -1,0 +1,49 @@
+---
+title: Friendbot Rate Limits
+description: Known rate limits for the Stellar Friendbot testnet funding service and how to handle them
+---
+
+# Friendbot Rate Limits
+
+Friendbot is a Stellar testnet service that creates and funds accounts with free test XLM. Because it is a shared public resource, it enforces rate limits to prevent abuse.
+
+---
+
+## Typical Limits
+
+Friendbot does not publish an exact rate limit, but in practice you should expect:
+
+- **One request per account** — funding the same address a second time returns an error because the account already exists.
+- **Throttling under load** — during heavy testnet usage, requests may be delayed or rejected with a `429 Too Many Requests` response.
+
+---
+
+## Common Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `400 Bad Request` | The account already exists on testnet. |
+| `429 Too Many Requests` | You have hit the rate limit. Wait before retrying. |
+| `500 Internal Server Error` | Transient Friendbot issue. Retry after a short delay. |
+
+---
+
+## Retry Suggestion
+
+Use exponential backoff when automating Friendbot calls in test scripts:
+
+```js
+async function fundAccount(publicKey, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(
+      `https://friendbot.stellar.org?addr=${publicKey}`
+    );
+    if (res.ok) return await res.json();
+    if (res.status === 400) break; // account already exists, no point retrying
+    await new Promise((r) => setTimeout(r, 1000 * 2 ** i));
+  }
+  throw new Error("Friendbot funding failed");
+}
+```
+
+**Related:** [Horizon Integration](/docs/integrations/horizon), [Testing](/docs/integrations/testing)

--- a/routes-d/481-latest-ledger-streaming.md
+++ b/routes-d/481-latest-ledger-streaming.md
@@ -1,0 +1,69 @@
+---
+title: Latest Ledger Streaming
+description: How to subscribe to the Stellar latest-ledger stream via Horizon SSE and handle reconnects
+---
+
+# Latest Ledger Streaming
+
+Horizon exposes a server-sent events (SSE) endpoint that pushes a message every time a new ledger closes on the Stellar network. Use it to stay in sync with the chain without polling.
+
+---
+
+## Subscription Setup
+
+Call the `/ledgers` endpoint with `cursor=now` to receive only ledgers that close after you connect:
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon-testnet.stellar.org");
+
+const close = server
+  .ledgers()
+  .cursor("now")
+  .stream({
+    onmessage: (ledger) => {
+      console.log("New ledger:", ledger.sequence, ledger.closed_at);
+    },
+    onerror: (err) => {
+      console.error("Stream error:", err);
+    },
+  });
+
+// Call close() to stop listening
+```
+
+---
+
+## Reconnect Behavior
+
+The Stellar SDK automatically reconnects when the SSE connection drops. On reconnect it resumes from the last received ledger sequence, so no ledgers are skipped. If you manage the connection manually, store the last `sequence` value and pass it as the new cursor:
+
+```js
+let lastSequence = "now";
+
+function startStream() {
+  return server
+    .ledgers()
+    .cursor(lastSequence)
+    .stream({
+      onmessage: (ledger) => {
+        lastSequence = ledger.sequence;
+        // process ledger ...
+      },
+      onerror: () => {
+        setTimeout(startStream, 2000); // manual reconnect after 2 s
+      },
+    });
+}
+```
+
+---
+
+## Notes
+
+- Each ledger closes roughly every **5 seconds** on Mainnet and Testnet.
+- The `cursor=now` value tells Horizon to skip historical ledgers and start from the current tip.
+- Long-lived streams will eventually be interrupted by network conditions; always handle `onerror`.
+
+**Related:** [Horizon Integration](/docs/integrations/horizon), [Glossary](/docs/guides/glossary)


### PR DESCRIPTION
## Summary

- **#458 — Glossary: Stroop and Validator** — Added definitions for Stroop (smallest XLM unit, 0.0000001 XLM) and Validator (SCP consensus node) with related term links.
- **#464 — Federation address resolution** — Explains the `user*domain.com` format, the two-step lookup flow (stellar.toml → federation server), and example response.
- **#465 — Friendbot rate limits** — Documents the account-already-exists 400, 429 throttle, and 500 transient errors; includes an exponential backoff retry snippet.
- **#481 — Latest ledger streaming** — Shows `cursor=now` SSE subscription via `@stellar/stellar-sdk`, explains automatic reconnect behavior, and demonstrates manual cursor tracking for custom reconnect logic.

All files placed in `routes-d/` per issue constraints.

closes #458
closes #464
closes #465
closes #481