### PR TITLE
docs(routes-d): add drafts for issues #466 #474 #484 and #488

### DIFF
--- a/routes-d/466.mdx
+++ b/routes-d/466.mdx
@@ -1,0 +1,47 @@
+---
+title: Horizon URL Endpoints
+description: Canonical Horizon endpoints for Testnet and Mainnet networks.
+---
+
+# Horizon URL Endpoints
+
+Use the correct Horizon endpoint for your target network.
+
+## Base URLs
+
+| Network | URL                                   |
+| ------- | ------------------------------------- |
+| Testnet | `https://horizon-testnet.stellar.org` |
+| Mainnet | `https://horizon.stellar.org`         |
+
+## When to Use Each
+
+- **Testnet**: Development, testing, and tutorials. No real funds at risk.
+- **Mainnet**: Production dApps and real transactions. Uses real XLM.
+
+## Example
+
+```ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+// Testnet for development
+const testnetServer = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+// Mainnet for production
+const mainnetServer = new Horizon.Server('https://horizon.stellar.org');
+```
+
+With Nextellar:
+
+```tsx
+// Use testnet for development
+<WalletProvider horizonUrl="https://horizon-testnet.stellar.org">
+
+// Use mainnet for production
+<WalletProvider horizonUrl="https://horizon.stellar.org">
+```
+
+## Related
+
+- [Stellar Horizon](/docs/integrations/horizon)
+- [WalletProvider](/docs/hooks/wallet-provider)

--- a/routes-d/474.mdx
+++ b/routes-d/474.mdx
@@ -1,0 +1,50 @@
+---
+title: Stellar Protocol Versions
+description: How to find the current Stellar protocol version and its relevance to features.
+---
+
+# Stellar Protocol Versions
+
+The Stellar protocol version determines which features are available on the network. Check the version before using newer operations.
+
+## Finding the Current Version
+
+Query the protocol version via Horizon:
+
+```bash
+curl https://horizon.stellar.org/
+```
+
+The response includes:
+
+```json
+{
+  "stellar_core_version": "20.1.0",
+  "protocol_version": 20
+}
+```
+
+Alternatively, use the Stellar SDK:
+
+```ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon.stellar.org');
+const info = await server.info();
+console.log(info.protocol_version); // e.g., 20
+```
+
+## Protocol Version Relevance
+
+Most Stellar operations work across protocol versions. However, some features require minimum versions:
+
+- **Sponsored Reserves** (CAP-23) - Protocol 15+
+- **Claimable Balances** (CAP-29) - Protocol 14+
+- **Smart Contracts** - Protocol 20+ (Soroban)
+
+Always check the protocol version when targeting mainnet to ensure compatibility.
+
+## Related
+
+- [Stellar Horizon](/docs/integrations/horizon)
+- [Soroban (Smart Contracts)](https://docs.soroban.stellar.org)

--- a/routes-d/484.mdx
+++ b/routes-d/484.mdx
@@ -1,0 +1,66 @@
+---
+title: Address vs Account ID
+description: Compare the user-facing Stellar address and the underlying account ID formats.
+---
+
+# Stellar Address vs Account ID
+
+Stellar uses two formats for identifying accounts: the **Stellar address** (user-friendly) and the **Account ID** (raw format).
+
+## Definitions
+
+### Stellar Address
+
+A Stellar address is a base32-encoded string with a `G` prefix, designed for users. It includes error correction and is more readable.
+
+- **Format**: `G[A-Z2-7]{55}` (starts with G)
+- **Example**: `GA7KMQ4N2WJN3XJH5Y4N5J6Z7X8C9V0B1M2N3P4Q5R6S7T8V9W0Y1Z2`
+
+### Account ID
+
+The Account ID is the raw public key in hexadecimal format, used internally by the network.
+
+- **Format**: 32-byte public key (hex-encoded)
+- **Example**: `0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`
+
+## When to Use Which
+
+| Use Case             | Format          | Reason                            |
+| -------------------- | --------------- | --------------------------------- |
+| User input           | Stellar address | Easier to read and type           |
+| API requests         | Stellar address | Public clients prefer G-addresses |
+| Backend storage      | Account ID      | Smaller storage footprint         |
+| Transaction building | Either          | SDK handles conversion            |
+
+## Examples
+
+### In SDK
+
+```ts
+import { StrKey } from '@stellar/stellar-sdk';
+
+// Encode account ID to address
+const accountId =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const address = StrKey.encodeEd25519PublicKey(accountId);
+// Returns: G...
+
+// Decode address to account ID
+const address = 'GA7KMQ4N2WJN3XJH5Y4N5J6Z7X8C9V0B1M2N3P4Q5R6S7T8V9W0Y1Z2';
+const accountId = StrKey.decodeEd25519PublicKey(address);
+// Returns: 32-byte Uint8Array
+```
+
+### With Nextellar Hooks
+
+```ts
+// Hooks accept both formats
+const { balances } = useStellarBalances(
+  'GA7KMQ4N2WJN3XJH5Y4N5J6Z7X8C9V0B1M2N3P4Q5R6S7T8V9W0Y1Z2'
+);
+```
+
+## Related
+
+- [Stellar Horizon](/docs/integrations/horizon)
+- [useStellarBalances](/docs/hooks/use-stellar-balances)

--- a/routes-d/488.mdx
+++ b/routes-d/488.mdx
@@ -1,0 +1,72 @@
+---
+title: Account Merge Operation
+description: Document the account merge operation and its constraints on Stellar.
+---
+
+# Account Merge Operation
+
+The `account_merge` operation deletes an account and transfers the remaining XLM balance to another account.
+
+## The Merge Flow
+
+1. **Source Account** initiates the merge with `account_merge`.
+2. **Destination Account** receives the XLM balance after reserves are deducted.
+3. **Account Removal** happens after the transaction succeeds.
+
+```ts
+import { TransactionBuilder, Operation } from '@stellar/stellar-sdk';
+
+const transaction = new TransactionBuilder(sourceAccount, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.PUBLIC,
+})
+  .addOperation(
+    Operation.accountMerge({
+      destination: 'GDQOZR5PRK5ZQJHYYDMQXSTJQJFUCKJQSGRH5OHO6O2FJN5QJGNGQZW5Q',
+    })
+  )
+  .setTimeout(30)
+  .build();
+```
+
+## Residual Requirements
+
+- **No Trustlines**: The account must have only one trustline (the native XLM asset).
+- **No Offers**: All DEX offers must be canceled before merging.
+- **No Signers**: Only the master key signer should remain.
+- **Sufficient Balance**: Account must maintain the base reserve until the merge completes.
+- **No Sponsorships**: Any sponsored reserves must be ended first.
+
+After merge, the account is removed from the ledger. Any remaining XLM after reserve deductions goes to the destination.
+
+## Example
+
+```ts
+// Check account is clean before merge
+const account = await server.loadAccount(publicKey);
+
+// Verify no trustlines except native
+if (account.balances.length > 1) {
+  throw new Error('Cancel trustlines before merging');
+}
+
+// Verify no offers
+const offers = await server.offers().forAccount(publicKey).call();
+if (offers.records.length > 0) {
+  throw new Error('Cancel offers before merging');
+}
+
+// Build and submit merge
+const tx = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.PUBLIC,
+})
+  .addOperation(Operation.accountMerge({ destination: destinationAccountId }))
+  .setTimeout(30)
+  .build();
+```
+
+## Related
+
+- [Stellar Horizon](/docs/integrations/horizon)
+- [useStellarPayment](/docs/hooks/use-stellar-payment)


### PR DESCRIPTION
## Summary
Adds 4 documentation drafts to `routes-d/` as requested by the issue constraints.

### Changes
- **`routes-d/466.mdx`** — Canonical Horizon URL endpoints for testnet and mainnet
- **`routes-d/474.mdx`** — How to find the current Stellar protocol version and its relevance to features
- **`routes-d/484.mdx`** — Comparison of user-facing Stellar address vs underlying account ID
- **`routes-d/488.mdx`** — Account merge operation flow and residual requirements

### Validation
- Frontmatter (`title`, `description`) parsed correctly for all 4 files.
- Internal links point to existing `/docs/` pages.
- Written to match existing MDX style used across the repo.

Closes #466, 
closes #474, 
closes #484, 
closes #488