### PR TITLE
docs: add Stellar Stack Exchange reference

### DIFF
--- a/routes-d/469-stellar-stack-exchange.md
+++ b/routes-d/469-stellar-stack-exchange.md
@@ -1,0 +1,44 @@
+---
+title: Stellar Stack Exchange
+description: Reference for using Stellar Stack Exchange when asking technical questions
+---
+
+# Stellar Stack Exchange
+
+[Stellar Stack Exchange](https://stellar.stackexchange.com/) is a community Q&A site for technical questions about Stellar development, operations, and protocol behavior.
+
+---
+
+## When to Use It
+
+Use Stellar Stack Exchange when you have a question that can be answered publicly and may help other developers later. It works well for:
+
+- Explaining Stellar protocol or Horizon behavior
+- Debugging SDK usage with a small reproducible example
+- Asking about transaction structure, memos, fees, or account state
+- Finding prior answers before opening a new support thread
+
+For private account recovery, exchange support, or security-sensitive incidents, contact the relevant service provider directly instead of posting details publicly.
+
+---
+
+## Asking a Good Question
+
+Include enough context for another developer to reproduce or reason about the issue:
+
+- Network: Mainnet, Testnet, or a local network
+- Tooling: SDK, Horizon endpoint, Stellar Core version, or contract toolchain
+- Error output: exact messages, response codes, or transaction result codes
+- Minimal example: the smallest code snippet or XDR needed to show the issue
+
+Avoid posting secret keys, recovery phrases, private API tokens, or personal account information.
+
+---
+
+## Notes
+
+- Search existing questions before posting; common Horizon, SDK, and transaction issues may already have answers.
+- Use focused tags such as `horizon`, `stellar-sdk`, `transactions`, `stellar-core`, or `soroban` when they fit the question.
+- Link back to relevant documentation or GitHub issues when they provide useful background.
+
+**Related:** [Stellar Community Discord](/routes-d/468-stellar-community-discord), [Horizon Integration](/docs/integrations/horizon)


### PR DESCRIPTION
## Summary
- add a routes-d draft for the Stellar Stack Exchange reference
- explain when to use the site and how to ask useful public questions
- include related links to the community Discord and Horizon integration docs

## Verification
- pnpm build:content
- pnpm check:links
- Verified https://stellar.stackexchange.com/ loads as the Stellar Stack Exchange site in browser fetch; direct curl receives a Cloudflare challenge

Closes #469