### PR TITLE
docs: Soroban oracle integration, fee statistics, tooltip note, federation resolution

### DIFF
--- a/routes-d/449-soroban-oracle-integration.md
+++ b/routes-d/449-soroban-oracle-integration.md
@@ -1,0 +1,107 @@
+---
+title: Soroban Oracle Integration
+description: How to integrate an oracle with a Soroban contract, covering the trust model, contract-side handling, and a worked example
+---
+
+# Soroban Oracle Integration
+
+Oracles bridge off-chain data (prices, randomness, weather, etc.) into on-chain Soroban contracts. Because Soroban contracts cannot make HTTP calls themselves, an oracle pushes data onto the ledger and the contract reads from it.
+
+---
+
+## Trust Model
+
+A Soroban oracle typically works as a **push oracle**: a trusted off-chain process submits price data via a contract call, and consuming contracts read that stored value. The trust assumptions are:
+
+- The oracle submitter address is known and stored in the contract at deployment.
+- Only that address (or a multisig quorum) may update the price feed.
+- Consumers must evaluate whether the data is stale before using it.
+
+```rust
+#[contracttype]
+pub enum DataKey {
+    OracleAdmin,
+    Price(Symbol),
+    LastUpdated(Symbol),
+}
+```
+
+---
+
+## Contract-Side Handling
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct OracleConsumer;
+
+#[contractimpl]
+impl OracleConsumer {
+    /// Called by the trusted oracle admin to update a price feed.
+    pub fn update_price(env: Env, caller: Address, feed: Symbol, price: i128) {
+        caller.require_auth();
+        let admin: Address = env.storage().instance().get(&DataKey::OracleAdmin).unwrap();
+        assert!(caller == admin, "unauthorized");
+
+        env.storage().instance().set(&DataKey::Price(feed.clone()), &price);
+        env.storage().instance().set(&DataKey::LastUpdated(feed), &env.ledger().timestamp());
+    }
+
+    /// Read the latest price and check staleness.
+    pub fn get_price(env: Env, feed: Symbol, max_age_seconds: u64) -> i128 {
+        let last: u64 = env.storage().instance().get(&DataKey::LastUpdated(feed.clone())).unwrap();
+        assert!(
+            env.ledger().timestamp() - last <= max_age_seconds,
+            "stale price"
+        );
+        env.storage().instance().get(&DataKey::Price(feed)).unwrap()
+    }
+}
+```
+
+---
+
+## Worked Example
+
+**Off-chain submitter** (Node.js) pushes an XLM/USD price every 60 seconds:
+
+```js
+import { Contract, TransactionBuilder, Networks, BASE_FEE } from "@stellar/stellar-sdk";
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+const contract = new Contract(ORACLE_CONTRACT_ID);
+
+async function pushPrice(adminKeypair, priceUsd) {
+  const account = await server.getAccount(adminKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(contract.call("update_price",
+      adminKeypair.publicKey(),
+      "XLM_USD",
+      BigInt(Math.round(priceUsd * 1e7)) // 7 decimal precision
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(adminKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+**Consuming contract** calls `get_price("XLM_USD", 120)` — rejects if the feed is more than 2 minutes old.
+
+---
+
+## Notes
+
+- For higher trust guarantees, use a multisig admin (threshold-based signers) so no single key controls the feed.
+- Emit events from `update_price` so consumers can subscribe to changes without polling.
+- Consider `env.storage().ttl_extend()` to keep price storage entries alive across ledger expiry.
+
+**Related:** [Soroban Integration](/docs/integrations/soroban), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/471-horizon-fee-statistics.md
+++ b/routes-d/471-horizon-fee-statistics.md
@@ -1,0 +1,85 @@
+---
+title: Horizon Fee Statistics Endpoint
+description: The Horizon fee statistics endpoint, its response fields, and how to use it to choose an appropriate transaction fee
+---
+
+# Horizon Fee Statistics Endpoint
+
+Before submitting a transaction, you can query Horizon for current network fee statistics to choose a fee that is likely to be accepted without overpaying.
+
+---
+
+## Endpoint
+
+```
+GET /fee_stats
+```
+
+No parameters required.
+
+---
+
+## Example Response Fields
+
+```json
+{
+  "last_ledger": "51234567",
+  "last_ledger_base_fee": "100",
+  "ledger_capacity_usage": "0.42",
+  "fee_charged": {
+    "max": "1000",
+    "min": "100",
+    "mode": "100",
+    "p10": "100",
+    "p20": "100",
+    "p50": "100",
+    "p80": "200",
+    "p95": "500",
+    "p99": "1000"
+  },
+  "max_fee": {
+    "max": "10000",
+    "min": "100",
+    "mode": "100",
+    "p10": "100",
+    "p20": "100",
+    "p50": "200",
+    "p80": "500",
+    "p95": "1000",
+    "p99": "5000"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `last_ledger_base_fee` | Minimum fee in stroops per operation for the last ledger |
+| `ledger_capacity_usage` | 0–1 fill ratio; values above ~0.5 indicate surge pricing may activate |
+| `fee_charged` | Distribution of fees actually charged on recently closed ledgers |
+| `max_fee` | Distribution of fees that submitters offered (bids) |
+
+---
+
+## How to Inform Fee Choice
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+async function getRecommendedFee() {
+  const stats = await server.feeStats();
+  const usage = parseFloat(stats.ledger_capacity_usage);
+
+  // Under normal load use p50 of what was charged; under surge use p95
+  const feeStroops = usage > 0.5
+    ? stats.fee_charged.p95
+    : stats.fee_charged.p50;
+
+  return feeStroops; // pass as `fee` to TransactionBuilder
+}
+```
+
+Using `fee_charged.p50` during normal conditions minimises cost. Switching to `p95` under high load increases the chance of inclusion without guessing a ceiling.
+
+**Related:** [Horizon Integration](/docs/integrations/horizon), [Transaction Results Shape](/routes-d/496-transaction-results-shape)

--- a/routes-d/476-docs-tooltip-behavior.md
+++ b/routes-d/476-docs-tooltip-behavior.md
@@ -1,0 +1,34 @@
+---
+title: Docs Tooltip Behavior
+description: How tooltips work in the Nextellar documentation site, including trigger behavior and keyboard accessibility
+---
+
+# Docs Tooltip Behavior
+
+Some terms and UI elements in the Nextellar docs include hover tooltips that surface brief definitions or contextual notes without requiring navigation away from the current page.
+
+---
+
+## How Tooltips Trigger
+
+Tooltips appear when you hover over an underlined or highlighted term. On touch devices, a tap toggles the tooltip open and closed.
+
+---
+
+## Keyboard Accessibility
+
+Tooltips are fully keyboard accessible:
+
+- **Tab** to focus the element carrying the tooltip.
+- **Enter** or **Space** to open the tooltip if it does not open on focus automatically.
+- **Escape** to dismiss an open tooltip.
+- Screen readers announce the tooltip content via `aria-describedby` when the trigger element receives focus.
+
+---
+
+## Notes
+
+- Tooltips are intentionally brief — one or two sentences. For full definitions, follow the linked term to the glossary.
+- If a tooltip appears clipped near the edge of the viewport, scroll slightly or resize the window; the tooltip repositions automatically where space allows.
+
+**Related:** [Glossary](/docs/guides/glossary)

--- a/routes-d/483-federation-address-resolution.md
+++ b/routes-d/483-federation-address-resolution.md
@@ -1,0 +1,63 @@
+---
+title: Federation Address Resolution
+description: How to resolve a Stellar federation address to an account ID, with caching considerations and a working example
+---
+
+# Federation Address Resolution
+
+A Stellar federation address (e.g. `alice*example.com`) maps to a full public key via a two-step lookup. Resolving it before payment lets users share readable addresses instead of 56-character keys.
+
+---
+
+## Resolution Flow
+
+1. Fetch `https://example.com/.well-known/stellar.toml`.
+2. Read the `FEDERATION_SERVER` URL from the TOML file.
+3. Query `GET <FEDERATION_SERVER>?q=alice*example.com&type=name`.
+4. Parse the `account_id` from the JSON response.
+
+```js
+import { Federation, StellarToml } from "@stellar/stellar-sdk";
+
+async function resolveAddress(federatedAddress) {
+  // The SDK handles the full two-step lookup
+  const result = await Federation.Server.resolve(federatedAddress);
+  return result.account_id; // the public key
+}
+
+// Usage
+const publicKey = await resolveAddress("alice*example.com");
+```
+
+The Stellar SDK's `Federation.Server.resolve` performs both steps automatically.
+
+---
+
+## Caching Considerations
+
+- **Cache the result per address.** The public key for a given federated address rarely changes; re-resolving on every payment adds unnecessary latency and load on the federation server.
+- **Respect TTL.** The stellar.toml and federation server responses may include HTTP `Cache-Control` headers — honour them.
+- **Invalidate on failure.** If a payment to a cached key fails with `op_no_destination`, the account may have been deleted; evict the cache entry and re-resolve.
+- **Do not cache indefinitely.** A reasonable TTL is 5–30 minutes for user-facing flows; longer for batch jobs where addresses are unlikely to change mid-run.
+
+```js
+const cache = new Map();
+
+async function resolveWithCache(federatedAddress, ttlMs = 10 * 60 * 1000) {
+  const cached = cache.get(federatedAddress);
+  if (cached && Date.now() - cached.ts < ttlMs) return cached.accountId;
+
+  const result = await Federation.Server.resolve(federatedAddress);
+  cache.set(federatedAddress, { accountId: result.account_id, ts: Date.now() });
+  return result.account_id;
+}
+```
+
+---
+
+## Notes
+
+- Not all Stellar public keys have federation addresses; only resolve when the user provides a `*`-containing string.
+- The `memo` and `memo_type` fields in the federation response, if present, must be included in the payment transaction.
+
+**Related:** [Glossary: Federation](/routes-d/459-glossary-federation-sequence-number), [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary

- **#449** — Complete guide on integrating an oracle with a Soroban contract: trust model, contract-side handling, off-chain submitter example
- **#471** — Horizon fee statistics endpoint reference with field descriptions and fee selection strategy
- **#476** — Short note on tooltip trigger behavior and keyboard accessibility in the docs
- **#483** — Federation address resolution flow with caching considerations and a working SDK example

## Changes

- `routes-d/449-soroban-oracle-integration.md`
- `routes-d/471-horizon-fee-statistics.md`
- `routes-d/476-docs-tooltip-behavior.md`
- `routes-d/483-federation-address-resolution.md`

closes #449
closes #471
closes #476
closes #483