### PR TITLE
docs: Discord reference, Horizon/Soroban glossary, XDR guide, account flags

### DIFF
--- a/routes-d/468-stellar-community-discord.md
+++ b/routes-d/468-stellar-community-discord.md
@@ -1,0 +1,31 @@
+---
+title: Stellar Developer Discord
+description: Reference for the official Stellar developer Discord community channel
+---
+
+# Stellar Developer Discord
+
+The Stellar Development Foundation maintains an official Discord server where developers can ask questions, share projects, and get help from the community and SDF team members.
+
+---
+
+## Joining
+
+The official invite link is available at [stellar.org/community](https://stellar.org/community). Look for the Discord button on the community page.
+
+---
+
+## Acceptable Use
+
+The server is intended for technical discussion, project showcases, and questions related to building on Stellar. Keep conversations relevant to Stellar development and follow the channel-specific guidelines pinned in each room.
+
+Common channels include `#soroban-dev`, `#horizon-help`, and `#sdk-support` — check the channel list after joining to find the most relevant space for your question.
+
+---
+
+## Notes
+
+- Search existing threads before posting; many common questions are already answered.
+- For bugs or feature requests, open a GitHub issue on the relevant SDF repository rather than posting in Discord.
+
+**Related:** [Stellar Community](https://stellar.org/community), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/472-glossary-horizon-soroban.md
+++ b/routes-d/472-glossary-horizon-soroban.md
@@ -1,0 +1,34 @@
+---
+title: "Glossary: Horizon and Soroban"
+description: Short definitions for Horizon and Soroban as used in the Stellar ecosystem and Nextellar docs
+---
+
+# Glossary: Horizon and Soroban
+
+Two distinct layers of the Stellar ecosystem that serve different purposes.
+
+---
+
+## Horizon
+
+The HTTP API server maintained by the Stellar Development Foundation that provides a RESTful interface to the Stellar network. Horizon indexes ledger data and exposes it through endpoints for accounts, transactions, operations, assets, offers, and streaming updates.
+
+Nextellar hooks use Horizon to read account balances, submit transactions, and fetch history. You do not interact with the Stellar network directly — you talk to a Horizon server, which handles the peer-to-peer layer for you.
+
+**Common usage:** `GET /accounts/{id}`, `POST /transactions`, `GET /accounts/{id}/operations`
+
+**Related:** Stellar SDK, `useStellarBalances`, `useTransactionHistory`
+
+---
+
+## Soroban
+
+Stellar's smart contract platform, introduced in Protocol 20. Soroban contracts are written in Rust, compiled to WebAssembly, and run inside the Stellar validator. They extend Stellar's capabilities beyond payments to arbitrary programmable logic.
+
+Soroban uses a separate RPC interface (not Horizon) for contract deployment and invocation, though Horizon can still be used to observe the resulting ledger changes.
+
+**Common usage:** token contracts, on-chain voting, DeFi primitives, oracle integrations
+
+**Related:** Soroban RPC, `#[contractimpl]`, Horizon, WebAssembly
+
+**Related docs:** [Soroban Integration](/docs/integrations/soroban), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/482-xdr-encoding-decoding.md
+++ b/routes-d/482-xdr-encoding-decoding.md
@@ -1,0 +1,82 @@
+---
+title: XDR Encoding and Decoding
+description: How to encode and decode XDR values used in Stellar transactions and responses
+---
+
+# XDR Encoding and Decoding
+
+XDR (External Data Representation) is the binary serialization format Stellar uses for transactions, operations, ledger entries, and results. Horizon returns XDR fields as base64 strings; the Stellar SDK provides helpers to decode them.
+
+---
+
+## Decode Helpers
+
+```js
+import { xdr, TransactionEnvelope } from "@stellar/stellar-sdk";
+
+// Decode a transaction envelope from base64 XDR
+function decodeEnvelope(envelopeXdr) {
+  return xdr.TransactionEnvelope.fromXDR(envelopeXdr, "base64");
+}
+
+// Decode a transaction result
+function decodeResult(resultXdr) {
+  return xdr.TransactionResult.fromXDR(resultXdr, "base64");
+}
+
+// Decode result meta (ledger entry changes)
+function decodeMeta(metaXdr) {
+  return xdr.TransactionMeta.fromXDR(metaXdr, "base64");
+}
+```
+
+---
+
+## Encode Helpers
+
+```js
+// Encode a built transaction back to base64 XDR (for signing or storage)
+function encodeTransaction(transaction) {
+  return transaction.toEnvelope().toXDR("base64");
+}
+
+// Round-trip: decode then re-encode to verify integrity
+function roundTrip(envelopeXdr) {
+  const decoded = xdr.TransactionEnvelope.fromXDR(envelopeXdr, "base64");
+  return decoded.toXDR("base64");
+}
+```
+
+---
+
+## Small Example
+
+```js
+import { Horizon, xdr } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+async function inspectTransaction(txHash) {
+  const tx = await server.transactions().transaction(txHash).call();
+
+  // Decode result to check per-operation outcomes
+  const result = xdr.TransactionResult.fromXDR(tx.result_xdr, "base64");
+  const opResults = result.result().results();
+
+  opResults.forEach((op, i) => {
+    console.log(`Op ${i}:`, op.tr().switch().name);
+  });
+}
+```
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Cause | Fix |
+|---------|-------|-----|
+| `UnknownError` on decode | Wrong XDR type used (e.g. decoding meta as result) | Match the XDR class to the field name: `result_xdr` → `TransactionResult`, `result_meta_xdr` → `TransactionMeta` |
+| `Invalid base64` | Extra whitespace or newlines in the string | Call `.trim()` before decoding |
+| Decoded value looks wrong | Encoding mismatch | Always pass `"base64"` as the second argument; omitting it defaults to raw bytes |
+
+**Related:** [Transaction Results Shape](/routes-d/496-transaction-results-shape), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/485-reading-account-flags.md
+++ b/routes-d/485-reading-account-flags.md
@@ -1,0 +1,86 @@
+---
+title: Reading Account Flags
+description: How to read and interpret account flags from Horizon responses, with a parsing example and common flag combinations
+---
+
+# Reading Account Flags
+
+Stellar accounts carry a set of boolean flags that control trustline authorization and asset behavior. Horizon returns these as both a raw integer bitmask and pre-parsed boolean fields.
+
+---
+
+## The Flags Field Shape
+
+When you fetch an account from Horizon, the `flags` object contains three parsed booleans:
+
+```json
+{
+  "flags": {
+    "auth_required": true,
+    "auth_revocable": true,
+    "auth_immutable": false,
+    "auth_clawback_enabled": false
+  }
+}
+```
+
+| Flag | Meaning |
+|------|---------|
+| `auth_required` | Trustlines to this account's assets must be explicitly authorized by the account before the holder can transact |
+| `auth_revocable` | The account can revoke (freeze) existing trustlines |
+| `auth_immutable` | The account's flags can never be changed again |
+| `auth_clawback_enabled` | The account can claw back issued assets from holders |
+
+---
+
+## Parsing Example
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+async function readAccountFlags(publicKey) {
+  const account = await server.loadAccount(publicKey);
+  const { flags } = account;
+
+  console.log("Auth required:", flags.auth_required);
+  console.log("Auth revocable:", flags.auth_revocable);
+  console.log("Auth immutable:", flags.auth_immutable);
+  console.log("Clawback enabled:", flags.auth_clawback_enabled);
+
+  return flags;
+}
+```
+
+---
+
+## Common Combinations
+
+| Combination | Typical use case |
+|-------------|-----------------|
+| All false | Open community token; anyone with a trustline can transact freely |
+| `auth_required` + `auth_revocable` | Regulated asset (KYC required, issuer can freeze) |
+| `auth_required` + `auth_revocable` + `auth_clawback_enabled` | Fully compliant security or CBDC |
+| `auth_immutable` set alone | Issuer has permanently locked flags to signal no future control changes |
+
+---
+
+## Checking Before Operations
+
+```js
+async function canHolderTransact(issuerPublicKey) {
+  const issuer = await server.loadAccount(issuerPublicKey);
+
+  if (issuer.flags.auth_required) {
+    // Must also check that the specific trustline is authorized
+    console.warn("Asset requires issuer authorization per trustline");
+  }
+
+  if (issuer.flags.auth_revocable) {
+    console.warn("Issuer can freeze this asset at any time");
+  }
+}
+```
+
+**Related:** [Asset Compliance Flags](/routes-d/504-asset-compliance-flags), [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary

- **#468** — Short reference to the Stellar developer Discord community channel
- **#472** — Glossary entries for Horizon and Soroban and their distinct roles
- **#482** — XDR encoding and decoding guide with encode/decode helpers and common pitfalls
- **#485** — Reading account flags from Horizon responses with parsing example and flag combinations

## Changes

- `routes-d/468-stellar-community-discord.md`
- `routes-d/472-glossary-horizon-soroban.md`
- `routes-d/482-xdr-encoding-decoding.md`
- `routes-d/485-reading-account-flags.md`

closes #468
closes #472
closes #482
closes #485