### PR TITLE
docs: Add Stellar and Horizon reference documentation drafts

### DIFF
--- a/routes-d/latest-ledger-query-endpoint.mdx
+++ b/routes-d/latest-ledger-query-endpoint.mdx
@@ -1,0 +1,55 @@
+---
+title: Latest Ledger Query Endpoint
+description: A short note about the Horizon endpoint for the latest ledger.
+---
+
+# Latest Ledger Query Endpoint
+
+The Horizon API provides an endpoint to query the latest ledger on the Stellar network.
+
+## Endpoint Shape
+
+To fetch the latest ledgers (ordered descending by sequence), use the `/ledgers` endpoint with the `order` parameter:
+
+```
+GET /ledgers?order=desc&limit=1
+```
+
+## Response Fields of Interest
+
+When you query this endpoint, the response includes several important fields for the latest ledger:
+
+- `sequence`: The sequence number of the ledger.
+- `successful_transaction_count`: The number of successful transactions included in this ledger.
+- `closed_at`: The timestamp when the ledger was closed.
+- `fee_pool`: The total amount of fees collected.
+
+## Example
+
+```json
+{
+  "_embedded": {
+    "records": [
+      {
+        "id": "278e384c3116fc0d421ffbe0092c6cc2620a23dc58bcf70b7936a282f6eefc46",
+        "paging_token": "219503487042560",
+        "hash": "278e384c3116fc0d421ffbe0092c6cc2620a23dc58bcf70b7936a282f6eefc46",
+        "prev_hash": "4df021b3df6248b11eb11ce510eab52a0a2df37b4e9b922d057777174db1ba2c",
+        "sequence": 51105,
+        "successful_transaction_count": 0,
+        "failed_transaction_count": 0,
+        "operation_count": 0,
+        "tx_set_operation_count": 0,
+        "closed_at": "2023-01-01T00:00:00Z",
+        "total_coins": "100000000000.0000000",
+        "fee_pool": "0.0000000",
+        "base_fee_in_stroops": 100,
+        "base_reserve_in_stroops": 5000000,
+        "max_tx_set_size": 1000,
+        "protocol_version": 19,
+        "header_xdr": "..."
+      }
+    ]
+  }
+}
+```

--- a/routes-d/stellar-github-organization.mdx
+++ b/routes-d/stellar-github-organization.mdx
@@ -1,0 +1,20 @@
+---
+title: Stellar GitHub Organization
+description: A reference to the official Stellar GitHub organization and key repositories.
+---
+
+# Stellar GitHub Organization
+
+The official Stellar repositories are hosted under the `stellar` GitHub organization.
+
+## Organization Link
+
+You can find the organization at: [https://github.com/stellar](https://github.com/stellar)
+
+## Key Repositories to Expect
+
+When exploring the organization, you will find several key repositories, including:
+- `stellar-core`: The reference implementation of the Stellar Consensus Protocol.
+- `go-horizon`: The Horizon API server, which provides a RESTful interface to the Stellar network.
+- SDKs: Various official SDKs for languages like JavaScript, Python, Go, and Java (e.g., `js-stellar-sdk`).
+- `soroban-cli`: Tools for working with Soroban smart contracts.

--- a/routes-d/stellar-quorum-sets.mdx
+++ b/routes-d/stellar-quorum-sets.mdx
@@ -1,0 +1,27 @@
+---
+title: Stellar Quorum Sets
+description: A short note on what a quorum set is and why it matters in the Stellar network.
+---
+
+# Stellar Quorum Sets
+
+A quorum set is a fundamental concept in the Stellar Consensus Protocol (SCP).
+
+## What is a Quorum Set?
+
+A **quorum set** is a list of nodes that a specific node trusts to help it reach consensus. Each node on the Stellar network chooses its own quorum set. For a node to agree to a transaction, it must see that a sufficient number of nodes in its quorum set also agree.
+
+## Why it Matters
+
+Quorum sets allow the network to reach consensus without relying on a central authority. Since each node defines its own trusted set of validators, the network remains decentralized and resilient against malicious actors.
+
+## Where it Appears
+
+You will typically encounter quorum sets when:
+- Configuring a Stellar Core node.
+- Analyzing the health and decentralization of the network.
+- Querying node information from the Horizon API.
+
+## Deeper Reading
+
+For more detailed information, read the [Stellar Consensus Protocol documentation](https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-consensus-protocol).


### PR DESCRIPTION
## Summary
This PR introduces three new short reference documents in the `routes-d` directory to cover core Stellar, Horizon, and ecosystem concepts. This will improve onboarding and serve as a quick reference for developers.

## Changes Included
- **Latest Ledger Query Endpoint:** Added a short note documenting the Horizon endpoint for querying the latest ledger, including the endpoint shape, response fields of interest, and a JSON example (`routes-d/latest-ledger-query-endpoint.mdx`).
- **Stellar Quorum Sets:** Added a brief overview of what a quorum set is within the Stellar Consensus Protocol, why it matters for decentralization, where it typically appears, and a link to deeper reading (`routes-d/stellar-quorum-sets.mdx`).
- **Stellar GitHub Organization:** Added a short reference to the official Stellar GitHub organization, outlining which key repositories to expect such as `stellar-core`, `go-horizon`, and the SDKs (`routes-d/stellar-github-organization.mdx`).

## Acceptance Criteria Met
- [x] Changes scoped to documentation only.
- [x] Working drafts placed in the `routes-d` folder at the repo root.
- [x] Existing MDX frontmatter and writing style matched.


Closes #455 
Closes #462 
Closes #470 