### PR TITLE
docs: limit orders, gasless txs, rate-limited API, double-submit prevention

### DIFF
--- a/routes-d/710-preventing-double-submits.mdx
+++ b/routes-d/710-preventing-double-submits.mdx
@@ -1,0 +1,168 @@
+---
+title: Preventing Double Submission of Transactions
+description: Patterns for preventing duplicate Stellar transaction submissions — idempotent send, UI disabling, and sequence-number guards.
+---
+
+# Preventing Double Submission of Transactions
+
+A double submit happens when a user clicks "Send" twice, a retry loop fires before the first attempt settles, or a network error causes the caller to retry an already-applied transaction. On Stellar the consequences range from a harmless rejected duplicate to a second unintended payment if the user signed two distinct transactions.
+
+---
+
+## Why Stellar Is Different
+
+Stellar transactions carry a **sequence number** tied to the source account. The network rejects any transaction whose sequence number has already been consumed. This gives you a built-in guard against exact-duplicate replays — but only for the same transaction object. If the user signs a *new* transaction after the first one is lost in transit, that second transaction has a new sequence number and will succeed, causing a genuine double payment.
+
+---
+
+## Idempotent Send Pattern
+
+Build a send function that checks outcome before deciding to retry.
+
+```ts
+import { SorobanRpc, TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+
+type SendStatus = "SUCCESS" | "PENDING" | "ERROR";
+
+async function idempotentSend(signedTxXdr: string): Promise<SendStatus> {
+  const tx   = TransactionBuilder.fromXDR(signedTxXdr, Networks.TESTNET);
+  const hash = tx.hash().toString("hex");
+
+  // Check if the transaction already exists on the network
+  try {
+    const existing = await server.getTransaction(hash);
+    if (existing.status === "SUCCESS") return "SUCCESS";
+    if (existing.status === "FAILED")  throw new Error("transaction failed: " + existing.resultXdr);
+  } catch (e: any) {
+    if (!e.message?.includes("not found")) throw e;
+    // Not yet submitted — fall through to submit
+  }
+
+  const result = await server.sendTransaction(tx);
+
+  if (result.status === "ERROR") {
+    throw new Error("submission error: " + result.errorResult?.toXDR("base64"));
+  }
+
+  // Poll for finality (PENDING / NOT_FOUND → SUCCESS / FAILED)
+  return pollUntilFinal(hash);
+}
+
+async function pollUntilFinal(hash: string, attempts = 10): Promise<SendStatus> {
+  for (let i = 0; i < attempts; i++) {
+    await sleep(2_000);
+    const status = await server.getTransaction(hash);
+    if (status.status === "SUCCESS") return "SUCCESS";
+    if (status.status === "FAILED")  throw new Error("transaction failed");
+  }
+  return "PENDING";
+}
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+```
+
+The key invariant: **always check `getTransaction(hash)` before re-submitting**. If the hash is already on-chain (success or failure), do not build a new transaction.
+
+---
+
+## UI Disabling Patterns
+
+Prevent the user from clicking Submit a second time while the first attempt is in-flight.
+
+```tsx
+import { useState } from "react";
+
+export function SendButton({ onSend }: { onSend: () => Promise<void> }) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleClick() {
+    if (submitting) return;           // guard against rapid clicks
+    setSubmitting(true);
+    try {
+      await onSend();
+    } finally {
+      setSubmitting(false);          // re-enable only after settlement
+    }
+  }
+
+  return (
+    <button onClick={handleClick} disabled={submitting}>
+      {submitting ? "Sending…" : "Send"}
+    </button>
+  );
+}
+```
+
+Additional UI guidance:
+
+- Replace the button label with a spinner or "Confirming…" state during the poll phase.
+- Disable the entire form, not just the submit button, so the user cannot change amounts while a transaction is pending.
+- Show a success confirmation (with transaction hash) before re-enabling, so the user knows the first attempt worked.
+
+---
+
+## Small Example: Full Send Flow
+
+```ts
+import { Keypair, Asset, Operation, TransactionBuilder, Networks, BASE_FEE } from "@stellar/stellar-sdk";
+import Horizon from "@stellar/stellar-sdk";
+
+const horizonServer = new Horizon.Server("https://horizon-testnet.stellar.org");
+
+let inFlight = false; // module-level guard for non-React environments
+
+async function safePay(
+  senderKeypair: Keypair,
+  destination: string,
+  amount: string
+) {
+  if (inFlight) throw new Error("a payment is already in progress");
+  inFlight = true;
+
+  try {
+    const account = await horizonServer.loadAccount(senderKeypair.publicKey());
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({ destination, asset: Asset.native(), amount })
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(senderKeypair);
+    const xdr = tx.toXDR();
+
+    // idempotentSend will check for existing hash before retrying
+    const status = await idempotentSend(xdr);
+    return status;
+  } finally {
+    inFlight = false;
+  }
+}
+```
+
+---
+
+## What Each Guard Protects Against
+
+| Guard | Prevents |
+|-------|---------|
+| Sequence number (network) | Exact-same signed transaction submitted twice |
+| `getTransaction` hash check | Retry loops re-submitting after timeout |
+| `inFlight` / `disabled` state | User clicking Submit rapidly before first result |
+| Single signed XDR per action | Signing a new transaction on retry (different seq number = new tx) |
+
+> The most dangerous scenario is signing a **new** transaction on retry. Always reuse the original signed XDR when polling and retrying — never build a new `TransactionBuilder` for the same logical payment.
+
+---
+
+## Accuracy Notes
+
+- `server.getTransaction(hash)` on Soroban RPC returns `NOT_FOUND` for transactions that have not yet been ingested; this is different from `FAILED`.
+- On Horizon, use `server.transactions().transaction(hash).call()` to check existence; it throws 404 if not found.
+- The ledger closes every ~5 seconds on mainnet; set your polling interval to at least 2 seconds and your timeout to at least 60 seconds before declaring a transaction lost.
+- A transaction with `setTimeout(30)` expires if not submitted within 30 seconds of its `timeBounds.maxTime`; after expiry it is safe to build and sign a new one.

--- a/routes-d/723-rate-limited-public-api.mdx
+++ b/routes-d/723-rate-limited-public-api.mdx
@@ -1,0 +1,189 @@
+---
+title: Rate-Limited Public API for a Stellar dApp
+description: Build a rate-limited API layer in front of your Stellar dApp using token buckets and per-account quotas.
+---
+
+# Rate-Limited Public API for a Stellar dApp
+
+Public APIs on Stellar dApps face a specific challenge: Horizon is a shared resource and most RPC providers impose their own rate limits. Wrapping your dApp's Horizon calls behind an authenticated proxy with token-bucket rate limiting protects your upstream quota and keeps your API fair for all clients.
+
+---
+
+## Architecture Overview
+
+```
+Client (dApp / SDK)
+      |
+      ↓ HTTP request + API key
+  [Your API Gateway]
+      |  ← Token bucket check (per API key)
+      |  ← If bucket empty → 429 Too Many Requests
+      |
+      ↓ forward allowed request
+  [Horizon / Soroban RPC]
+      |
+      ↓
+  Response back to client
+```
+
+---
+
+## Token Bucket Algorithm
+
+A token bucket gives each API key a bucket that refills at a fixed rate. Every request consumes one token. Requests that find an empty bucket are rejected immediately.
+
+```ts
+interface Bucket {
+  tokens: number;
+  lastRefill: number; // epoch ms
+}
+
+const RATE   = 10;   // tokens added per second
+const BURST  = 30;   // maximum bucket capacity
+
+const buckets = new Map<string, Bucket>();
+
+function consume(apiKey: string): boolean {
+  const now  = Date.now();
+  let bucket = buckets.get(apiKey);
+
+  if (!bucket) {
+    bucket = { tokens: BURST, lastRefill: now };
+  }
+
+  // Refill tokens based on elapsed time
+  const elapsed  = (now - bucket.lastRefill) / 1000; // seconds
+  bucket.tokens  = Math.min(BURST, bucket.tokens + elapsed * RATE);
+  bucket.lastRefill = now;
+
+  if (bucket.tokens < 1) {
+    buckets.set(apiKey, bucket);
+    return false; // rate limited
+  }
+
+  bucket.tokens -= 1;
+  buckets.set(apiKey, bucket);
+  return true;
+}
+```
+
+For production, replace the in-process `Map` with Redis so the limit is shared across multiple API server instances.
+
+---
+
+## Per-Account Quota
+
+Beyond per-request rate limiting, some operations (like contract reads) are cheap while others (like transaction submissions) are expensive. Apply a daily quota by operation tier:
+
+```ts
+const QUOTAS: Record<string, number> = {
+  read:   10_000, // horizon GET, contract state reads
+  submit: 100,    // transaction submissions per day
+};
+
+async function checkQuota(
+  apiKey: string,
+  tier: "read" | "submit",
+  redis: Redis
+): Promise<boolean> {
+  const key   = `quota:${apiKey}:${tier}:${todayUtc()}`;
+  const count = await redis.incr(key);
+  if (count === 1) {
+    await redis.expire(key, 86_400); // expire at end of day
+  }
+  return count <= QUOTAS[tier];
+}
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+```
+
+---
+
+## Small Implementation
+
+Here is a minimal Express proxy that enforces both token-bucket rate limiting and daily quota:
+
+```ts
+import express from "express";
+import fetch   from "node-fetch";
+
+const HORIZON = "https://horizon-testnet.stellar.org";
+const app     = express();
+
+function apiKeyMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const key = req.headers["x-api-key"] as string;
+  if (!key) return res.status(401).json({ error: "missing x-api-key" });
+  (req as any).apiKey = key;
+  next();
+}
+
+function rateLimitMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const allowed = consume((req as any).apiKey);
+  if (!allowed) {
+    res.setHeader("Retry-After", "1");
+    return res.status(429).json({ error: "rate limit exceeded" });
+  }
+  next();
+}
+
+app.use(apiKeyMiddleware);
+app.use(rateLimitMiddleware);
+
+// Proxy all GET requests to Horizon
+app.get("/*", async (req, res) => {
+  const url      = `${HORIZON}${req.path}${req.url.includes("?") ? "?" + req.url.split("?")[1] : ""}`;
+  const upstream = await fetch(url);
+  const body     = await upstream.text();
+  res.status(upstream.status).set("Content-Type", "application/json").send(body);
+});
+
+// Transaction submission (stricter quota)
+app.post("/transactions", async (req, res) => {
+  const allowed = await checkQuota((req as any).apiKey, "submit", redis);
+  if (!allowed) return res.status(429).json({ error: "daily submission quota exceeded" });
+
+  const upstream = await fetch(`${HORIZON}/transactions`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body:    req.body,
+  });
+  const body = await upstream.text();
+  res.status(upstream.status).send(body);
+});
+
+app.listen(3001, () => console.log("Stellar API proxy running on :3001"));
+```
+
+---
+
+## Abuse Prevention
+
+| Attack | Defense |
+|--------|---------|
+| API key sharing | Rotate keys; alert on sudden traffic spikes from one key |
+| Key stuffing (trying leaked keys) | Hash keys in storage; use `crypto.timingSafeEqual` for comparison |
+| Horizon crawling | Block `*` path if the key's tier doesn't allow raw Horizon access |
+| Burst farming (many keys) | Tie keys to verified accounts; apply global burst cap |
+| Replayed transactions | Let Stellar handle this — network rejects duplicate sequence numbers |
+
+---
+
+## Response Headers
+
+Always return rate-limit headers so clients can back off gracefully:
+
+```ts
+res.setHeader("X-RateLimit-Limit",     BURST);
+res.setHeader("X-RateLimit-Remaining", Math.floor(bucket.tokens));
+res.setHeader("X-RateLimit-Reset",     Math.ceil(bucket.lastRefill / 1000) + 1);
+```
+
+---
+
+## Accuracy Notes
+
+- Token-bucket refill is approximate when using a `Map`; use an atomic Redis Lua script for precise per-key tracking under concurrency.
+- Horizon's own rate limit is IP-based; use a single egress IP for your proxy and request a higher quota from your Horizon provider.
+- Soroban RPC calls (`simulateTransaction`, `sendTransaction`) have separate quotas on most providers — track them in a second bucket tier.

--- a/routes-d/726-gasless-transaction-patterns.mdx
+++ b/routes-d/726-gasless-transaction-patterns.mdx
@@ -1,0 +1,199 @@
+---
+title: Gasless Transaction Patterns
+description: How to implement sponsor-paid (gasless) transactions on Stellar so users never hold XLM for fees.
+---
+
+# Gasless Transaction Patterns
+
+On Stellar every transaction requires a fee paid in XLM. "Gasless" patterns shift that fee responsibility from the end user to a sponsor account, letting wallets onboard users who hold zero XLM.
+
+---
+
+## The Sponsor Model
+
+```
+User           Sponsor Service      Stellar Network
+  |                  |                    |
+  |--- sign tx ----→ |                    |
+  |                  |--- add fee + sig →|
+  |                  |                   |--- execute tx
+  |                  |←-- result --------|
+  |←-- result -------|
+```
+
+1. **User** builds and signs the transaction body (operations + sequence number).
+2. **Sponsor service** inspects the transaction, wraps it, pays the fee, adds its own signature, and submits.
+3. The network deducts the fee from the **sponsor** account, not the user.
+
+Stellar's fee-bump transaction ([CAP-0015](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0015.md)) is the native mechanism for this.
+
+---
+
+## Building a Fee-Bump Transaction
+
+```ts
+import {
+  TransactionBuilder,
+  FeeBumpTransaction,
+  Networks,
+  BASE_FEE,
+  Keypair,
+} from "@stellar/stellar-sdk";
+import { Server } from "@stellar/stellar-sdk/lib/stellartoml";
+
+const sponsorKeypair = Keypair.fromSecret(process.env.SPONSOR_SECRET!);
+const NETWORK = Networks.TESTNET;
+
+/**
+ * Accepts a base-64 encoded signed inner transaction from the user and
+ * wraps it in a fee-bump paid by the sponsor.
+ */
+export async function wrapWithFeeBump(
+  innerTxXdr: string,
+  server: StellarSdk.Horizon.Server
+): Promise<string> {
+  const innerTx = TransactionBuilder.fromXDR(innerTxXdr, NETWORK);
+
+  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+    sponsorKeypair,           // fee source
+    BASE_FEE,                 // max fee per operation (sponsor pays)
+    innerTx,
+    NETWORK
+  );
+
+  feeBump.sign(sponsorKeypair);
+  const result = await server.submitTransaction(feeBump);
+  return result.hash;
+}
+```
+
+The inner transaction must already be **signed by the user** before being sent to the sponsor.
+
+---
+
+## Submission Flow
+
+### User side (client)
+
+```ts
+import { TransactionBuilder, Networks, BASE_FEE, Operation } from "@stellar/stellar-sdk";
+
+async function buildUserTransaction(userKeypair: Keypair, server: Horizon.Server) {
+  const account = await server.loadAccount(userKeypair.publicKey());
+
+  // Fee is set to 0 or a nominal amount — sponsor overwrites it
+  const tx = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: "GDEST...",
+        asset: Asset.native(),
+        amount: "10",
+      })
+    )
+    .setTimeout(300)
+    .build();
+
+  tx.sign(userKeypair);
+  return tx.toXDR();
+}
+
+// Send XDR to your sponsor endpoint
+const signedXdr = await buildUserTransaction(userKeypair, server);
+await fetch("/api/sponsor/submit", {
+  method: "POST",
+  body: JSON.stringify({ tx: signedXdr }),
+});
+```
+
+### Sponsor service (server)
+
+```ts
+import express from "express";
+import { wrapWithFeeBump } from "./sponsor";
+import Stellar from "@stellar/stellar-sdk";
+
+const app = express();
+app.use(express.json());
+
+const horizonServer = new Stellar.Horizon.Server("https://horizon-testnet.stellar.org");
+
+app.post("/api/sponsor/submit", async (req, res) => {
+  try {
+    const { tx } = req.body;
+    if (!isAllowed(tx)) {
+      return res.status(403).json({ error: "transaction not permitted" });
+    }
+    const hash = await wrapWithFeeBump(tx, horizonServer);
+    res.json({ hash });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+```
+
+---
+
+## Abuse Prevention
+
+Without safeguards, a sponsor service becomes a free transaction relay. Apply these controls:
+
+| Risk | Mitigation |
+|------|-----------|
+| Anyone submitting arbitrary operations | Whitelist allowed operation types in `isAllowed()` |
+| Replay attacks (same tx submitted twice) | Track submitted transaction hashes in a database; reject duplicates |
+| Rate abuse by one address | Per-account rate limit (e.g. 5 sponsored tx/minute) |
+| Excessive fee drain | Cap `BASE_FEE` and reject inner tx with unusually high sequence gaps |
+| Malicious inner tx destination | Allowlist destinations or operation types |
+
+```ts
+function isAllowed(txXdr: string): boolean {
+  const tx = TransactionBuilder.fromXDR(txXdr, Networks.TESTNET);
+  const ops = tx.operations;
+
+  // Only allow payments and contract invocations
+  const allowed = ["payment", "invokeHostFunction"];
+  return ops.every((op) => allowed.includes(op.type));
+}
+```
+
+---
+
+## Account Sponsorship (Reserve Sponsorship)
+
+Separate from fee bumps, Stellar also lets a sponsor cover the **XLM reserve** for a new account:
+
+```ts
+const sponsorAccount = await server.loadAccount(sponsorKeypair.publicKey());
+
+const tx = new TransactionBuilder(sponsorAccount, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(Operation.beginSponsoringFutureReserves({ sponsoredId: newUserPublicKey }))
+  .addOperation(Operation.createAccount({ destination: newUserPublicKey, startingBalance: "0" }))
+  .addOperation(Operation.endSponsoringFutureReserves({ source: newUserPublicKey }))
+  .setTimeout(30)
+  .build();
+
+// Requires BOTH sponsor and new user signatures
+tx.sign(sponsorKeypair);
+tx.sign(newUserKeypair);
+await server.submitTransaction(tx);
+```
+
+The new account exists with 0 XLM; its base reserve is covered by the sponsor.
+
+---
+
+## Pattern Comparison
+
+| Pattern | What sponsor covers | User XLM needed |
+|---------|---------------------|-----------------|
+| Fee-bump transaction | Transaction fee | Sequence number only (user must have account) |
+| Reserve sponsorship | Account base reserve | 0 XLM to create account |
+| Both combined | Fee + reserve | 0 XLM from user |
+
+Use reserve sponsorship at onboarding, then fee bumps for ongoing transactions, for a fully gasless UX.

--- a/routes-d/733-limit-order-contract-tutorial.mdx
+++ b/routes-d/733-limit-order-contract-tutorial.mdx
@@ -1,0 +1,215 @@
+---
+title: Limit Order Contract Tutorial
+description: A complete walkthrough for building a Soroban limit order contract — placing, matching, and cancelling orders on Stellar.
+---
+
+# Limit Order Contract Tutorial
+
+A limit order lets a user set the price at which they are willing to buy or sell an asset. Orders sit on-chain until a matching counter-order arrives or the original poster cancels. This tutorial builds a minimal but production-shaped limit order contract on Soroban.
+
+---
+
+## What You Will Build
+
+- A `place_order` entry point that stores buy/sell orders at a specified price.
+- A `match_order` entry point that executes a trade when bid ≥ ask.
+- A `cancel_order` entry point so users can reclaim their escrowed funds.
+- A small off-chain script that watches for matchable pairs and calls the contract.
+
+---
+
+## Contract Data Model
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+#[contracttype]
+pub enum DataKey {
+    Order(u64),     // order_id → OrderEntry
+    NextId,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct OrderEntry {
+    pub owner:     Address,
+    pub side:      Symbol,   // "buy" or "sell"
+    pub amount:    i128,     // token amount (in stroops / smallest unit)
+    pub price:     i128,     // price per unit in quote asset smallest unit
+    pub filled:    bool,
+}
+```
+
+All orders are stored in contract instance storage keyed by a monotonically increasing `u64` ID.
+
+---
+
+## Placing an Order
+
+```rust
+#[contract]
+pub struct LimitOrderBook;
+
+#[contractimpl]
+impl LimitOrderBook {
+    pub fn place_order(
+        env: Env,
+        caller: Address,
+        side: Symbol,
+        amount: i128,
+        price: i128,
+    ) -> u64 {
+        caller.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        assert!(price > 0, "price must be positive");
+
+        let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(0);
+        let entry = OrderEntry {
+            owner: caller,
+            side,
+            amount,
+            price,
+            filled: false,
+        };
+        env.storage().instance().set(&DataKey::Order(id), &entry);
+        env.storage().instance().set(&DataKey::NextId, &(id + 1));
+
+        env.events().publish(
+            (Symbol::new(&env, "place"), id),
+            (entry.side.clone(), entry.amount, entry.price),
+        );
+        id
+    }
+}
+```
+
+> **Escrow note**: In a production contract you would transfer tokens into contract custody here using `token::Client::transfer`. This tutorial focuses on the order-book logic; add the token transfer before the storage write.
+
+---
+
+## Matching Orders
+
+A match happens when a buy order's price is ≥ the ask price of a sell order.
+
+```rust
+    pub fn match_order(env: Env, buy_id: u64, sell_id: u64) {
+        let mut buy: OrderEntry = env
+            .storage().instance().get(&DataKey::Order(buy_id))
+            .expect("buy order not found");
+        let mut sell: OrderEntry = env
+            .storage().instance().get(&DataKey::Order(sell_id))
+            .expect("sell order not found");
+
+        assert!(!buy.filled, "buy order already filled");
+        assert!(!sell.filled, "sell order already filled");
+        assert_eq!(buy.side, Symbol::new(&env, "buy"), "buy_id is not a buy");
+        assert_eq!(sell.side, Symbol::new(&env, "sell"), "sell_id is not a sell");
+        assert!(buy.price >= sell.price, "no price match: bid < ask");
+        assert_eq!(buy.amount, sell.amount, "partial fills not supported in this example");
+
+        // In production: transfer base asset from contract to buy.owner,
+        //                transfer quote asset from contract to sell.owner.
+
+        buy.filled  = true;
+        sell.filled = true;
+        env.storage().instance().set(&DataKey::Order(buy_id),  &buy);
+        env.storage().instance().set(&DataKey::Order(sell_id), &sell);
+
+        env.events().publish(
+            (Symbol::new(&env, "match"), buy_id, sell_id),
+            (buy.price, sell.price, buy.amount),
+        );
+    }
+```
+
+The matcher is **trustless**: anyone can call `match_order` once a bid ≥ ask pair exists. The contract enforces correctness, not the caller.
+
+---
+
+## Cancelling an Order
+
+```rust
+    pub fn cancel_order(env: Env, caller: Address, order_id: u64) {
+        caller.require_auth();
+        let mut order: OrderEntry = env
+            .storage().instance().get(&DataKey::Order(order_id))
+            .expect("order not found");
+
+        assert_eq!(order.owner, caller, "not your order");
+        assert!(!order.filled, "order already filled");
+
+        order.filled = true; // mark as cancelled so it cannot be matched
+        env.storage().instance().set(&DataKey::Order(order_id), &order);
+
+        // In production: return escrowed tokens to caller here.
+
+        env.events().publish(
+            (Symbol::new(&env, "cancel"), order_id),
+            caller,
+        );
+    }
+```
+
+---
+
+## Off-Chain Matching Script
+
+The contract stores orders passively. A lightweight off-chain watcher queries open orders and submits match transactions when a pair qualifies.
+
+```ts
+import { Contract, SorobanRpc, TransactionBuilder, Networks, BASE_FEE } from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+const CONTRACT_ID = "C..."; // your deployed contract ID
+const matcherKeypair = /* load from env */;
+
+async function scanAndMatch() {
+  // Fetch all open orders from contract storage (use getContractData or an indexer)
+  const openBuys  = await fetchOpenOrders("buy");
+  const openSells = await fetchOpenOrders("sell");
+
+  for (const buy of openBuys) {
+    for (const sell of openSells) {
+      if (buy.price >= sell.price && buy.amount === sell.amount) {
+        await submitMatch(buy.id, sell.id);
+      }
+    }
+  }
+}
+
+async function submitMatch(buyId: bigint, sellId: bigint) {
+  const account  = await server.getAccount(matcherKeypair.publicKey());
+  const contract = new Contract(CONTRACT_ID);
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call("match_order", /* xdr args */))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(matcherKeypair);
+  await server.sendTransaction(prepared);
+}
+
+// Run every 5 seconds
+setInterval(scanAndMatch, 5_000);
+```
+
+---
+
+## Cancellation Flow Summary
+
+| Step | Who | What |
+|------|-----|------|
+| 1 | User | Calls `place_order` — escrowed funds locked in contract |
+| 2 | Anyone | Calls `match_order` when bid ≥ ask — funds exchanged |
+| 3 | User | Calls `cancel_order` anytime before a match — escrowed funds returned |
+
+---
+
+## Accuracy Notes
+
+- All amounts and prices are in the smallest unit of each asset (stroops for XLM, 7 decimals for SAC tokens).
+- Partial fills require splitting orders and tracking `amount_filled`; omitted here for brevity.
+- On testnet use `Networks.TESTNET` and fund the contract's Stellar account via Friendbot before deploying.
+- `env.storage().instance()` TTL defaults to ~100 ledgers; extend with `env.storage().instance().extend_ttl(...)` for longer-lived order books.


### PR DESCRIPTION
## Summary

- **#733** — Complete tutorial for a Soroban limit order contract: placing, matching, and cancelling orders with an off-chain matcher script.
- **#726** — Gasless transaction patterns: fee-bump (CAP-0015) + reserve sponsorship, sponsor service implementation, abuse prevention.
- **#723** — Rate-limited public API for a Stellar dApp: token-bucket algorithm, per-account daily quota, Express proxy, abuse mitigations.
- **#710** — Preventing double submission: idempotent send with hash check, UI disabled state, sequence-number guard, polling pattern.

## Changes

- `routes-d/733-limit-order-contract-tutorial.mdx`
- `routes-d/726-gasless-transaction-patterns.mdx`
- `routes-d/723-rate-limited-public-api.mdx`
- `routes-d/710-preventing-double-submits.mdx`

closes #733
closes #726
closes #723
closes #710