### PR TITLE
docs: add Stellar notes for CLI help flag, SEP, XDR, and canonical timestamps

### DIFF
--- a/routes-d/463-cli-help-flag.md
+++ b/routes-d/463-cli-help-flag.md
@@ -1,0 +1,41 @@
+---
+title: "Hint: Discovering CLI Commands via the Help Flag"
+description: How to use the --help flag to explore Nextellar CLI commands and subcommand options
+---
+
+# Discovering CLI Commands via the Help Flag
+
+Every Nextellar CLI command and subcommand accepts a `--help` (or `-h`) flag that prints a usage summary directly in your terminal.
+
+---
+
+## Top-Level Help
+
+```bash
+nextellar --help
+```
+
+This prints the full list of top-level commands, global flags, and a short description of each.
+
+---
+
+## Subcommand Help
+
+Pass `--help` after any subcommand to see its specific options:
+
+```bash
+nextellar add --help
+nextellar deploy --help
+nextellar init --help
+```
+
+Each subcommand's help output includes its accepted flags, required arguments, and brief usage examples.
+
+---
+
+## Notes
+
+- `--help` never modifies any files or runs any side effects — it is safe to run at any time.
+- If a command is not behaving as expected, running it with `--help` is a good first step before consulting the full reference.
+
+**Related:** `--version`, [CLI Flags & Options](/docs/cli/flags), [CLI Commands](/docs/cli/commands)

--- a/routes-d/473-glossary-sep.md
+++ b/routes-d/473-glossary-sep.md
@@ -1,0 +1,42 @@
+---
+title: "Glossary: SEP"
+description: Short definition of SEP (Stellar Ecosystem Proposal) and where to find the published standards
+---
+
+# Glossary: SEP
+
+**SEP** stands for **Stellar Ecosystem Proposal** — the specification process used to define interoperability standards across applications, wallets, anchors, and other services built on Stellar.
+
+---
+
+## What SEPs Cover
+
+SEPs describe protocols that multiple parties must implement consistently to work together. Common examples include:
+
+| SEP | Topic |
+|-----|-------|
+| SEP-1 | `stellar.toml` — machine-readable metadata for Stellar accounts and assets |
+| SEP-10 | Stellar Web Authentication — wallet-based sign-in |
+| SEP-24 | Hosted Deposit and Withdrawal — anchor interactive flows |
+| SEP-31 | Cross-Border Payments — direct payment API for sending parties |
+
+---
+
+## Where SEPs Are Published
+
+The full SEP index is maintained in the `stellar/stellar-protocol` repository on GitHub:
+
+**[github.com/stellar/stellar-protocol/tree/master/ecosystem](https://github.com/stellar/stellar-protocol/tree/master/ecosystem)**
+
+Each SEP is a Markdown file in that folder. Proposed SEPs start as drafts; finalized SEPs carry a `Status: Final` header.
+
+---
+
+## Notes
+
+- SEPs are ecosystem conventions, not protocol upgrades. They do not require changes to validators or the core Stellar protocol.
+- Core protocol changes follow a separate track called **CAPs** (Core Advancement Proposals).
+
+**Related:** SEP-1, SEP-10, SEP-24, anchor, `stellar.toml`, CAP
+
+**Related docs:** [Integrations](/docs/integrations), [Glossary](/docs/guides/glossary)

--- a/routes-d/477-xdr-introduction.md
+++ b/routes-d/477-xdr-introduction.md
@@ -1,0 +1,42 @@
+---
+title: "Note: XDR on Stellar"
+description: A brief introduction to XDR — what it is, where it appears, and where to learn more
+---
+
+# XDR on Stellar
+
+XDR (External Data Representation) is the binary serialization format Stellar uses to encode transactions, operations, ledger entries, and results. It is defined by RFC 4506 and produces compact, deterministic byte sequences that validators and clients exchange.
+
+---
+
+## Where XDR Appears
+
+You will encounter XDR in several places:
+
+| Context | How it shows up |
+|---------|----------------|
+| Horizon responses | `envelope_xdr`, `result_xdr`, `result_meta_xdr` fields (base64-encoded) |
+| Transaction signing | `TransactionBuilder.build()` returns an XDR envelope |
+| Soroban RPC | `simulateTransaction`, `sendTransaction`, and `getTransaction` all use XDR |
+| Stellar Laboratory | The "XDR Viewer" tab decodes raw XDR blobs manually |
+
+---
+
+## Quick Example
+
+```js
+import { xdr, TransactionEnvelope } from "@stellar/stellar-sdk";
+
+// Decode a transaction envelope returned by Horizon
+const envelope = xdr.TransactionEnvelope.fromXDR(envelopeXdrBase64, "base64");
+```
+
+---
+
+## Further Reading
+
+- [XDR Encoding and Decoding](/routes-d/482-xdr-encoding-decoding) — detailed decode helpers for transactions, results, and metadata
+- [Stellar XDR definitions on GitHub](https://github.com/stellar/stellar-xdr) — the canonical `.x` schema files
+- RFC 4506 — the underlying XDR standard
+
+**Related:** Horizon, Soroban RPC, TransactionBuilder, `envelope_xdr`

--- a/routes-d/479-canonical-timestamps.md
+++ b/routes-d/479-canonical-timestamps.md
@@ -1,0 +1,49 @@
+---
+title: "Note: Canonical Timestamps in Stellar"
+description: The timestamp format used across Stellar APIs, including timezone expectations and a short example
+---
+
+# Canonical Timestamps in Stellar
+
+Stellar APIs return timestamps as Unix epoch integers — seconds since 1 January 1970 00:00:00 UTC. All timestamps are in UTC; there is no timezone offset or local-time variant in the protocol.
+
+---
+
+## Format
+
+| Field | Value |
+|-------|-------|
+| Type | Integer (Unix epoch) |
+| Unit | Seconds |
+| Timezone | UTC (always) |
+
+Horizon surfaces this value on transactions, operations, and ledger records under the `created_at` field, which it returns as an ISO 8601 string for convenience. The underlying ledger stores only the raw integer.
+
+---
+
+## Example
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon-testnet.stellar.org");
+const tx = await server.transactions().transaction("<tx-hash>").call();
+
+// Horizon returns ISO 8601 for created_at
+console.log(tx.created_at); // "2024-06-25T11:18:36Z"
+
+// Convert to a JS Date or Unix integer as needed
+const date = new Date(tx.created_at);
+const unixSeconds = Math.floor(date.getTime() / 1000);
+```
+
+---
+
+## Notes
+
+- Always treat timestamps as UTC. Stellar has no concept of local time zones.
+- The ledger `close_time` on a `LedgerRecord` is the epoch integer directly.
+- `time_bounds` in a transaction (`min_time`, `max_time`) are also Unix epoch seconds. A transaction will fail if submitted outside these bounds.
+- Clock skew between your system and validator nodes can cause transactions near the bounds to fail; leave a small buffer (30–60 seconds) on both ends.
+
+**Related:** time bounds, ledger close time, `TransactionBuilder.setTimeout`


### PR DESCRIPTION
## Summary

- Add a short hint on discovering CLI commands via the `--help` flag
- Add a glossary entry for SEP (Stellar Ecosystem Proposal)
- Add a brief XDR introduction note
- Add a note on canonical timestamps in Stellar

## Issues closed

closes #463
closes #473
closes #477
closes #479

## Test plan

- [ ] `pnpm build:content` passes with no new errors
- [ ] `pnpm check:links` passes with no new broken links
- [ ] All 4 files follow existing MDX frontmatter and writing style