### PR TITLE
docs: transaction details guide, Horizon params, idempotency, WalletConnect disconnect

### DIFF
--- a/routes-d/507-transaction-details-page.md
+++ b/routes-d/507-transaction-details-page.md
@@ -1,0 +1,114 @@
+---
+title: Building a Transaction Details Page
+description: How to implement a transaction details page on Stellar, including the data shape, minimal UI code, and status badges
+---
+
+# Building a Transaction Details Page
+
+A transaction details page lets users inspect a specific transaction — its status, fee, operations, and timestamps. This guide covers fetching the data from Horizon and rendering it with status badges.
+
+---
+
+## Data Shape
+
+Fetch a single transaction by hash:
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+async function fetchTransaction(txHash) {
+  const tx = await server.transactions().transaction(txHash).call();
+  return tx;
+}
+```
+
+Key fields on the response:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Transaction hash |
+| `successful` | boolean | Whether all operations succeeded |
+| `created_at` | string | ISO 8601 timestamp of ledger close |
+| `fee_charged` | string | Fee in stroops |
+| `operation_count` | number | Number of operations |
+| `memo_type` | string | `none`, `text`, `id`, `hash`, or `return` |
+| `memo` | string | Memo value if present |
+
+---
+
+## Minimal UI Code
+
+```jsx
+import { useState, useEffect } from "react";
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+export function TransactionDetails({ txHash }) {
+  const [tx, setTx] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    server.transactions().transaction(txHash).call()
+      .then(setTx)
+      .catch(setError);
+  }, [txHash]);
+
+  if (error) return <p>Transaction not found.</p>;
+  if (!tx) return <p>Loading…</p>;
+
+  return (
+    <div>
+      <h2>Transaction</h2>
+      <StatusBadge successful={tx.successful} />
+      <dl>
+        <dt>Hash</dt><dd>{tx.id}</dd>
+        <dt>Date</dt><dd>{new Date(tx.created_at).toLocaleString()}</dd>
+        <dt>Fee</dt><dd>{(parseInt(tx.fee_charged) / 1e7).toFixed(7)} XLM</dd>
+        <dt>Operations</dt><dd>{tx.operation_count}</dd>
+        {tx.memo && <><dt>Memo</dt><dd>{tx.memo}</dd></>}
+      </dl>
+    </div>
+  );
+}
+```
+
+---
+
+## Status Badges
+
+```jsx
+function StatusBadge({ successful }) {
+  const style = {
+    display: "inline-block",
+    padding: "2px 10px",
+    borderRadius: "12px",
+    fontSize: "0.85rem",
+    fontWeight: 600,
+    background: successful ? "#d1fae5" : "#fee2e2",
+    color: successful ? "#065f46" : "#991b1b",
+  };
+
+  return <span style={style}>{successful ? "Success" : "Failed"}</span>;
+}
+```
+
+For a more detailed badge that distinguishes pending, success, and failed states:
+
+```jsx
+function TransactionStatus({ successful, ledger }) {
+  if (!ledger) return <span style={{ color: "#b45309" }}>Pending</span>;
+  return <StatusBadge successful={successful} />;
+}
+```
+
+---
+
+## Notes
+
+- A transaction on Horizon always has a ledger, so `successful` is definitively `true` or `false`; pending transactions simply aren't returned yet (404).
+- To list the operations within the transaction, call `server.operations().forTransaction(txHash).call()`.
+
+**Related:** [Transaction Results Shape](/routes-d/496-transaction-results-shape), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/508-horizon-query-parameters.md
+++ b/routes-d/508-horizon-query-parameters.md
@@ -1,0 +1,76 @@
+---
+title: Horizon Query Parameter Conventions
+description: How cursor, order, and limit work across Horizon collection endpoints, with examples and pagination edge cases
+---
+
+# Horizon Query Parameter Conventions
+
+All Horizon collection endpoints (transactions, operations, payments, effects, etc.) share a consistent set of query parameters for pagination and ordering.
+
+---
+
+## Parameters
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `cursor` | record paging token or `now` | none (start) | Resume from this position; `now` on streaming endpoints means start from the current tip |
+| `order` | `asc` or `desc` | `asc` | Sort direction — `asc` returns oldest first, `desc` returns newest first |
+| `limit` | 1–200 | 10 | Number of records per page |
+
+---
+
+## Examples
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+// Most recent 20 transactions for an account
+const recent = await server
+  .transactions()
+  .forAccount(publicKey)
+  .order("desc")
+  .limit(20)
+  .call();
+
+// Paginate forward from a known cursor
+const page2 = await server
+  .transactions()
+  .forAccount(publicKey)
+  .order("asc")
+  .cursor(recent.records[recent.records.length - 1].paging_token)
+  .limit(20)
+  .call();
+```
+
+The SDK also exposes `.next()` and `.prev()` on each page result for convenience:
+
+```js
+let page = await server.transactions().forAccount(publicKey).order("asc").limit(20).call();
+while (page.records.length > 0) {
+  // process page.records ...
+  page = await page.next();
+}
+```
+
+---
+
+## Pagination Edge Cases
+
+| Edge case | Behaviour |
+|-----------|-----------|
+| `cursor` points to a deleted or non-existent record | Horizon returns the next record after that position — no error |
+| `limit` exceeds 200 | Horizon caps at 200 and returns at most 200 records |
+| Empty page | `records` is an empty array; `next()` will also return empty — use this as the stop condition |
+| `order=desc` with a `cursor` from an `asc` page | The cursor is directional — mixing directions causes unexpected results; always use a cursor from the same order direction |
+| Streaming with `cursor=now` | Skips all historical records; only future events are delivered |
+
+---
+
+## Notes
+
+- `paging_token` is the cursor value for each record. Store it to resume pagination after a restart.
+- Prefer `order=desc` + `limit` for "latest N" queries; prefer `order=asc` + cursor-based pagination for full historical scans.
+
+**Related:** [Transaction Results Shape](/routes-d/496-transaction-results-shape), [Latest Ledger Streaming](/routes-d/481-latest-ledger-streaming), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/514-transaction-submission-idempotency.md
+++ b/routes-d/514-transaction-submission-idempotency.md
@@ -1,0 +1,85 @@
+---
+title: Idempotent Transaction Submission
+description: How to safely retry Stellar transaction submissions without double-spending, covering sequence number handling and safe retry strategies
+---
+
+# Idempotent Transaction Submission
+
+Stellar transactions are inherently idempotent by design — submitting the same signed transaction envelope twice produces one ledger result, not two. This property makes safe retries straightforward once you understand sequence number handling.
+
+---
+
+## Why Retries Are Safe
+
+A Stellar transaction is uniquely identified by its **hash**, which is derived from the transaction envelope including the sequence number. If a submission times out or returns a network error, you can re-submit the same signed envelope and Horizon will either:
+
+- Return the already-applied result if the transaction was already included in a ledger, or
+- Apply it now if it hasn't been yet.
+
+The sequence number is consumed exactly once regardless of how many times you submit the same envelope.
+
+---
+
+## Sequence Number Handling
+
+The danger is **building a new transaction** with an old sequence number after a partial failure:
+
+```
+Account seq = 100
+Build tx with seq = 101, sign → submit → network error
+❌ Build NEW tx with seq = 101 → this will conflict if the first landed
+✅ Re-submit the ORIGINAL signed envelope → safe
+```
+
+Always cache the signed envelope and re-submit it on retry. Only rebuild with a fresh sequence number if you have confirmed the original transaction was **not** applied.
+
+---
+
+## Safe Retry Strategy
+
+```js
+async function submitWithRetry(server, signedTx, maxAttempts = 5) {
+  const txHash = signedTx.hash().toString("hex");
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await server.submitTransaction(signedTx);
+      return result; // success
+    } catch (err) {
+      const status = err?.response?.status;
+
+      // Already applied — fetch and return the existing result
+      if (status === 400 && err?.response?.data?.extras?.result_codes?.transaction === "tx_bad_seq") {
+        // Sequence was consumed — check if OUR tx landed
+        try {
+          const existing = await server.transactions().transaction(txHash).call();
+          return existing;
+        } catch {
+          throw err; // sequence consumed by a different transaction — must rebuild
+        }
+      }
+
+      // Timeout or 5xx — safe to retry the same envelope
+      if (!status || status >= 500) {
+        const delay = 1000 * 2 ** (attempt - 1);
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+
+      throw err; // 4xx other than bad_seq — not retryable
+    }
+  }
+
+  throw new Error(`Transaction not confirmed after ${maxAttempts} attempts`);
+}
+```
+
+---
+
+## Notes
+
+- `tx_bad_seq` during retry means either (a) your tx landed and incremented the sequence, or (b) another transaction used that sequence slot. Distinguish by fetching the tx hash directly.
+- Never rebuild with a fresh sequence number until you've confirmed the original is absent from the ledger.
+- On Testnet, network resets invalidate all pending transactions — check `horizon-testnet.stellar.org/fee_stats` for liveness before debugging retries.
+
+**Related:** [Transaction Results Shape](/routes-d/496-transaction-results-shape), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/515-walletconnect-disconnection.md
+++ b/routes-d/515-walletconnect-disconnection.md
@@ -1,0 +1,89 @@
+---
+title: Graceful WalletConnect Disconnection
+description: How to handle WalletConnect session disconnects in a Stellar dApp, including the disconnect flow, state cleanup, and a working example
+---
+
+# Graceful WalletConnect Disconnection
+
+WalletConnect sessions can end either by user action (explicit disconnect) or unexpectedly (wallet app closed, session timeout). Handling both cases cleanly prevents stale state and avoids broken UI.
+
+---
+
+## Disconnect Flow
+
+1. **User-initiated:** user clicks "Disconnect" in the dApp or wallet → the SDK emits a `session_delete` event on both sides.
+2. **Wallet-initiated:** the wallet terminates the session → the dApp receives a `session_delete` event from the WalletConnect relay.
+3. **Network/timeout:** the relay connection drops → no event is delivered; the dApp must detect staleness on the next interaction.
+
+---
+
+## State Cleanup
+
+When a disconnect is detected, clear all session-derived state:
+
+- Connected public key / account address
+- Session topic
+- Signed-in status flags
+- Any cached balances or transaction history tied to that session
+
+---
+
+## Example
+
+```js
+import { WalletConnect } from "@walletconnect/web3wallet";
+import { useState, useEffect } from "react";
+
+export function useWalletSession(walletConnectClient) {
+  const [publicKey, setPublicKey] = useState(null);
+  const [sessionTopic, setSessionTopic] = useState(null);
+
+  useEffect(() => {
+    if (!walletConnectClient) return;
+
+    // Listen for wallet-initiated or relay-initiated disconnects
+    walletConnectClient.on("session_delete", ({ topic }) => {
+      if (topic === sessionTopic) {
+        clearSession();
+      }
+    });
+
+    return () => {
+      walletConnectClient.off("session_delete");
+    };
+  }, [walletConnectClient, sessionTopic]);
+
+  function clearSession() {
+    setPublicKey(null);
+    setSessionTopic(null);
+    // Clear any localStorage/sessionStorage entries
+    sessionStorage.removeItem("wc_session_topic");
+    sessionStorage.removeItem("stellar_public_key");
+  }
+
+  async function disconnect() {
+    if (!sessionTopic) return;
+    try {
+      await walletConnectClient.disconnectSession({
+        topic: sessionTopic,
+        reason: { code: 6000, message: "User disconnected" },
+      });
+    } finally {
+      // Always clear local state even if the remote call fails
+      clearSession();
+    }
+  }
+
+  return { publicKey, setPublicKey, setSessionTopic, disconnect };
+}
+```
+
+---
+
+## Notes
+
+- Always clear local state in a `finally` block — the remote disconnect call can fail if the relay is down, but local state should still be cleaned up.
+- If the dApp restores sessions from storage on page reload, validate that the stored session topic is still active with `walletConnectClient.getActiveSessions()` before treating the user as connected.
+- For mobile wallets that go to background, sessions can silently expire; add a connectivity check before every transaction submission.
+
+**Related:** [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary

- **#507** — Transaction details page: data shape from Horizon, minimal React UI, status badges
- **#508** — Horizon query parameter conventions: cursor, order, limit, pagination edge cases
- **#514** — Idempotency for retried transaction submissions: sequence number handling and safe retry strategy
- **#515** — Graceful WalletConnect disconnection: disconnect flow, state cleanup, working hook example

## Changes

- `routes-d/507-transaction-details-page.md`
- `routes-d/508-horizon-query-parameters.md`
- `routes-d/514-transaction-submission-idempotency.md`
- `routes-d/515-walletconnect-disconnection.md`

closes #507
closes #508
closes #514
closes #515