### PR TITLE
docs: add guides for consensus, liquidity, bump sequence and reserves

### DIFF
--- a/routes-d/489.mdx
+++ b/routes-d/489.mdx
@@ -1,0 +1,35 @@
+---
+title: Bump Sequence Operation
+description: Document the bump sequence operation and its use cases.
+---
+
+# Bump Sequence Operation
+
+The `bump_sequence` operation allows an account to increase its sequence number forward to a specified value. This operation must bump the sequence number to a value strictly greater than the account's current sequence number.
+
+## Use Cases
+
+The primary use cases for the bump sequence operation include:
+
+- **Invalidating Transactions**: By bumping the sequence number past the sequence number of a previously signed, but unsubmitted transaction, you can permanently invalidate that transaction.
+- **Smart Contracts and Pre-Auth**: It is frequently used in complex multi-signature setups or smart contracts where specific sequence numbers are pre-authorized and need to be skipped or consumed without executing an actual transaction.
+
+## Example
+
+Here is a small example of how a `bump_sequence` operation might look in a Stellar transaction:
+
+```json
+{
+  "source_account": "GB7...",
+  "fee": 100,
+  "sequence_number": 10,
+  "operations": [
+    {
+      "type": "bump_sequence",
+      "bump_to": 15
+    }
+  ]
+}
+```
+
+After this transaction is applied, the account's sequence number becomes 15, invalidating any pre-signed transactions that had sequence numbers 11 through 15.

--- a/routes-d/490.mdx
+++ b/routes-d/490.mdx
@@ -1,0 +1,46 @@
+---
+title: Sponsoring Future Reserves
+description: Document the begin_sponsoring_future_reserves operation on Stellar.
+---
+
+# Sponsoring Future Reserves
+
+The `begin_sponsoring_future_reserves` operation allows one account (the sponsor) to pay the base reserve requirements for another account (the sponsored account) for any subsequent operations within the same transaction.
+
+## The Sponsor Flow
+
+Sponsorship always follows a strict pattern involving two distinct operations:
+
+1. **Begin Sponsorship**: The sponsoring account issues a `begin_sponsoring_future_reserves` operation, specifying the account to be sponsored.
+2. **Sponsored Operations**: The sponsored account executes one or more operations (e.g., creating a trustline or offering). The sponsor will cover the base reserve requirement for these actions.
+3. **End Sponsorship**: The sponsored account must issue an `end_sponsoring_future_reserves` operation to conclude the sponsorship block.
+
+Both the start and end operations must occur within the **same transaction**.
+
+## Example
+
+Here is a small example showing the sponsor flow:
+
+```json
+{
+  "operations": [
+    {
+      "source_account": "SponsorAccount",
+      "type": "begin_sponsoring_future_reserves",
+      "sponsored_id": "SponsoredAccount"
+    },
+    {
+      "source_account": "SponsoredAccount",
+      "type": "change_trust",
+      "line": "USDC:IssuerAccount",
+      "limit": "10000"
+    },
+    {
+      "source_account": "SponsoredAccount",
+      "type": "end_sponsoring_future_reserves"
+    }
+  ]
+}
+```
+
+In this transaction, `SponsorAccount` pays the reserve required to establish the USDC trustline for `SponsoredAccount`.

--- a/routes-d/493.mdx
+++ b/routes-d/493.mdx
@@ -1,0 +1,39 @@
+---
+title: Liquidity Pool Deposit Math
+description: Explain the math behind liquidity pool deposits and shares on Stellar.
+---
+
+# Liquidity Pool Deposit Math
+
+When you deposit assets into a Stellar liquidity pool, you receive pool shares representing your proportional ownership of the pool's assets.
+
+## Share Calculation
+
+The number of shares minted upon deposit is determined by the ratio of the deposited amounts to the pool's total reserves prior to the deposit. If the pool is empty, the initial shares are calculated as the geometric mean of the deposited amounts.
+
+For subsequent deposits, the shares received ($S_{mint}$) are calculated as:
+
+$$
+S_{mint} = S_{total} \times \min\left( \frac{A_{deposit}}{A_{reserve}}, \frac{B_{deposit}}{B_{reserve}} \right)
+$$
+
+Where:
+
+- $S_{total}$ is the total outstanding pool shares.
+- $A_{deposit}, B_{deposit}$ are the amounts of Asset A and Asset B deposited.
+- $A_{reserve}, B_{reserve}$ are the current reserves of Asset A and Asset B in the pool.
+
+## Slippage Considerations
+
+Because the pool reserves can change between the time you submit a deposit transaction and when it executes, the actual amount of shares you receive can vary. You must specify a maximum slippage tolerance (e.g., `min_price` and `max_price` bounds) to prevent your transaction from executing if the pool's ratio shifts unfavorably.
+
+## Example
+
+Suppose a pool contains 100X and 200Y, with 100 total pool shares. You deposit 10X and 20Y.
+
+The ratio is:
+
+- $10 / 100 = 0.1$
+- $20 / 200 = 0.1$
+
+You will receive $100 \times 0.1 = 10$ pool shares. If the pool ratio had shifted to 100X and 210Y right before your transaction, your 20Y deposit would fall short of the required ratio, triggering a potential slippage failure depending on your set bounds.

--- a/routes-d/500.mdx
+++ b/routes-d/500.mdx
@@ -1,0 +1,20 @@
+---
+title: Stellar Consensus Rounds
+description: A brief explanation of how consensus rounds work on Stellar.
+---
+
+# Stellar Consensus Rounds
+
+The Stellar Consensus Protocol (SCP) organizes agreement on the network through continuous rounds. In each round, nodes agree on a candidate transaction set to apply to the ledger.
+
+## Round Phases
+
+A typical consensus round consists of several phases:
+
+1. **Nomination**: Nodes propose and exchange candidate transaction sets. The network converges on a single composite set of transactions to apply.
+2. **Ballot Preparation**: Nodes construct a ballot containing the nominated transaction set and attempt to reach an agreement that the ballot is safe to commit.
+3. **Ballot Commit**: Once a ballot is sufficiently prepared, nodes commit the ballot. Applying the transaction set advances the ledger state.
+
+## Typical Duration
+
+A complete consensus round on the Stellar network typically takes around **5 to 7 seconds**. This fast finality is a core feature of SCP, ensuring that transactions are confirmed quickly and cannot be reversed once the round concludes.


### PR DESCRIPTION
# Description

This PR introduces initial draft documentation for several key Stellar concepts and operations, expanding our educational resources for developers building on the network. These guides are currently placed in the `routes-d/` directory as working drafts, matching our existing MDX frontmatter and structural conventions, and they will be moved to their final routes once approved.

Specifically, the following guides have been added:
- **Stellar Consensus Rounds (#500):** A brief explanation of how the Stellar Consensus Protocol (SCP) organizes agreement. It defines the core round phases (Nomination, Ballot Preparation, Ballot Commit) and highlights their typical 5–7 second duration to emphasize network finality.
- **Liquidity Pool Deposit Math (#493):** A breakdown of the math governing liquidity pool deposits. It covers how pool shares are calculated for both initial and subsequent deposits, discusses slippage considerations (such as setting `min_price` and `max_price` bounds), and provides a practical numerical example to illustrate the concepts.
- **Bump Sequence Operation (#489):** Documentation on the `bump_sequence` operation, detailing its usage and common patterns. This includes practical use cases like invalidating pre-signed, unsubmitted transactions and facilitating complex smart contract pre-auth setups. A complete JSON transaction example is included.
- **Sponsoring Future Reserves (#490):** A guide covering the `begin_sponsoring_future_reserves` operation. It outlines the strict three-step sponsor flow (Begin Sponsorship, Sponsored Operations, End Sponsorship) required within a single transaction, accompanied by a JSON example to show how a sponsor can cover the base reserve requirement for actions like establishing a trustline.

## Issues Closed
Closes #489
Closes #490
Closes #493
Closes #500

## Validation
- [x] Content builds successfully via `pnpm build:content` without syntax errors.
- [x] Internal links checked and verified via `pnpm check:links`.
- [x] MDX frontmatter and writing style match the existing repository conventions.
