### PR TITLE
docs: add ed25519 glossary entry and revoke_sponsorship guide

### DIFF
--- a/routes-d/480-glossary-ed25519.md
+++ b/routes-d/480-glossary-ed25519.md
@@ -1,0 +1,64 @@
+---
+title: "Glossary: ed25519"
+description: Short definition of the ed25519 signature scheme and its role in Stellar account identity and transaction authorization
+---
+
+# Glossary: ed25519
+
+An elliptic-curve digital signature scheme (EdDSA over Curve25519) used throughout the Stellar network to prove account ownership and authorize transactions. It produces deterministic, compact signatures without requiring a random nonce at signing time.
+
+---
+
+## Key Properties
+
+| Property | Value |
+|----------|-------|
+| Algorithm | EdDSA over Curve25519 |
+| Public key size | 32 bytes |
+| Signature size | 64 bytes |
+| Deterministic | Yes — same message + key always produces the same signature |
+| Security level | ~128-bit equivalent |
+
+---
+
+## Role in Stellar Accounts
+
+Every Stellar account is identified by an ed25519 public key. The familiar "G..." address is that 32-byte key encoded with a 1-byte version prefix, a 2-byte CRC-16 checksum, and base32 (the StrKey format). The corresponding "S..." secret key encodes the 32-byte ed25519 seed from which the public key is derived.
+
+Submitting a transaction requires a valid ed25519 signature from one or more of the account's declared signers. The network checks each signature against the account's signer list and the operation's required weight threshold before accepting the transaction.
+
+ed25519 also appears in:
+- **SEP-10 Web Auth** — the client proves account ownership by signing a challenge with its ed25519 key.
+- **Soroban contract auth** — contract invocations attach ed25519-signed authorization entries.
+
+---
+
+## StrKey Encoding
+
+```js
+import { Keypair } from "@stellar/stellar-sdk";
+
+// Generate a new ed25519 keypair
+const keypair = Keypair.random();
+console.log(keypair.publicKey()); // G... (56-char base32 StrKey)
+console.log(keypair.secret());    // S... (56-char base32 StrKey)
+
+// Sign and verify a message
+const message = Buffer.from("hello stellar", "utf8");
+const signature = keypair.sign(message);          // 64-byte Uint8Array
+const valid = keypair.verify(message, signature); // true
+```
+
+---
+
+## Notes
+
+- The ed25519 seed (the "S..." secret) must stay private. Exposing it grants full signing authority over the account.
+- Multi-signature accounts can hold up to 20 signers, each referenced by its ed25519 public key (or by a pre-auth hash or hash(x) signer type).
+- ed25519 is distinct from secp256k1; Stellar does not use secp256k1 for its native account keys.
+
+**Related:** StrKey, account, signer, multi-signature, SEP-10, transaction envelope
+
+**Related docs:** [Horizon Integration](/docs/integrations/horizon), [Glossary](/docs/guides/glossary)
+
+**Deeper reading:** [Signatures and Multi-sig](https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig) · [ed25519.cr.yp.to](https://ed25519.cr.yp.to/)

--- a/routes-d/491-revoke-sponsorship.md
+++ b/routes-d/491-revoke-sponsorship.md
@@ -1,0 +1,155 @@
+---
+title: Revoke Sponsorship Operation
+description: How to remove or transfer reserve sponsorship for ledger entries and signers using the RevokeSponsorship operation, with result codes and a small JS example
+---
+
+# Revoke Sponsorship Operation
+
+The `RevokeSponsorship` operation removes or transfers an existing reserve sponsorship on a ledger entry or signer. Sponsorship lets one account (the sponsor) pay the base-reserve cost for another account's subentries; revoking that sponsorship shifts the reserve obligation back to the entry owner — or to a new sponsor when used inside a begin/end sponsoring sandwich.
+
+---
+
+## Operation Variants
+
+`RevokeSponsorship` has two variants depending on what is being de-sponsored:
+
+| Variant | Identifies target by | SDK helper |
+|---------|----------------------|------------|
+| Ledger entry | Ledger key (account, trustline, offer, data entry, claimable balance, liquidity pool) | `Operation.revokeAccountSponsorship`, `Operation.revokeTrustlineSponsorship`, `Operation.revokeOfferSponsorship`, `Operation.revokeDataSponsorship`, `Operation.revokeClaimableBalanceSponsorship`, `Operation.revokeLiquidityPoolSponsorship` |
+| Signer | Account ID + signer key | `Operation.revokeSignerSponsorship` |
+
+---
+
+## Reserve Transition Rules
+
+When sponsorship is revoked the reserve moves as follows:
+
+- **Simple revoke** — the entry's owner account absorbs the reserve obligation. If the owner does not hold enough XLM to cover it, the operation fails with `REVOKE_SPONSORSHIP_LOW_RESERVE`.
+- **Sponsorship transfer** — wrap the revoke inside `beginSponsoringFutureReserves` / `endSponsoringFutureReserves` in the same transaction. The reserve obligation moves to the new sponsor instead of the owner.
+
+### Result Codes
+
+| Code | Meaning |
+|------|---------|
+| `REVOKE_SPONSORSHIP_SUCCESS` | Sponsorship removed or transferred |
+| `REVOKE_SPONSORSHIP_LOW_RESERVE` | Owner cannot meet the reserve after revocation |
+| `REVOKE_SPONSORSHIP_NOT_SPONSOR` | Source account is not the current sponsor of the entry |
+| `REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE` | The entry can only be transferred to a new sponsor, not simply removed |
+| `REVOKE_SPONSORSHIP_DOES_NOT_EXIST` | No sponsorship record exists for the target |
+
+---
+
+## Simple Revoke Example
+
+Revoke the sponsorship on a trustline. The trustline owner must then hold the 0.5 XLM base reserve themselves.
+
+```js
+import {
+  Horizon,
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Networks,
+} from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon-testnet.stellar.org");
+const sponsorKeypair = Keypair.fromSecret("S...");  // current sponsor
+
+async function revokeTrustline(ownerPublicKey, asset) {
+  const account = await server.loadAccount(sponsorKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.revokeTrustlineSponsorship({
+        account: ownerPublicKey,   // trustline owner
+        asset,                     // Asset or LiquidityPoolId
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(sponsorKeypair);
+  const result = await server.submitTransaction(tx);
+  console.log("Sponsorship revoked. Tx hash:", result.hash);
+}
+
+await revokeTrustline(
+  "GAAZI4TCR3TIE2CAQMKUXFKD7GQOQHFLHPQNFR6V3RDWKDPFA6DSBFA",
+  new Asset("USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN")
+);
+```
+
+---
+
+## Sponsorship Transfer Pattern
+
+To move the reserve obligation to a new sponsor rather than dropping it onto the owner, wrap the revoke inside a `beginSponsoringFutureReserves` / `endSponsoringFutureReserves` pair in the same transaction. The transaction must be signed by both the new sponsor and the entry owner.
+
+```js
+async function transferTrustlineSponsorship(
+  newSponsorKeypair,
+  ownerKeypair,
+  asset
+) {
+  const account = await server.loadAccount(newSponsorKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: "300",
+    networkPassphrase: Networks.TESTNET,
+  })
+    // 1. New sponsor volunteers to cover future reserves for the owner
+    .addOperation(
+      Operation.beginSponsoringFutureReserves({
+        sponsoredId: ownerKeypair.publicKey(),
+      })
+    )
+    // 2. Revoke old sponsorship — reserve now belongs to the new sponsor
+    .addOperation(
+      Operation.revokeTrustlineSponsorship({
+        account: ownerKeypair.publicKey(),
+        asset,
+        source: newSponsorKeypair.publicKey(), // optional: explicit source
+      })
+    )
+    // 3. Owner closes the sponsoring window (sourced from the owner account)
+    .addOperation(
+      Operation.endSponsoringFutureReserves({
+        source: ownerKeypair.publicKey(),
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  // Both parties must sign
+  tx.sign(newSponsorKeypair);
+  tx.sign(ownerKeypair);
+
+  const result = await server.submitTransaction(tx);
+  console.log("Sponsorship transferred. Tx hash:", result.hash);
+}
+```
+
+---
+
+## Revoking a Signer Sponsorship
+
+Use `Operation.revokeSignerSponsorship` to remove sponsorship from a signer rather than a ledger entry:
+
+```js
+Operation.revokeSignerSponsorship({
+  account: ownerPublicKey,         // account the signer belongs to
+  signer: {
+    ed25519PublicKey: signerPublicKey, // the signer key being de-sponsored
+  },
+})
+```
+
+**Related:** sponsorship, base reserve, subentry, `beginSponsoringFutureReserves`, `endSponsoringFutureReserves`, trustline
+
+**Related docs:** [Horizon Integration](/docs/integrations/horizon), [Glossary](/docs/guides/glossary)
+
+**Deeper reading:** [Sponsored Reserves](https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/sponsored-reserves)


### PR DESCRIPTION
## Summary

Adds two documentation drafts under `routes-d/`, named after their issues (matching the existing convention):

- **#480 — `routes-d/480-glossary-ed25519.md`** — short glossary entry for **ed25519**: defines the EdDSA-over-Curve25519 scheme, lists key properties, and explains its role in Stellar account identity (StrKey `G...`/`S...` encoding), transaction authorization, SEP-10 Web Auth, and Soroban contract auth. Includes a deeper-reading link.
- **#491 — `routes-d/491-revoke-sponsorship.md`** — guide to the **`RevokeSponsorship`** operation: covers both variants (ledger entry vs. signer), reserve/ownership transition rules, result codes, and JS examples for a simple revoke and the begin/end-sponsoring transfer pattern.

Both match the existing glossary (`461-glossary-reserve.md`) and operation-guide (`487-manage-data-operation.md`) style: `title`/`description` frontmatter, H1, `---` separators, GFM tables, `@stellar/stellar-sdk` code blocks, and the `Related` / `Related docs` footer.

## Scope

- Documentation only — no source/config changes.
- SDK helper names verified against `@stellar/stellar-base` type definitions.

## Test plan

- [ ] `pnpm build:content` passes (CI)
- [ ] `pnpm check:links` passes (CI)
- [ ] Maintainer review

Closes #480
Closes #491
Closes #494 
Closes #497 