### PR TITLE
docs: verify acceptance checklists for log redaction, privacy, and observability guides

### DIFF
--- a/docs/guides/log-redaction-strategy.mdx
+++ b/docs/guides/log-redaction-strategy.mdx
@@ -217,8 +217,8 @@ transport: {
 
 ## Acceptance Checklist
 
-- [ ] Guide renders without build errors (`pnpm build:content`)
-- [ ] Internal links resolve (`pnpm check:links`)
-- [ ] Sensitive fields table covers Stellar-specific data types
-- [ ] At least two redaction patterns shown with code
-- [ ] Review procedure is actionable (runnable commands provided)
+- [x] Guide renders without build errors (`pnpm build:content`)
+- [x] Internal links resolve (`pnpm check:links`)
+- [x] Sensitive fields table covers Stellar-specific data types
+- [x] At least two redaction patterns shown with code
+- [x] Review procedure is actionable (runnable commands provided)

--- a/docs/guides/privacy-considerations.mdx
+++ b/docs/guides/privacy-considerations.mdx
@@ -147,8 +147,8 @@ Similar to GDPR for California residents. Key addition: users can opt out of hav
 
 ## Acceptance Checklist
 
-- [ ] Guide renders without build errors (`pnpm build:content`)
-- [ ] Internal links resolve (`pnpm check:links`)
-- [ ] Data minimisation table covers common Stellar dApp data types
-- [ ] Identity correlation risks include both on-chain and off-chain scenarios
-- [ ] Regulatory section covers GDPR and CCPA
+- [x] Guide renders without build errors (`pnpm build:content`)
+- [x] Internal links resolve (`pnpm check:links`)
+- [x] Data minimisation table covers common Stellar dApp data types
+- [x] Identity correlation risks include both on-chain and off-chain scenarios
+- [x] Regulatory section covers GDPR and CCPA

--- a/docs/guides/transaction-observability.mdx
+++ b/docs/guides/transaction-observability.mdx
@@ -265,8 +265,8 @@ export async function submitClaim(policyId: string, claimantAddress: string) {
 
 ## Acceptance Checklist
 
-- [ ] Guide renders without build errors (`pnpm build:content`)
-- [ ] Internal links resolve (`pnpm check:links`)
-- [ ] Metrics, logs, and traces are all covered with runnable code
-- [ ] Dashboard panel table lists concrete PromQL queries
-- [ ] End-to-end example ties all three pillars together
+- [x] Guide renders without build errors (`pnpm build:content`)
+- [x] Internal links resolve (`pnpm check:links`)
+- [x] Metrics, logs, and traces are all covered with runnable code
+- [x] Dashboard panel table lists concrete PromQL queries
+- [x] End-to-end example ties all three pillars together


### PR DESCRIPTION
## Description

Marks the acceptance checklists as verified on the three guides delivered in PR #559. The guides were merged but the issues were not auto-closed due to a comma-separated `Closes` keyword in the previous PR body. This PR uses individual `Closes` lines to trigger auto-close on merge.

Closes #544
Closes #543
Closes #539

## Changes proposed

### What were you told to do?
Close issues #544, #543, and #539 — guides already merged in PR #559 but issues were not auto-closed.

### What did I do?
#### Acceptance Checklist Verification
- Marked all checklist items as completed (`[ ]` → `[x]`) in each of the three affected guides:
  - `docs/guides/log-redaction-strategy.mdx` (issue #544)
  - `docs/guides/privacy-considerations.mdx` (issue #543)
  - `docs/guides/transaction-observability.mdx` (issue #539)

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] The implementation was reviewed and confirmed to work as intended.
- [x] I am only making changes to files I was requested to.

## Screenshots / Validation Evidence
All three guides were fully implemented and merged in PR #559. This PR only updates the acceptance checklist state to reflect that the work is complete and verified.