### PR TITLE
docs: document Husky pre-commit hooks  CLOSED #288

### DIFF
--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -313,6 +313,7 @@ description: 'Clear description for SEO and navigation (50-160 chars)'
 - [Docs Style Guide](/docs/guides/style-guide) — tone, structure, formatting, and examples
 - [Versioned Docs Strategy](/docs/guides/versioned-docs-strategy) — when to split or freeze docs by major version
 - [Redirects Map](/docs/guides/redirects-map) — how moved pages keep old URLs working
+- [Husky Pre-commit Hooks](/docs/guides/husky-pre-commit-hooks) — what the commit hook runs and how to troubleshoot it
 - [Hook Error Handling](/docs/guides/hook-error-handling) — shared failure patterns for hook pages
 - [Issue Templates](/docs/guides/issue-templates) — which template to use when opening a new issue
 

--- a/docs/guides/husky-pre-commit-hooks.mdx
+++ b/docs/guides/husky-pre-commit-hooks.mdx
@@ -1,0 +1,106 @@
+---
+title: Husky Pre-commit Hooks
+description: Understand the Husky pre-commit hook, what it runs, how to skip it when necessary, and how to fix common failures.
+---
+
+# Husky Pre-commit Hooks
+
+This project uses Husky to run a lightweight quality check before each commit.
+The hook keeps staged documentation and source files formatted without running the
+full docs build on every commit.
+
+## Hook summary
+
+| Hook         | File                | Command            | Purpose                                  |
+| ------------ | ------------------- | ------------------ | ---------------------------------------- |
+| `pre-commit` | `.husky/pre-commit` | `pnpm lint-staged` | Formats staged files through lint-staged |
+
+## What the pre-commit hook runs
+
+The `pre-commit` hook runs before Git creates a commit:
+
+```bash
+pnpm lint-staged
+```
+
+`lint-staged` reads its configuration from `package.json`:
+
+```json
+{
+  "*.{js,jsx,ts,tsx,json,css,md,mdx}": ["prettier --write"]
+}
+```
+
+This means staged files with the listed extensions are passed to Prettier and
+rewritten in place. After the hook finishes, review the formatting changes and
+stage any files that Prettier updated before committing again.
+
+The hook does not run `pnpm build:content`, `pnpm check:links`, or the full
+Next.js build. Run those commands manually before opening a pull request. See
+[Testing Documentation Changes](/docs/guides/testing-docs-changes) for the full
+docs validation checklist.
+
+## Skipping the hook only when needed
+
+Prefer fixing hook failures instead of skipping the hook. If you need to create a
+commit while the hook is temporarily blocked, use Git's no-verify flag:
+
+```bash
+git commit --no-verify -m "docs: update draft"
+```
+
+Use this only for exceptional cases, such as:
+
+- saving work before switching machines or branches
+- committing while a local dependency install is broken
+- creating a temporary checkpoint that will be cleaned up before review
+
+After skipping the hook, run the skipped check manually before pushing:
+
+```bash
+pnpm lint-staged
+```
+
+If Prettier changes files, stage those changes and amend or create a follow-up
+commit before requesting review.
+
+## Common failures and fixes
+
+| Failure                                      | Likely cause                                              | Fix                                                            |
+| -------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------- |
+| `pnpm: command not found`                    | pnpm is not installed or is not on your shell path        | Enable pnpm with Corepack or install pnpm, then retry          |
+| `Cannot find module ...`                     | dependencies are missing after cloning or pulling         | Run `pnpm install` from the repository root                    |
+| `lint-staged could not find any staged files` | no matching staged files are included in the commit       | Confirm the expected files are staged with `git status --short` |
+| `prettier --write` changes files             | staged files needed formatting                            | Review the diff, stage the updated files, and commit again     |
+| Prettier reports an MDX parse error          | the MDX file has invalid syntax or unclosed JSX           | Fix the reported line, then run `pnpm lint-staged` again       |
+| The hook works locally but CI fails          | the hook formats only, while CI runs broader checks       | Run `pnpm build:content` and `pnpm check:links` before pushing |
+
+## Manual verification
+
+Use these commands from the repository root when changing documentation:
+
+```bash
+pnpm lint-staged
+pnpm build:content
+```
+
+For link validation, start the local docs server in one terminal:
+
+```bash
+pnpm dev
+```
+
+Then run the link checker in another terminal:
+
+```bash
+pnpm check:links
+```
+
+Open the changed page in the browser and confirm the title, tables, code blocks,
+and internal links render correctly.
+
+## Related
+
+- [Contributing to Documentation](/docs/guides/contributing)
+- [Testing Documentation Changes](/docs/guides/testing-docs-changes)
+- [Editor Setup](/docs/guides/editor-setup)

--- a/routes-d/288-document-husky-pre-commit-hook.md
+++ b/routes-d/288-document-husky-pre-commit-hook.md
@@ -1,0 +1,19 @@
+---
+title: Document the Husky pre-commit hook
+description: Working draft for issue 288 covering the project's Husky pre-commit hook.
+---
+
+# Document the Husky pre-commit hook
+
+Draft for issue #288.
+
+The published page is `docs/guides/husky-pre-commit-hooks.mdx`.
+
+Coverage:
+
+- Describes `.husky/pre-commit` and the `pnpm lint-staged` command it runs.
+- Documents the `lint-staged` Prettier pattern from `package.json`.
+- Shows how to skip the hook with `git commit --no-verify` only when needed.
+- Lists common failures and fixes.
+- Points readers to the docs validation workflow for `pnpm build:content` and
+  `pnpm check:links`.

--- a/routes-d/issue-288-husky-pre-commit-hooks.mdx
+++ b/routes-d/issue-288-husky-pre-commit-hooks.mdx
@@ -1,0 +1,82 @@
+---
+title: Husky Pre-commit Hooks
+description: Learn which Husky pre-commit hooks run in this repository, how to bypass them when necessary, and how to resolve common failures.
+---
+
+# Husky Pre-commit Hooks
+
+This repository uses Husky to run lightweight checks before a commit is created. The current setup is intentionally simple and focuses on formatting staged files before they are committed.
+
+## What runs on commit
+
+The pre-commit hook is defined in the repository's Husky configuration and runs the following command:
+
+```bash
+pnpm lint-staged
+```
+
+The hook is configured in the root package manifest and applies formatting rules through lint-staged. For the current repository setup, that means:
+
+- staged files matching `*.js`, `*.jsx`, `*.ts`, `*.tsx`, `*.json`, `*.css`, `*.md`, and `*.mdx` are formatted with Prettier
+- the formatting step is applied only to files that are staged for commit
+- the hook helps keep documentation, config files, and source files consistent before they are pushed
+
+## When the hook runs
+
+The hook runs automatically whenever you execute a normal commit such as:
+
+```bash
+git commit -m "Update docs"
+```
+
+If the formatting step changes a file, review the updated diff, stage the formatted changes, and retry the commit.
+
+## How to skip the hook when needed
+
+Use the skip flag only for exceptional cases, such as when you need to commit a temporary change without running the usual checks:
+
+```bash
+git commit --no-verify -m "Temporary workaround"
+```
+
+This bypasses the Husky pre-commit hook for that specific commit. If you use this approach, make sure to run formatting and validation manually before you push your changes.
+
+## Common failures and fixes
+
+### Prettier reformats a file
+
+This is expected if a staged file does not match the repository formatting rules. The hook will rewrite the file and stop the commit until the changes are re-staged.
+
+Fix:
+
+```bash
+pnpm format
+```
+
+Then review the diff, stage the updated file, and run the commit again.
+
+### The hook does not run
+
+If Husky does not seem to be executing, confirm that dependencies are installed and the Git hooks were initialized:
+
+```bash
+pnpm install
+pnpm prepare
+```
+
+If the hook still does not appear, verify that the repository is using a normal Git working tree and that the `.husky` directory is present.
+
+### The commit is blocked by a formatting error
+
+This usually means one or more staged files need to be reformatted before the commit can proceed. Re-run the formatter, stage the corrected files, and retry the commit.
+
+## Recommended workflow
+
+For day-to-day work, the recommended flow is:
+
+1. make your changes
+2. stage the relevant files
+3. commit normally and let the hook format anything that needs it
+4. review the resulting diff and push once the commit succeeds
+
+This keeps the repository consistent without introducing extra manual steps for routine contributions.


### PR DESCRIPTION
## Summary

Document the repository's Husky pre-commit hook and explain how it works for contributors.

## Changes

- Added a dedicated guide for the Husky pre-commit hook
- Documented what the hook runs and which files it formats
- Explained how to skip the hook only when needed
- Listed common failures and practical fixes
- Linked the new guide from the contributor documentation

## Verification

- Verified the content build with `pnpm build:content`
- Verified internal links with `pnpm check:links`

- CLOSED #288 