### PR TITLE
docs: add guides for transaction hash lookup, envelope formats, home_domain, and manage data

### DIFF
--- a/routes-d/467-fetching-transaction-details-by-hash.md
+++ b/routes-d/467-fetching-transaction-details-by-hash.md
@@ -1,0 +1,85 @@
+---
+title: Fetching Transaction Details by Hash
+description: How to retrieve a transaction's full details from Horizon using its hash, with endpoint reference and common errors
+---
+
+# Fetching Transaction Details by Hash
+
+Every submitted transaction has a unique hash that Horizon uses as its primary identifier. You can use this hash to retrieve the full transaction record at any time — useful for confirming payment status, reading operation results, or debugging submission failures.
+
+---
+
+## Endpoint
+
+```
+GET https://horizon.stellar.org/transactions/{hash}
+```
+
+Replace `{hash}` with the hex-encoded SHA-256 transaction hash (64 characters).
+
+---
+
+## Response Shape
+
+```json
+{
+  "hash": "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889",
+  "ledger": 27147222,
+  "created_at": "2021-12-07T17:44:00Z",
+  "source_account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  "fee_charged": "100",
+  "operation_count": 1,
+  "envelope_xdr": "AAAAAgAAAA...",
+  "result_xdr": "AAAAAAAAAGQ...",
+  "result_meta_xdr": "AAAAAwAAAAI...",
+  "memo_type": "none",
+  "signatures": ["..."],
+  "successful": true
+}
+```
+
+Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `hash` | Unique transaction identifier |
+| `ledger` | Ledger sequence number that included this transaction |
+| `successful` | `true` if all operations in the transaction succeeded |
+| `envelope_xdr` | Base64 XDR of the full signed transaction envelope |
+| `result_xdr` | Base64 XDR of the per-operation results |
+| `fee_charged` | Actual fee deducted in stroops |
+
+---
+
+## Example
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+async function getTransactionByHash(hash) {
+  const tx = await server.transactions().transaction(hash).call();
+
+  console.log("Successful:", tx.successful);
+  console.log("Ledger:", tx.ledger);
+  console.log("Operations:", tx.operation_count);
+  console.log("Fee charged:", tx.fee_charged, "stroops");
+
+  return tx;
+}
+```
+
+For testnet, replace the server URL with `https://horizon-testnet.stellar.org`.
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `404 Not Found` | Hash not on the network yet or was never submitted | Confirm submission succeeded; wait a few seconds and retry |
+| `400 Bad Request` | Malformed hash (wrong length or non-hex characters) | Verify the hash is exactly 64 hex characters |
+| `403 Forbidden` | Horizon node has restricted access to this endpoint | Use the public Horizon endpoint or your own node |
+
+**Related:** [XDR Encoding and Decoding](/routes-d/482-xdr-encoding-decoding), [Transaction Results Shape](/routes-d/496-transaction-results-shape)

--- a/routes-d/478-transaction-envelope-formats.md
+++ b/routes-d/478-transaction-envelope-formats.md
@@ -1,0 +1,81 @@
+---
+title: Transaction Envelope Formats
+description: A brief overview of Stellar transaction envelope formats, version differences, and how to work with them
+---
+
+# Transaction Envelope Formats
+
+A Stellar transaction is always wrapped in an envelope before it is submitted to the network. The envelope pairs the transaction body with one or more cryptographic signatures. Horizon returns envelopes as base64-encoded XDR strings.
+
+---
+
+## Envelope Shapes
+
+Stellar currently uses two envelope variants:
+
+### `TransactionV0Envelope`
+
+The original format, used by transactions built before Protocol 13. Contains the classic `Transaction` body (no fee-bump support, no inner transaction).
+
+```
+TransactionV0Envelope
+  └── TransactionV0      (source account, fee, sequence, time bounds, memo, operations)
+  └── DecoratedSignature[] (signer + signature pairs)
+```
+
+### `TransactionV1Envelope`
+
+Introduced in Protocol 13. Identical in structure to V0 but uses a different XDR discriminant, which allows it to be wrapped inside a `FeeBumpTransaction`.
+
+```
+TransactionV1Envelope
+  └── Transaction        (same fields as V0 plus ext for future additions)
+  └── DecoratedSignature[]
+```
+
+### `FeeBumpTransactionEnvelope`
+
+Wraps a `TransactionV1Envelope` so a fee sponsor can pay the base fee without modifying the inner transaction's signatures.
+
+```
+FeeBumpTransactionEnvelope
+  └── FeeBumpTransaction (fee source, fee, inner TransactionV1Envelope)
+  └── DecoratedSignature[]  (sponsor's signature)
+```
+
+---
+
+## Version Differences
+
+| Property | V0 | V1 | Fee Bump |
+|----------|----|----|----------|
+| Protocol introduced | Pre-13 | 13 | 13 |
+| Can be fee-bumped | No | Yes | — |
+| `ext` field for future extensions | No | Yes | Yes |
+| XDR discriminant | `ENVELOPE_TYPE_TX_V0` | `ENVELOPE_TYPE_TX` | `ENVELOPE_TYPE_TX_FEE_BUMP` |
+
+The Stellar SDK always builds `TransactionV1Envelope` by default. You only encounter V0 envelopes when reading historical transactions predating Protocol 13.
+
+---
+
+## Working with Envelopes
+
+```js
+import { TransactionBuilder, xdr } from "@stellar/stellar-sdk";
+
+// Build a transaction — returns a V1 envelope by default
+const tx = new TransactionBuilder(account, { fee: "100", networkPassphrase })
+  .addOperation(/* ... */)
+  .setTimeout(30)
+  .build();
+
+// Serialize to base64 XDR for signing or storage
+const envelopeXdr = tx.toEnvelope().toXDR("base64");
+
+// Deserialize back
+const decoded = xdr.TransactionEnvelope.fromXDR(envelopeXdr, "base64");
+const type = decoded.switch().name;
+// "envelopeTypeTx" for V1, "envelopeTypeTxV0" for V0, "envelopeTypeTxFeeBump" for fee-bump
+```
+
+**Related:** [XDR Encoding and Decoding](/routes-d/482-xdr-encoding-decoding), [Fetching Transaction Details by Hash](/routes-d/467-fetching-transaction-details-by-hash)

--- a/routes-d/486-home-domain-field.md
+++ b/routes-d/486-home-domain-field.md
@@ -1,0 +1,114 @@
+---
+title: The home_domain Field
+description: How to set and use the home_domain account field, its role in stellar.toml discovery, and a small example
+---
+
+# The `home_domain` Field
+
+Every Stellar account can store a `home_domain` string — a plain domain name (e.g. `example.com`) that points to the web server hosting that issuer's `stellar.toml` file. Wallets, exchanges, and other clients use this field to discover asset metadata, federation servers, and compliance endpoints without any out-of-band configuration.
+
+---
+
+## How the Field Is Set
+
+`home_domain` is set via the `SetOptions` operation:
+
+```js
+import {
+  Horizon,
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Networks,
+} from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon-testnet.stellar.org");
+const keypair = Keypair.fromSecret("S...");
+
+async function setHomeDomain(domain) {
+  const account = await server.loadAccount(keypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.setOptions({
+        homeDomain: domain, // e.g. "example.com" — no scheme, no trailing slash
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(keypair);
+  await server.submitTransaction(tx);
+  console.log("home_domain set to:", domain);
+}
+```
+
+Constraints:
+- Maximum 32 characters.
+- No `https://` scheme — just the bare domain.
+- No trailing slash.
+
+---
+
+## TOML Discovery Integration
+
+Once `home_domain` is set, the TOML file must be reachable at:
+
+```
+https://<home_domain>/.well-known/stellar.toml
+```
+
+The file must be served over HTTPS with a `Content-Type` of `text/plain` and include a `CORS` header allowing `*`.
+
+A minimal `stellar.toml` for an issuing account:
+
+```toml
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+FEDERATION_SERVER="https://example.com/federation"
+
+[[CURRENCIES]]
+code="USDC"
+issuer="G..."
+display_decimals=2
+name="USD Coin"
+desc="A fiat-backed stablecoin."
+```
+
+Horizon includes `home_domain` in every account record, so any client can perform the lookup:
+
+```js
+async function fetchToml(publicKey) {
+  const account = await server.loadAccount(publicKey);
+  const domain = account.home_domain;
+
+  if (!domain) {
+    throw new Error("Account has no home_domain set");
+  }
+
+  const res = await fetch(`https://${domain}/.well-known/stellar.toml`);
+  return res.text(); // parse with a TOML library
+}
+```
+
+---
+
+## Example: Resolving an Asset's Metadata
+
+```js
+import { StellarToml } from "@stellar/stellar-sdk";
+
+async function getAssetInfo(issuerPublicKey) {
+  const account = await server.loadAccount(issuerPublicKey);
+  const domain = account.home_domain;
+
+  if (!domain) return null;
+
+  const toml = await StellarToml.Resolver.resolve(domain);
+  return toml.CURRENCIES; // array of currency descriptors
+}
+```
+
+**Related:** [Federation Address Resolution](/routes-d/464-federation-address-resolution), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/487-manage-data-operation.md
+++ b/routes-d/487-manage-data-operation.md
@@ -1,0 +1,124 @@
+---
+title: Manage Data Operation
+description: How to set and remove key-value data entries on a Stellar account using the ManageData operation, with size limits and a small example
+---
+
+# Manage Data Operation
+
+The `ManageData` operation lets you attach arbitrary key-value string pairs to a Stellar account. These entries are stored on-ledger and visible to anyone who reads the account record from Horizon. Common uses include storing a DID, marking an account for protocol-level feature flags, or anchoring off-chain records.
+
+---
+
+## Storage Size Limits
+
+| Property | Limit |
+|----------|-------|
+| Key length | 1 – 64 bytes (UTF-8) |
+| Value length | 0 – 64 bytes (arbitrary binary) |
+| Entries per account | Up to the account's available subentry capacity (each entry costs 0.5 XLM base reserve) |
+
+Setting a value of `null` or an empty buffer removes the entry and releases its reserve.
+
+---
+
+## Set Flow
+
+```js
+import {
+  Horizon,
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Networks,
+} from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon-testnet.stellar.org");
+const keypair = Keypair.fromSecret("S...");
+
+async function setDataEntry(key, value) {
+  const account = await server.loadAccount(keypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.manageData({
+        name: key,           // up to 64 bytes
+        value: Buffer.from(value, "utf8"), // up to 64 bytes; null to delete
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(keypair);
+  const result = await server.submitTransaction(tx);
+  console.log("Data entry set. Tx hash:", result.hash);
+}
+```
+
+---
+
+## Remove Flow
+
+Pass `null` (or omit `value`) to delete an existing entry:
+
+```js
+async function removeDataEntry(key) {
+  const account = await server.loadAccount(keypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.manageData({
+        name: key,
+        value: null, // null removes the entry
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(keypair);
+  await server.submitTransaction(tx);
+  console.log("Data entry removed:", key);
+}
+```
+
+---
+
+## Reading Entries
+
+Horizon returns all data entries in the `data` object of the account record, with values base64-encoded:
+
+```js
+async function readDataEntries(publicKey) {
+  const account = await server.loadAccount(publicKey);
+
+  for (const [key, b64Value] of Object.entries(account.data_attr)) {
+    const value = Buffer.from(b64Value, "base64").toString("utf8");
+    console.log(`${key} = ${value}`);
+  }
+}
+```
+
+---
+
+## Small Example
+
+```js
+// Store a DID document reference on the account
+await setDataEntry("did", "did:stellar:GAAZI4TCR...");
+
+// Read it back
+const account = await server.loadAccount(keypair.publicKey());
+const raw = account.data_attr["did"];
+console.log(Buffer.from(raw, "base64").toString("utf8"));
+// → did:stellar:GAAZI4TCR...
+
+// Remove it when no longer needed
+await removeDataEntry("did");
+```
+
+**Related:** [Reading Account Flags](/routes-d/485-reading-account-flags), [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary
- Document how to fetch a full transaction record from Horizon using its hash, including endpoint, response shape, and common errors
- Add a concise note on Stellar transaction envelope formats (V0, V1, and fee-bump), version differences, and how to serialize/deserialize them
- Document the `home_domain` account field — how to set it, its 32-character limit, and how wallets use it to discover `stellar.toml` metadata
- Add a guide on the `ManageData` operation covering set and remove flows, the 64-byte key/value limits, and how to read entries back from Horizon

## Closes
closes #467
closes #478
closes #486
closes #487

## Test plan
- [x] All four files added to `routes-d/` following the existing MDX-like markdown frontmatter and section style
- [x] No internal links point to pages that don't exist; cross-references use existing `routes-d` slugs
- [x] Code examples use `@stellar/stellar-sdk` imports consistent with other docs in this repo
- [x] Each document is self-contained and keeps a focused scope matching the issue summary