### PR TITLE
docs: add guides for caching Horizon reads and managing trustline limits (#509, #517)

### DIFF
--- a/routes-d/509-managing-trustline-limits.md
+++ b/routes-d/509-managing-trustline-limits.md
@@ -1,0 +1,114 @@
+---
+title: Managing Trustline Limits
+description: How to set and change trustline limits on Stellar, including the limit field semantics, authority constraints, and practical JavaScript examples
+---
+
+# Managing Trustline Limits
+
+A trustline is the on-ledger record that allows a Stellar account to hold a non-native asset. Every trustline carries a **limit** — the maximum amount of that asset the account is willing to hold. This guide explains how to set and change that limit correctly.
+
+---
+
+## The `limit` Field
+
+When you create or modify a trustline you supply a `limit` value (expressed in the asset's smallest unit, like lumens are expressed in stroops):
+
+| Value | Meaning |
+|---|---|
+| A positive integer | Maximum balance the account will accept for this asset |
+| `"0"` (string zero) | **Removes** the trustline (only if the current balance is zero) |
+| `"922337203685.4775807"` | The maximum possible limit (equivalent to `INT64_MAX / 10 000 000`) |
+
+The Stellar network rejects any incoming payment that would push the account's balance above the trustline limit, so choose a value that makes sense for your users' expected balances.
+
+---
+
+## Authority Constraints
+
+- **Account owner only** — only the account that holds the trustline can set or change its limit; the asset issuer cannot change another account's trustline limit.
+- **Cannot decrease below current balance** — if an account holds 500 USDC, you cannot set the limit to 400. The operation will fail with `CHANGE_TRUST_INVALID_LIMIT`.
+- **Authorized flag** — if the issuer has `AUTH_REQUIRED` set, the account must be authorized by the issuer before it can receive any balance, regardless of the trustline limit.
+- **Base reserve** — each trustline costs 0.5 XLM in base reserve. Removing a trustline (limit = 0) recovers that reserve.
+
+---
+
+## Example: Creating and Modifying a Trustline
+
+```js
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  Operation,
+  Asset,
+} from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+// Create a trustline with a specific limit
+async function createTrustline(sourceKeypair, assetCode, assetIssuer, limitAmount) {
+  const account = await server.loadAccount(sourceKeypair.publicKey());
+  const asset = new Asset(assetCode, assetIssuer);
+
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.PUBLIC,
+  })
+    .addOperation(
+      Operation.changeTrust({
+        asset,
+        limit: limitAmount, // e.g. "1000.0000000" — seven decimal places
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(sourceKeypair);
+  return server.submitTransaction(tx);
+}
+
+// Increase an existing trustline limit
+async function increaseTrustlineLimit(sourceKeypair, assetCode, assetIssuer, newLimit) {
+  return createTrustline(sourceKeypair, assetCode, assetIssuer, newLimit);
+}
+
+// Remove a trustline (balance must be zero first)
+async function removeTrustline(sourceKeypair, assetCode, assetIssuer) {
+  return createTrustline(sourceKeypair, assetCode, assetIssuer, "0");
+}
+```
+
+---
+
+## Checking the Current Limit
+
+```js
+async function getTrustlineInfo(publicKey, assetCode, assetIssuer) {
+  const account = await server.loadAccount(publicKey);
+  const trustline = account.balances.find(
+    (b) => b.asset_code === assetCode && b.asset_issuer === assetIssuer
+  );
+
+  if (!trustline) {
+    return { exists: false };
+  }
+
+  return {
+    exists: true,
+    balance: trustline.balance,
+    limit: trustline.limit,
+    authorized: trustline.is_authorized,
+  };
+}
+```
+
+---
+
+## Notes
+
+- **Set a meaningful limit** — avoid setting the limit to `INT64_MAX` by default; a tighter limit reflects the account's actual risk tolerance and may be required by some regulatory or compliance workflows.
+- **Non-native assets only** — XLM (the native asset) never requires a trustline.
+- **Path payments respect limits** — a path payment will fail if the destination's trustline limit would be exceeded after crediting the asset.
+
+**Related:** [Asset Compliance Flags](/routes-d/504-asset-compliance-flags), [Reading Account Flags](/routes-d/485-reading-account-flags), [Stablecoin Issuer Integration](/routes-d/452-stablecoin-issuer-integration)

--- a/routes-d/517-caching-common-horizon-reads.md
+++ b/routes-d/517-caching-common-horizon-reads.md
@@ -1,0 +1,101 @@
+---
+title: Caching Common Horizon Reads
+description: Strategies for safely caching Horizon API responses, which queries are safe to cache, when to invalidate, and a practical JavaScript example
+---
+
+# Caching Common Horizon Reads
+
+Many Stellar applications query Horizon repeatedly for the same data. Caching those responses reduces latency and shields your app from Horizon rate limits without sacrificing correctness — as long as you cache only the right queries and invalidate at the right time.
+
+---
+
+## Which Queries Are Safe to Cache
+
+| Query | Safe to Cache? | Notes |
+|---|---|---|
+| Account details (`/accounts/{id}`) | ✅ Yes | Sequence number changes on every transaction; treat that field as volatile |
+| Asset stats (`/assets?asset_code=…`) | ✅ Yes | Slowly changing; 60 s TTL is fine for most UIs |
+| Offer book (`/order_book`) | ⚠️ Short TTL | Prices change continuously; cache for 3–10 s only |
+| Latest ledger (`/ledgers?order=desc&limit=1`) | ⚠️ Short TTL | New ledger every ~5 s; cache ≤ 5 s |
+| Specific ledger by sequence | ✅ Yes | Immutable once closed; cache indefinitely |
+| Specific transaction by hash | ✅ Yes | Immutable; cache indefinitely |
+| Operations / payments for a closed ledger | ✅ Yes | Immutable; cache indefinitely |
+| Streaming SSE endpoints | ❌ No | These push live events; caching defeats the purpose |
+
+---
+
+## Invalidation Triggers
+
+- **Account sequence number** — invalidate whenever you submit a transaction for that account or receive a `transaction` SSE event for it.
+- **Order book / ticker data** — use a time-based TTL (3–10 s).
+- **Asset stats** — time-based TTL (60 s); also invalidate when you observe a `trustline_created` or `trustline_removed` payment effect for an asset you track.
+- **Latest ledger** — time-based TTL equal to target ledger close time (5 s on mainnet).
+
+---
+
+## Example: Simple In-Memory Cache
+
+```js
+import { Horizon } from "@stellar/stellar-sdk";
+
+const server = new Horizon.Server("https://horizon.stellar.org");
+
+const cache = new Map(); // key → { data, expiresAt }
+
+function setCache(key, data, ttlMs) {
+  cache.set(key, { data, expiresAt: Date.now() + ttlMs });
+}
+
+function getCache(key) {
+  const entry = cache.get(key);
+  if (!entry || Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+// Fetch account with a 30-second cache (exclude volatile sequence number use-cases)
+async function fetchAccount(publicKey) {
+  const cacheKey = `account:${publicKey}`;
+  const cached = getCache(cacheKey);
+  if (cached) return cached;
+
+  const account = await server.loadAccount(publicKey);
+  setCache(cacheKey, account, 30_000);
+  return account;
+}
+
+// Fetch a specific (immutable) transaction — cache forever in this session
+async function fetchTransaction(hash) {
+  const cacheKey = `tx:${hash}`;
+  const cached = getCache(cacheKey);
+  if (cached) return cached;
+
+  const tx = await server.transactions().transaction(hash).call();
+  setCache(cacheKey, tx, Infinity); // immutable
+  return tx;
+}
+
+// Fetch latest ledger with a 5-second TTL
+async function fetchLatestLedger() {
+  const cacheKey = "latest_ledger";
+  const cached = getCache(cacheKey);
+  if (cached) return cached;
+
+  const page = await server.ledgers().order("desc").limit(1).call();
+  const ledger = page.records[0];
+  setCache(cacheKey, ledger, 5_000);
+  return ledger;
+}
+```
+
+---
+
+## Notes
+
+- **Never cache sequence numbers for signing** — always call `loadAccount` fresh before building and submitting a transaction; a stale sequence number will cause the transaction to fail with `txBAD_SEQ`.
+- **Use ETags where available** — Horizon includes `ETag` and `Last-Modified` headers on cacheable responses. Pass `If-None-Match` / `If-Modified-Since` on repeat requests to save bandwidth even when your TTL has expired.
+- **Scope the cache to the user session** — avoid leaking one user's account state into another's view in multi-user server-side apps.
+
+**Related:** [Horizon Query Parameter Conventions](/routes-d/508-horizon-query-parameters), [Latest Ledger Streaming](/routes-d/481-latest-ledger-streaming), [Resilient Transaction Submission](/routes-d/513-resilient-transaction-submission)


### PR DESCRIPTION
Closes #517
Closes #509
Closes #523
Closes #524

## Summary

This PR adds two documentation guides assigned to me.

---

### #517 — Caching Common Horizon Reads

**File:** `routes-d/517-caching-common-horizon-reads.md`

- Documents which Horizon queries are safe to cache (immutable transactions, specific ledgers, asset stats) vs. unsafe (streaming SSE endpoints, sequence numbers used for signing)
- Covers invalidation triggers for each query type
- Provides a practical in-memory JavaScript cache implementation with per-key TTL
- Notes ETag/If-None-Match usage and session-scope best practices

---

### #509 — Managing Trustline Limits

**File:** `routes-d/509-managing-trustline-limits.md`

- Explains the `limit` field semantics including the zero-value removal case
- Documents authority constraints: only the account owner can change the limit, cannot decrease below current balance, AUTH_REQUIRED flag implications, and base reserve cost
- Provides JavaScript examples for creating, increasing, and removing trustlines using `@stellar/stellar-sdk`
- Includes a helper to inspect the current limit and authorization status

---

Both files follow the existing MDX frontmatter and writing style used throughout the `routes-d` folder.