### PR TITLE
docs: add routes-d guides for issues #495, #498, #501, #503

### DIFF
--- a/routes-d/495-reading-operation-results.md
+++ b/routes-d/495-reading-operation-results.md
@@ -1,0 +1,156 @@
+---
+title: Reading Operation Results
+description: How to parse operation result codes from Horizon responses and decoded XDR, with common code mappings and a worked example
+---
+
+# Reading Operation Results
+
+When a Stellar transaction is applied to the ledger, each operation produces its own result code. Horizon surfaces these codes in two places: the structured `result_codes` object on failed submissions, and the `result_xdr` field on any settled transaction. Knowing how to read both saves time when debugging failed payments, trustline changes, and contract calls.
+
+---
+
+## Where Result Fields Live
+
+| Field                 | When present              | What it contains                                                 |
+| --------------------- | ------------------------- | ---------------------------------------------------------------- |
+| `successful`          | Every settled transaction | `true` only if every operation succeeded                         |
+| `result_xdr`          | Every settled transaction | Base64-encoded `TransactionResult` with per-operation outcomes   |
+| `result_meta_xdr`     | Every settled transaction | Ledger entry changes (balances, trustlines, contract storage)    |
+| `extras.result_codes` | Failed submit (`400`)     | Human-readable `transaction` and `operations` codes from Horizon |
+| `fee_charged`         | Every settled transaction | Actual fee deducted in stroops                                   |
+
+Horizon's submit endpoint returns `200 OK` when the transaction was accepted for processing — not when every operation succeeded. Always inspect `successful` and the operation-level codes before treating a transaction as complete.
+
+---
+
+## Reading Result Codes from Horizon
+
+On a failed submission, Horizon includes structured codes under `extras.result_codes`:
+
+```js
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+async function submitAndReadCodes(signedTx) {
+  try {
+    const result = await server.submitTransaction(signedTx);
+    console.log('Transaction hash:', result.hash);
+    console.log('All operations succeeded:', result.successful);
+    return result;
+  } catch (err) {
+    const extras = err?.response?.data?.extras;
+    if (extras?.result_codes) {
+      console.error('Transaction code:', extras.result_codes.transaction);
+      console.error('Operation codes:', extras.result_codes.operations);
+    }
+    throw err;
+  }
+}
+```
+
+The `operations` array aligns with operation index: `operations[2]` is the result code for the third operation in the envelope.
+
+---
+
+## Decoding `result_xdr`
+
+For transactions already on the ledger, decode `result_xdr` to inspect each operation's outcome:
+
+```js
+import { Horizon, xdr } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+
+async function readOperationResults(txHash) {
+  const tx = await server.transactions().transaction(txHash).call();
+  const result = xdr.TransactionResult.fromXDR(tx.result_xdr, 'base64');
+  const opResults = result.result().results();
+
+  return opResults.map((opResult, index) => {
+    const tr = opResult.tr();
+    const code = tr.switch().name;
+
+    // Payment-specific detail when available
+    if (code === 'payment') {
+      return { index, code, detail: tr.paymentResult().switch().name };
+    }
+
+    return { index, code };
+  });
+}
+```
+
+Use `result_meta_xdr` when you need balance deltas or trustline changes — not just success or failure.
+
+---
+
+## Common Code Mappings
+
+### Transaction-level codes
+
+| Code                           | Meaning                       | Typical fix                  |
+| ------------------------------ | ----------------------------- | ---------------------------- |
+| `tx_success`                   | All operations succeeded      | None                         |
+| `tx_failed`                    | At least one operation failed | Inspect `operations` array   |
+| `tx_bad_seq`                   | Sequence number already used  | Reload account and rebuild   |
+| `tx_insufficient_fee`          | Fee below network minimum     | Raise fee via `/fee_stats`   |
+| `tx_too_early` / `tx_too_late` | Outside valid time bounds     | Adjust `minTime` / `maxTime` |
+| `tx_bad_auth`                  | Missing required signature    | Check signers and weights    |
+
+### Operation-level codes
+
+| Code                     | Meaning                             | Typical fix                                 |
+| ------------------------ | ----------------------------------- | ------------------------------------------- |
+| `op_success`             | Operation applied                   | None                                        |
+| `op_underfunded`         | Source balance too low              | Check available balance and reserves        |
+| `op_no_trust`            | Destination lacks trustline         | Add trustline or use authorized asset       |
+| `op_line_full`           | Destination trustline limit reached | Raise limit or use different account        |
+| `op_low_reserve`         | Account would drop below minimum    | Leave more XLM for base reserve             |
+| `op_bad_auth`            | Operation signer missing            | Add required signature                      |
+| `op_not_supported`       | Operation type disabled on network  | Verify network and protocol version         |
+| `op_exceeded_work_limit` | Soroban resource budget exceeded    | Reduce contract work or raise resource fees |
+
+---
+
+## Small Example
+
+```js
+import { Horizon, xdr } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+async function diagnosePayment(txHash) {
+  const tx = await server.transactions().transaction(txHash).call();
+
+  if (tx.successful) {
+    console.log('Payment succeeded. Fee:', tx.fee_charged, 'stroops');
+    return;
+  }
+
+  const result = xdr.TransactionResult.fromXDR(tx.result_xdr, 'base64');
+  const txCode = result.result().switch().name;
+  console.log('Transaction result:', txCode);
+
+  result
+    .result()
+    .results()
+    .forEach((op, i) => {
+      const opCode = op.tr().switch().name;
+      console.log(`Operation ${i}: ${opCode}`);
+    });
+}
+
+// Usage after a failed payment attempt
+await diagnosePayment('a1b2c3d4e5f6...');
+```
+
+---
+
+## Notes
+
+- Batch transactions fail atomically — if operation 3 fails, operations 4+ are not applied, but earlier operations in the same transaction are rolled back too.
+- Fee-bump wrappers expose the inner transaction's result inside the outer `result_xdr`; decode both layers when debugging nested envelopes.
+- For live dashboards, emit metrics keyed by `result_code` rather than logging full XDR on every failure.
+
+**Related:** [Transaction Results Shape](/routes-d/496-transaction-results-shape), [XDR Encoding and Decoding](/routes-d/482-xdr-encoding-decoding), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/498-webhook-patterns-horizon.md
+++ b/routes-d/498-webhook-patterns-horizon.md
@@ -1,0 +1,172 @@
+---
+title: Webhook Patterns over Horizon
+description: How to fan out Horizon SSE updates to HTTP webhooks, delivery guarantees, and a small bridge-service example
+---
+
+# Webhook Patterns over Horizon
+
+Horizon exposes real-time ledger data through server-sent events (SSE) on collection endpoints such as `/payments`, `/transactions`, `/effects`, and `/ledgers`. Most backend services, however, expect plain HTTP webhooks. A small bridge layer between Horizon streams and your webhook consumers is the standard pattern for turning on-chain activity into application events.
+
+---
+
+## The Fan-Out Pattern
+
+```
+Horizon SSE  →  Bridge service  →  Webhook subscribers
+(payments)      (filter + queue)     (HTTPS POST endpoints)
+```
+
+The bridge service:
+
+1. Opens one or more long-lived Horizon SSE connections (typically one stream per watched account or contract).
+2. Normalizes each event into a stable JSON payload.
+3. Matches the event against subscriber rules (account, asset, operation type).
+4. Delivers matching events to registered webhook URLs with retries and idempotency keys.
+
+This keeps Horizon connection count low while allowing many downstream consumers.
+
+---
+
+## Horizon Streams to Bridge
+
+```js
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+
+function watchPayments(accountId, onEvent) {
+  return server
+    .payments()
+    .forAccount(accountId)
+    .cursor('now')
+    .stream({
+      onmessage: (payment) => {
+        onEvent({
+          id: payment.id,
+          type: payment.type,
+          account: payment.to ?? payment.from,
+          asset: payment.asset_type === 'native' ? 'XLM' : payment.asset_code,
+          amount: payment.amount,
+          txHash: payment.transaction_hash,
+          ledger: payment.ledger,
+        });
+      },
+      onerror: (err) => console.error('SSE error:', err),
+    });
+}
+```
+
+Use `cursor=now` to skip historical records. Persist the last `paging_token` (or ledger sequence) so the bridge can resume after restarts without replaying the full history.
+
+---
+
+## Webhook Delivery
+
+```js
+async function deliverWebhook(subscriber, event) {
+  const idempotencyKey = `${event.txHash}:${event.id}`;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const res = await fetch(subscriber.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Id': idempotencyKey,
+        'X-Webhook-Signature': signPayload(subscriber.secret, event),
+      },
+      body: JSON.stringify({ event: 'payment.received', data: event }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (res.ok) return;
+    await sleep(2 ** attempt * 1000); // 1 s, 2 s, 4 s backoff
+  }
+
+  await deadLetterQueue.push({ subscriber, event, idempotencyKey });
+}
+```
+
+Subscribers should verify the HMAC signature and deduplicate on `X-Webhook-Id`.
+
+---
+
+## Delivery Guarantees
+
+| Guarantee                           | Reality                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| **At-least-once delivery**          | Yes, with retries — subscribers may receive duplicates                                     |
+| **Exactly-once**                    | No — design handlers to be idempotent                                                      |
+| **Ordering**                        | Per-stream ordering is roughly ledger order, but reconnects can replay or skip during gaps |
+| **Latency**                         | Typically within one ledger close (~5 s) plus bridge processing time                       |
+| **Durability while bridge is down** | No — events missed during downtime are lost unless you backfill from Horizon REST          |
+
+Horizon SSE is a **best-effort push channel**, not a durable message bus. For guaranteed replay across outages, persist cursors and backfill gaps with paginated REST queries (`order=asc`, cursor-based pagination) before resuming the stream.
+
+---
+
+## Small Example: Multi-Subscriber Bridge
+
+```js
+import { Horizon } from '@stellar/stellar-sdk';
+
+const subscribers = [
+  {
+    url: 'https://api.example.com/hooks/treasury',
+    accounts: ['GABC...'],
+    secret: 'whsec_...',
+  },
+  {
+    url: 'https://billing.example.com/stellar',
+    accounts: ['GABC...', 'GDEF...'],
+    secret: 'whsec_...',
+  },
+];
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+
+function matchesSubscriber(payment, sub) {
+  return (
+    sub.accounts.includes(payment.to) || sub.accounts.includes(payment.from)
+  );
+}
+
+function startBridge(watchedAccount) {
+  return server
+    .payments()
+    .forAccount(watchedAccount)
+    .cursor('now')
+    .stream({
+      onmessage: async (payment) => {
+        const normalized = {
+          id: payment.id,
+          type: payment.type,
+          from: payment.from,
+          to: payment.to,
+          amount: payment.amount,
+          asset: payment.asset_type,
+          txHash: payment.transaction_hash,
+        };
+
+        await Promise.all(
+          subscribers
+            .filter((sub) => matchesSubscriber(payment, sub))
+            .map((sub) => deliverWebhook(sub, normalized))
+        );
+      },
+    });
+}
+
+startBridge('GABC...');
+```
+
+Run one SSE connection per watched account (or merge filters in the bridge) rather than opening a connection per webhook subscriber.
+
+---
+
+## Notes
+
+- Rate-limit outbound webhook calls so a burst of ledger activity does not overwhelm downstream services.
+- Separate **operational** streams (payments to your treasury) from **analytics** streams (all contract events) — they have different durability and filtering needs.
+- For Soroban contract events, combine Horizon payment/transaction streams with a dedicated indexer when you need historical queries or complex filters.
+
+**Related:** [Latest Ledger Streaming](/routes-d/481-latest-ledger-streaming), [Transaction Observability](/docs/guides/transaction-observability), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/501-off-chain-user-preferences.md
+++ b/routes-d/501-off-chain-user-preferences.md
@@ -1,0 +1,178 @@
+---
+title: Storing User Preferences Off Chain
+description: Compare off-chain storage options for dApp user preferences, privacy considerations, and a small implementation example
+---
+
+# Storing User Preferences Off Chain
+
+dApps often need to remember UI settings — theme, locale, notification toggles, slippage tolerance — that do not belong on the public Stellar ledger. Storing preferences off chain keeps transactions cheap, avoids permanent exposure of personal choices, and sidesteps the 64-byte `ManageData` limit. This guide compares common approaches and notes the privacy trade-offs for each.
+
+---
+
+## Option Comparison
+
+| Storage                   | Persistence       | Sync across devices | Privacy                       | Best for                                  |
+| ------------------------- | ----------------- | ------------------- | ----------------------------- | ----------------------------------------- |
+| **sessionStorage**        | Tab session only  | No                  | Highest (cleared on close)    | Wallet connection state, ephemeral UI     |
+| **localStorage**          | Until cleared     | No                  | Medium (device-local)         | Theme, language, dismissed banners        |
+| **IndexedDB**             | Until cleared     | No                  | Medium                        | Larger structured prefs, offline caches   |
+| **Backend database**      | Server-controlled | Yes                 | Lower (links wallet to prefs) | Cross-device settings, account dashboards |
+| **Encrypted backend**     | Server-controlled | Yes                 | Medium–high                   | PII-adjacent prefs with user consent      |
+| **IPFS / decentralized**  | Content-addressed | Yes (with pinning)  | Varies                        | Portable, user-owned preference blobs     |
+| **ManageData (on-chain)** | Permanent, public | Yes                 | Lowest                        | Protocol flags only — not UI preferences  |
+
+For most dApps, **localStorage for device-local UI** plus an **optional encrypted backend** for signed-in users covers the common cases without putting preference data on the ledger.
+
+---
+
+## Privacy Considerations
+
+- **Wallet correlation**: Storing `{ publicKey → preferences }` in your backend links a user's on-chain history to their settings. Collect only what you need and offer deletion.
+- **Public ledger alternative**: `ManageData` entries are visible to anyone who reads the account from Horizon. Never store emails, names, or other PII on-chain.
+- **Third-party analytics**: Sending preference changes to analytics tools can leak behavioral data. Keep analytics payloads coarse-grained (e.g. `"theme: dark"`) rather than full preference objects.
+- **Cross-site leakage**: `localStorage` is origin-scoped. Subdomains and iframes cannot read each other's storage — but do not embed third-party scripts that can read the DOM alongside wallet addresses.
+
+Prefer session-scoped storage for anything tied to an active wallet session:
+
+```ts
+// Cleared when the tab closes — safer for wallet-linked state
+export const sessionPrefs = {
+  get: (key: string) => sessionStorage.getItem(`pref:${key}`),
+  set: (key: string, value: string) =>
+    sessionStorage.setItem(`pref:${key}`, value),
+  clear: () => {
+    Object.keys(sessionStorage)
+      .filter((k) => k.startsWith('pref:'))
+      .forEach((k) => sessionStorage.removeItem(k));
+  },
+};
+```
+
+---
+
+## Local Preference Store
+
+```ts
+export interface UserPreferences {
+  theme: 'light' | 'dark' | 'system';
+  locale: string;
+  slippageBps: number;
+  notifications: { payments: boolean; governance: boolean };
+}
+
+const DEFAULTS: UserPreferences = {
+  theme: 'system',
+  locale: 'en',
+  slippageBps: 50,
+  notifications: { payments: true, governance: false },
+};
+
+export function loadPreferences(): UserPreferences {
+  try {
+    const raw = localStorage.getItem('nextellar:prefs');
+    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS;
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function savePreferences(prefs: Partial<UserPreferences>) {
+  const merged = { ...loadPreferences(), ...prefs };
+  localStorage.setItem('nextellar:prefs', JSON.stringify(merged));
+  return merged;
+}
+```
+
+---
+
+## Optional Backend Sync
+
+When users opt in to cross-device sync, key preferences by public key and require a SEP-10 or wallet signature before writing:
+
+```ts
+// app/api/preferences/route.ts
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const { publicKey, preferences, signedMessage } = await request.json();
+
+  // Verify the user controls publicKey (SEP-10 token or signed challenge)
+  if (!(await verifyWalletAuth(publicKey, signedMessage))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  await db.preferences.upsert({
+    where: { publicKey },
+    update: { data: preferences, updatedAt: new Date() },
+    create: { publicKey, data: preferences },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(request: Request) {
+  const publicKey = new URL(request.url).searchParams.get('publicKey');
+  if (!publicKey)
+    return NextResponse.json({ error: 'Missing publicKey' }, { status: 400 });
+
+  const row = await db.preferences.findUnique({ where: { publicKey } });
+  return NextResponse.json(row?.data ?? {});
+}
+```
+
+Store only non-sensitive UI settings server-side. Keep KYC data in a separate, access-controlled table.
+
+---
+
+## Small Example: React Hook
+
+```tsx
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  loadPreferences,
+  savePreferences,
+  type UserPreferences,
+} from '@/lib/preferences';
+
+export function usePreferences() {
+  const [prefs, setPrefs] = useState<UserPreferences>(loadPreferences);
+
+  useEffect(() => {
+    savePreferences(prefs);
+  }, [prefs]);
+
+  const update = useCallback((patch: Partial<UserPreferences>) => {
+    setPrefs((current) => ({ ...current, ...patch }));
+  }, []);
+
+  return { prefs, update };
+}
+
+// Usage
+function SettingsPanel() {
+  const { prefs, update } = usePreferences();
+
+  return (
+    <label>
+      Slippage tolerance (%)
+      <input
+        type="number"
+        value={prefs.slippageBps / 100}
+        onChange={(e) => update({ slippageBps: Number(e.target.value) * 100 })}
+      />
+    </label>
+  );
+}
+```
+
+---
+
+## Notes
+
+- On-chain `ManageData` is appropriate for protocol-visible flags (home domain, federation hints), not for UI toggles — see [Manage Data Operation](/routes-d/487-manage-data-operation).
+- Export and delete endpoints help meet privacy regulations when you store preferences server-side.
+- Version your preference schema (`prefsVersion: 2`) so migrations do not corrupt stored JSON.
+
+**Related:** [Privacy Considerations](/docs/guides/privacy-considerations), [Manage Data Operation](/routes-d/487-manage-data-operation), [Horizon Integration](/docs/integrations/horizon)

--- a/routes-d/503-price-oracle-horizon-data.md
+++ b/routes-d/503-price-oracle-horizon-data.md
@@ -1,0 +1,179 @@
+---
+title: Price Oracle Integration with Horizon Data
+description: How to derive price signals from Horizon market data, staleness considerations, and a small mid-price example
+---
+
+# Price Oracle Integration with Horizon Data
+
+On-chain Soroban contracts cannot fetch HTTP endpoints directly, but off-chain services can read Stellar's decentralized exchange (DEX) data through Horizon and push derived prices to a contract or cache. Horizon exposes order books, recent trades, and path-finding endpoints that together form a practical price signal for many asset pairs.
+
+---
+
+## Data Sources
+
+| Horizon endpoint            | What it provides                         | Typical use                                  |
+| --------------------------- | ---------------------------------------- | -------------------------------------------- |
+| `GET /order_book`           | Current bids and asks for a trading pair | Mid-price, spread, liquidity depth           |
+| `GET /trades`               | Executed trades (recent history)         | Volume-weighted average price (VWAP)         |
+| `GET /paths/strict-receive` | Best conversion path for a target amount | Effective swap price including path payments |
+| `GET /assets`               | Issuer metadata, tom flags               | Filter unauthorized or frozen assets         |
+
+All endpoints are available through the Stellar SDK:
+
+```js
+import { Horizon, Asset } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+const usdc = new Asset(
+  'USDC',
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPPXUUZAAZ5'
+);
+
+// Order book snapshot
+const book = await server.orderbook(usdc, Asset.native()).call();
+
+// Recent trades (newest first with order=desc)
+const trades = await server
+  .trades()
+  .forAssetPair(usdc, Asset.native())
+  .order('desc')
+  .limit(20)
+  .call();
+```
+
+---
+
+## Deriving a Mid-Price
+
+The simplest signal is the midpoint between the best bid and best ask:
+
+```js
+function midPriceFromOrderBook(book) {
+  const bestBid = book.bids[0];
+  const bestAsk = book.asks[0];
+
+  if (!bestBid || !bestAsk) return null;
+
+  const bid = parseFloat(bestBid.price);
+  const ask = parseFloat(bestAsk.price);
+
+  return (bid + ask) / 2;
+}
+
+async function fetchXlmUsdcMid(server) {
+  const usdc = new Asset(
+    'USDC',
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPPXUUZAAZ5'
+  );
+  const book = await server.orderbook(usdc, Asset.native()).call();
+  return midPriceFromOrderBook(book);
+}
+```
+
+For thin markets, prefer a **VWAP over recent trades** instead of the mid-price:
+
+```js
+function vwapFromTrades(trades) {
+  let volume = 0;
+  let notional = 0;
+
+  for (const trade of trades.records) {
+    const qty = parseFloat(trade.base_amount);
+    const px = parseFloat(trade.price);
+    volume += qty;
+    notional += qty * px;
+  }
+
+  return volume > 0 ? notional / volume : null;
+}
+```
+
+---
+
+## Staleness Considerations
+
+| Risk                        | Mitigation                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| **Order book snapshot age** | Timestamp is implicit — re-fetch on a fixed interval (e.g. every ledger close, ~5 s) |
+| **Stale resting offers**    | Cross-check against recent trades; ignore bids/asks with zero recent volume          |
+| **Wide spread**             | Treat mid-price as unreliable when `(ask - bid) / mid > threshold` (e.g. 2%)         |
+| **Thin liquidity**          | Require minimum depth at top of book before publishing a price                       |
+| **Ledger delay**            | Horizon trails the network by roughly one ledger; not suitable for sub-second HFT    |
+| **Push oracle lag**         | Record `lastUpdated` in your contract and reject reads older than `maxAgeSeconds`    |
+
+A practical policy: publish a price only when the spread is below your threshold **and** at least one trade occurred in the last N ledgers.
+
+```js
+const MAX_SPREAD_PCT = 0.02;
+const MAX_TRADE_AGE_SEC = 60;
+
+function isPriceFresh(book, latestTrade) {
+  const mid = midPriceFromOrderBook(book);
+  if (!mid || !latestTrade) return false;
+
+  const bid = parseFloat(book.bids[0].price);
+  const ask = parseFloat(book.asks[0].price);
+  const spread = (ask - bid) / mid;
+
+  const tradeAge =
+    Date.now() / 1000 -
+    new Date(latestTrade.ledger_close_time).getTime() / 1000;
+
+  return spread <= MAX_SPREAD_PCT && tradeAge <= MAX_TRADE_AGE_SEC;
+}
+```
+
+---
+
+## Small Example: Off-Chain Feeder
+
+```js
+import { Horizon, Asset } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+const USDC = new Asset(
+  'USDC',
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPPXUUZAAZ5'
+);
+
+async function pollAndPush(onPrice) {
+  const [book, trades] = await Promise.all([
+    server.orderbook(USDC, Asset.native()).call(),
+    server
+      .trades()
+      .forAssetPair(USDC, Asset.native())
+      .order('desc')
+      .limit(10)
+      .call(),
+  ]);
+
+  const latestTrade = trades.records[0];
+  if (!isPriceFresh(book, latestTrade)) {
+    console.warn('Price signal stale or spread too wide — skipping publish');
+    return;
+  }
+
+  const price = midPriceFromOrderBook(book);
+  await onPrice({
+    pair: 'XLM/USDC',
+    price,
+    ledger: latestTrade.ledger,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+// Poll every ledger close (~5 s)
+setInterval(() => pollAndPush(pushToOracleContract), 5_000);
+```
+
+Wire `pushToOracleContract` to your Soroban admin keypair — see [Soroban Oracle Integration](/routes-d/449-soroban-oracle-integration) for the on-chain consumer side.
+
+---
+
+## Notes
+
+- Stellar stores offer prices as exact fractions (`price_r.n` / `price_r.d`); Horizon also returns a decimal `price` string — use `price_r` when precision matters. See [Price Representation](/routes-d/502-price-representation).
+- For pairs with no direct market, use `/paths/strict-receive` to derive an implied price through intermediary assets.
+- Do not treat Horizon DEX data as an authoritative fiat oracle — it reflects on-network liquidity, not external exchange rates.
+
+**Related:** [Price Representation and Precision](/routes-d/502-price-representation), [Soroban Oracle Integration](/routes-d/449-soroban-oracle-integration), [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary

Adds four working documentation drafts in `routes-d/` for open documentation issues:

- **#495 — Reading operation results** (`routes-d/495-reading-operation-results.md`): Explains where result fields live in Horizon responses, how to decode `result_xdr`, common transaction/operation code mappings, and a diagnostic example.
- **#498 — Webhook patterns over Horizon** (`routes-d/498-webhook-patterns-horizon.md`): Outlines the SSE-to-webhook fan-out pattern, delivery guarantees (at-least-once, idempotency, backfill), and a small multi-subscriber bridge example.
- **#501 — Off-chain user preferences** (`routes-d/501-off-chain-user-preferences.md`): Compares storage options (sessionStorage, localStorage, backend, IPFS vs on-chain ManageData), privacy considerations, and a React hook example.
- **#503 — Price oracle integration with Horizon data** (`routes-d/503-price-oracle-horizon-data.md`): Covers Horizon DEX data sources, mid-price/VWAP derivation, staleness and spread checks, and an off-chain feeder example.

All drafts follow existing `routes-d` frontmatter and writing style, with internal links to related guides.

## Test plan

- [x] `pnpm build:content` completes without errors
- [x] Internal links reference existing published docs and `routes-d` drafts
- [ ] Maintainer review and approval before merge
- [ ] `pnpm check:links` (requires dev server; validates sidebar component links — unchanged by this PR)

Closes #495, closes #498, closes #501, closes #503

Made with [Cursor](https://cursor.com)