### PR TITLE
docs: AMM implementation, off-chain compute, background jobs, and TWAP guides

### DIFF
--- a/routes-d/issue-716-amm-implementation-guide.md
+++ b/routes-d/issue-716-amm-implementation-guide.md
@@ -1,0 +1,260 @@
+---
+title: AMM Implementation on Soroban
+description: A comprehensive guide to implementing an automated market maker on Soroban, comparing pricing formulas, covering fee and slippage handling, and providing a reference contract design
+---
+
+# AMM Implementation on Soroban
+
+An automated market maker (AMM) lets users trade assets against a liquidity pool instead of a counterparty. This guide compares the pricing formulas you can build on, explains how fees and slippage should be handled, and walks through a reference design for a Soroban AMM contract.
+
+---
+
+## Table of Contents
+
+1. [How an AMM Works](#how-an-amm-works)
+2. [Comparing Pricing Formulas](#comparing-pricing-formulas)
+3. [Fee Handling](#fee-handling)
+4. [Slippage Handling](#slippage-handling)
+5. [Reference Design](#reference-design)
+6. [Testing the Pool](#testing-the-pool)
+7. [Production Considerations](#production-considerations)
+
+---
+
+## How an AMM Works
+
+A pool holds reserves of two assets, `A` and `B`. Traders swap one for the other; the pool's pricing formula decides how much of `B` a trader receives for a given amount of `A`. Liquidity providers (LPs) deposit both assets and receive pool shares that entitle them to a proportional cut of reserves plus accumulated fees.
+
+```
+        deposit A + B                    swap A -> B
+LP  ------------------->  Pool  <-------------------  Trader
+    <-------------------  (reserves,     ------------->
+        pool shares        formula,        B out, fee
+                           fees)           retained
+```
+
+Stellar's classic protocol already ships constant-product liquidity pools natively (CAP-38). Building your own AMM on Soroban makes sense when you need a different curve, custom fee logic, LP incentives, or composability with other contracts.
+
+---
+
+## Comparing Pricing Formulas
+
+### Constant product (`x * y = k`)
+
+The Uniswap V2 formula. For reserves `x` and `y`, any swap must keep the product constant:
+
+```
+(x + dx) * (y - dy) = x * y
+dy = y * dx / (x + dx)
+```
+
+- **Pros:** simple, never runs out of inventory, price always defined, easy to audit.
+- **Cons:** high slippage for large trades relative to reserves; LPs suffer impermanent loss when prices trend.
+- **Use when:** volatile pairs, general-purpose pools, first implementation.
+
+### Constant sum (`x + y = k`)
+
+Trades 1:1 until one side is exhausted.
+
+- **Pros:** zero slippage while both reserves last.
+- **Cons:** the pool can be fully drained of one asset the moment the market price deviates from 1:1 — an arbitrageur will take the entire cheaper side.
+- **Use when:** effectively never on its own; useful only as a component of hybrid curves.
+
+### StableSwap / hybrid (Curve-style)
+
+Interpolates between constant sum (near balance) and constant product (when unbalanced), controlled by an amplification coefficient `A`:
+
+```
+A * n^n * sum(x_i) + D = A * D * n^n + D^(n+1) / (n^n * prod(x_i))
+```
+
+- **Pros:** very low slippage for like-valued assets (e.g. USDC/EURC-pegged pairs, wrapped variants).
+- **Cons:** iterative solvers (Newton's method) on-chain cost more compute; mispriced `A` hurts LPs when a peg breaks.
+- **Use when:** stablecoin pairs or assets that track each other tightly.
+
+### Concentrated liquidity (Uniswap V3-style)
+
+LPs allocate liquidity to price ranges, multiplying capital efficiency.
+
+- **Pros:** far better quotes with the same TVL.
+- **Cons:** substantially more complex (tick math, per-position accounting, NFT-like positions); LP experience is active, not passive.
+- **Use when:** you have deep liquidity demands and experienced LPs; not recommended as a first Soroban AMM.
+
+### Summary
+
+| Formula           | Slippage profile    | Complexity | Best fit                       |
+| ----------------- | ------------------- | ---------- | ------------------------------ |
+| Constant product  | Moderate everywhere | Low        | Volatile pairs, default choice |
+| Constant sum      | None until drained  | Low        | Never standalone               |
+| StableSwap hybrid | Very low near peg   | Medium     | Pegged/correlated pairs        |
+| Concentrated      | Low inside ranges   | High       | Mature, deep markets           |
+
+The reference design below uses **constant product** — it is the simplest formula that is safe to ship, and everything else in the contract (fees, shares, slippage guards) carries over unchanged if you later swap the curve.
+
+---
+
+## Fee Handling
+
+Fees compensate LPs for impermanent loss and make arbitrage-driven rebalancing profitable for the pool.
+
+- **Charge on input, inside the invariant.** Deduct the fee from the input amount before applying the curve, so fees accrue into reserves and compound for LPs:
+
+```
+dx_after_fee = dx * (FEE_DENOM - fee_bps) / FEE_DENOM
+dy = y * dx_after_fee / (x + dx_after_fee)
+```
+
+- **Basis points, integer math only.** Store `fee_bps` (e.g. `30` = 0.30%) and a `FEE_DENOM` of `10_000`. Soroban contracts use `i128` arithmetic — never floats.
+- **Rounding must favor the pool.** Round `dy` down and any fee up. If rounding ever favors the trader, the pool leaks value one stroop at a time under adversarial trade sizing.
+- **Protocol fee (optional).** A cut of the LP fee (e.g. 1/6) can be diverted to a treasury address. Keep it a parameter with a hard upper bound so governance cannot rug LPs.
+
+---
+
+## Slippage Handling
+
+Slippage is the difference between the quoted price and the executed price. Two mechanisms protect traders:
+
+1. **`min_out` on swaps.** The trader supplies the minimum acceptable output; the contract aborts if the curve produces less. This is the primary defense against sandwich attacks and stale quotes.
+2. **Deadline / ledger bound.** Reject transactions that execute after a caller-supplied ledger sequence, so a quote signed at ledger `N` cannot execute at `N + 500` when reserves have moved.
+
+For LP operations, the same idea applies: `deposit` takes `min_shares`, `withdraw` takes `min_a` / `min_b`.
+
+> Quoting UIs should compute expected output off-chain from current reserves, then set `min_out = expected * (1 - tolerance)` with a user-configurable tolerance (0.1%–1% is typical).
+
+---
+
+## Reference Design
+
+The contract below is a minimal but complete constant-product pool. Interface first:
+
+```rust
+pub trait LiquidityPool {
+    /// One-time setup with the two token addresses and the LP fee.
+    fn initialize(env: Env, token_a: Address, token_b: Address, fee_bps: u32);
+
+    /// Deposit both assets; mints pool shares. Aborts if shares < min_shares.
+    fn deposit(env: Env, from: Address, amount_a: i128, amount_b: i128, min_shares: i128) -> i128;
+
+    /// Swap an exact amount of one asset for the other.
+    fn swap(env: Env, from: Address, buy_a: bool, amount_in: i128, min_out: i128, deadline_ledger: u32) -> i128;
+
+    /// Burn shares, receive proportional reserves.
+    fn withdraw(env: Env, from: Address, shares: i128, min_a: i128, min_b: i128) -> (i128, i128);
+
+    /// Read-only quote for UIs.
+    fn quote(env: Env, buy_a: bool, amount_in: i128) -> i128;
+}
+```
+
+Core swap logic:
+
+```rust
+const FEE_DENOM: i128 = 10_000;
+
+fn swap_out(reserve_in: i128, reserve_out: i128, amount_in: i128, fee_bps: u32) -> i128 {
+    // Fee is taken from the input and stays in the pool for LPs.
+    let in_after_fee = amount_in
+        .checked_mul(FEE_DENOM - fee_bps as i128)
+        .unwrap()
+        / FEE_DENOM;
+
+    // dy = y * dx' / (x + dx'), rounded down (favors the pool).
+    reserve_out
+        .checked_mul(in_after_fee)
+        .unwrap()
+        / reserve_in.checked_add(in_after_fee).unwrap()
+}
+
+pub fn swap(env: Env, from: Address, buy_a: bool, amount_in: i128, min_out: i128, deadline_ledger: u32) -> i128 {
+    from.require_auth();
+
+    if env.ledger().sequence() > deadline_ledger {
+        panic_with_error!(&env, Error::DeadlineExpired);
+    }
+    if amount_in <= 0 {
+        panic_with_error!(&env, Error::InvalidAmount);
+    }
+
+    let (mut reserve_a, mut reserve_b) = read_reserves(&env);
+    let (reserve_in, reserve_out) = if buy_a { (reserve_b, reserve_a) } else { (reserve_a, reserve_b) };
+
+    let out = swap_out(reserve_in, reserve_out, amount_in, read_fee_bps(&env));
+    if out < min_out {
+        panic_with_error!(&env, Error::SlippageExceeded);
+    }
+
+    // Pull the input, push the output.
+    let (token_in, token_out) = swap_token_addresses(&env, buy_a);
+    token::Client::new(&env, &token_in).transfer(&from, &env.current_contract_address(), &amount_in);
+    token::Client::new(&env, &token_out).transfer(&env.current_contract_address(), &from, &out);
+
+    if buy_a { reserve_a -= out; reserve_b += amount_in; } else { reserve_a += amount_in; reserve_b -= out; }
+    write_reserves(&env, reserve_a, reserve_b);
+
+    env.events().publish((symbol_short!("swap"), from), (buy_a, amount_in, out));
+    out
+}
+```
+
+Share accounting for deposits uses the standard geometric-mean bootstrap and proportional mints afterwards:
+
+```rust
+fn shares_for_deposit(total_shares: i128, reserve_a: i128, reserve_b: i128, amount_a: i128, amount_b: i128) -> i128 {
+    if total_shares == 0 {
+        // First LP: sqrt(a * b) locks the initial price; burn a minimum
+        // liquidity amount to prevent share-price inflation attacks.
+        integer_sqrt(amount_a.checked_mul(amount_b).unwrap()) - MINIMUM_LIQUIDITY
+    } else {
+        // Subsequent LPs: mint the smaller proportional amount so deposits
+        // at the wrong ratio donate the excess to the pool.
+        core::cmp::min(
+            amount_a.checked_mul(total_shares).unwrap() / reserve_a,
+            amount_b.checked_mul(total_shares).unwrap() / reserve_b,
+        )
+    }
+}
+```
+
+Design notes:
+
+- **Reserves are tracked in storage, not read from token balances.** Balance-based accounting is manipulable by direct transfers into the contract.
+- **`MINIMUM_LIQUIDITY` (e.g. 1,000 share units) is burned on first deposit.** Without it, the first LP can inflate share price and round out later depositors.
+- **All state-changing entry points call `require_auth()`** on the acting address, and token movements use the token client so Stellar Asset Contract (SAC) wrapped assets and custom tokens both work.
+- **Events on every mutation** (`deposit`, `swap`, `withdraw`) so indexers and UIs can track the pool without polling.
+
+---
+
+## Testing the Pool
+
+Test the math exhaustively before anything else — curve bugs are the expensive ones:
+
+```rust
+#[test]
+fn swap_preserves_invariant() {
+    // k must never decrease across a swap (fees make it grow).
+    let out = swap_out(1_000_000, 1_000_000, 10_000, 30);
+    let k_before = 1_000_000i128 * 1_000_000;
+    let k_after = (1_000_000 + 10_000) * (1_000_000 - out);
+    assert!(k_after >= k_before);
+}
+
+#[test]
+fn swap_rounds_in_favor_of_pool() {
+    // Tiny swaps must never extract more than they put in.
+    assert_eq!(swap_out(1_000_000_000, 1_000_000_000, 1, 30), 0);
+}
+```
+
+Then integration-test with the Soroban test environment: deposit → swap both directions → withdraw, asserting reserve and share conservation at each step, plus the failure paths (`SlippageExceeded`, `DeadlineExpired`, zero amounts, uninitialized pool).
+
+---
+
+## Production Considerations
+
+- **Oracle usage:** spot reserves are manipulable within a transaction; never let another protocol read them as a price feed. Expose a TWAP accumulator if downstream contracts need prices.
+- **Upgradability:** if you use contract upgrade hooks, gate them behind a timelocked admin and emit events, so LPs can exit before logic changes.
+- **Fee bounds:** enforce `fee_bps <= 100` (1%) or similar at `initialize` — a governance mistake should not be able to set a 100% fee.
+- **Decimal mismatches:** pools of tokens with different decimals work fine with constant product, but UIs must normalize when displaying prices.
+- **Audit the rounding direction of every division** — it is the single most common AMM bug class.
+
+With the constant-product base in place, a StableSwap curve or protocol-fee switch can be added behind the same interface without changing the LP or trader experience.

--- a/routes-d/issue-720-offchain-compute-onchain-settlement.md
+++ b/routes-d/issue-720-offchain-compute-onchain-settlement.md
@@ -1,0 +1,207 @@
+---
+title: Off-Chain Compute with On-Chain Settlement
+description: A comprehensive guide to running heavy computation off-chain while settling results on Stellar, covering trust models, the settlement flow, and a reference batch-payout example
+---
+
+# Off-Chain Compute with On-Chain Settlement
+
+Ledgers are good at ordering, authorization, and final settlement — and bad at heavy computation. The standard answer is to compute off-chain and settle on-chain: run the expensive logic on ordinary servers, then commit only the _result_ to Stellar where it becomes authoritative and auditable. This guide covers the trust models available, the settlement flow, and a reference implementation for a batch payout system.
+
+---
+
+## Table of Contents
+
+1. [When to Use This Pattern](#when-to-use-this-pattern)
+2. [The Trust Model](#the-trust-model)
+3. [The Settlement Flow](#the-settlement-flow)
+4. [Reference Example: Batch Payouts](#reference-example-batch-payouts)
+5. [Failure Handling](#failure-handling)
+6. [Auditability](#auditability)
+7. [Choosing a Trust Level](#choosing-a-trust-level)
+
+---
+
+## When to Use This Pattern
+
+Reach for off-chain compute when the logic is too expensive, too private, or too data-hungry to run in a Soroban contract:
+
+- **Aggregation** — computing payouts, rewards, interest, or rankings across thousands of accounts.
+- **Matching** — order matching, auction clearing, routing.
+- **External data** — anything that needs web APIs, ML inference, or large datasets.
+- **Privacy** — inputs that must not appear on a public ledger (salaries, KYC attributes).
+
+The ledger's role shrinks to three things it does perfectly: hold funds, verify authorization, and record the final state transition.
+
+---
+
+## The Trust Model
+
+Everything in this pattern hinges on one question: **why should anyone believe the off-chain result?** There are four broad answers, in increasing order of machinery:
+
+### 1. Trusted operator
+
+The computing party is simply trusted (it is your own backend, or a contractual counterparty). Settlement is a normal transaction signed by the operator's key.
+
+- Verification cost: none. Trust required: total.
+- Right for: internal systems, payroll, single-company products — the majority of real deployments.
+
+### 2. Multi-party attestation (M-of-N)
+
+Several independent parties run the same computation; settlement requires M-of-N signatures. On Stellar this maps directly onto native multisig: set signer weights and thresholds on the settlement account, or require multiple `require_auth` addresses in a Soroban contract.
+
+- Verification cost: running N replicas. Trust required: that M parties don't collude.
+- Right for: consortiums, bridges, oracle committees.
+
+### 3. Optimistic settlement (challenge window)
+
+One party posts the result along with a bond; anyone can challenge within a window by submitting proof of a wrong result. Unchallenged results finalize; successful challenges slash the bond.
+
+- Verification cost: only on dispute. Trust required: at least one honest watcher exists.
+- Right for: high-value results where independent parties have an incentive to watch.
+
+### 4. Validity proofs (zk)
+
+The off-chain computation produces a cryptographic proof that the result is correct; the contract verifies the proof before accepting settlement.
+
+- Verification cost: proof generation is heavy; verification is cheap. Trust required: none beyond the cryptography.
+- Right for: cases that justify significant engineering investment; proving general computation remains expensive.
+
+> Start with the weakest trust model your users will accept. Each step up the ladder multiplies engineering cost, and a trusted-operator design with good auditability (below) is often more honest than a half-finished optimistic scheme.
+
+---
+
+## The Settlement Flow
+
+The flow is the same regardless of trust model — only the "verify" step changes:
+
+```
+   Off-chain worker                     Stellar / Soroban
+        |                                     |
+ 1. read inputs (DB, APIs,                    |
+    ledger snapshots)                         |
+        |                                     |
+ 2. compute result                            |
+    result_hash = H(result)                   |
+        |                                     |
+ 3. ------- submit(result, result_hash) ----> |
+        |                              4. verify authorization
+        |                                 (operator sig / M-of-N /
+        |                                  challenge window / proof)
+        |                              5. execute state change
+        |                                 (transfers, storage writes)
+        |                              6. emit settlement event
+        | <------- tx hash, events ---------- |
+ 7. reconcile: confirm on-ledger              |
+    state matches computed result             |
+```
+
+Two rules make this robust:
+
+- **Commit to the inputs.** Record which ledger sequence / data snapshot the computation used, and include it (or its hash) in the settlement. Without this, "recompute to verify" is meaningless because inputs drift.
+- **Make settlement idempotent.** The settlement transaction must be safe to submit twice. Use a batch identifier stored on-chain: settling an already-settled batch ID must fail cleanly.
+
+---
+
+## Reference Example: Batch Payouts
+
+A creator platform computes weekly revenue shares for thousands of creators off-chain, then settles the batch on Stellar. Trusted-operator model, with hashes committed for auditability.
+
+**Off-chain worker (TypeScript):**
+
+```ts
+import { createHash } from 'node:crypto';
+
+interface Payout {
+  destination: string; // G... address
+  amountXlm: string; // fixed 7-decimal string
+}
+
+async function computeBatch(
+  weekId: string
+): Promise<{ payouts: Payout[]; batchHash: string }> {
+  // 1. Snapshot inputs: revenue events up to a fixed cutoff ledger.
+  const cutoffLedger = await getWeekCutoffLedger(weekId);
+  const events = await db.revenueEvents.where({
+    weekId,
+    maxLedger: cutoffLedger,
+  });
+
+  // 2. Heavy computation happens here, in ordinary code you can test.
+  const payouts = aggregateRevenueShares(events);
+
+  // 3. Commit to the result: canonical serialization, then hash.
+  const canonical = JSON.stringify(
+    payouts.map((p) => [p.destination, p.amountXlm]).sort()
+  );
+  const batchHash = createHash('sha256').update(canonical).digest('hex');
+
+  return { payouts, batchHash };
+}
+```
+
+**Settlement contract (Soroban, abbreviated):**
+
+```rust
+pub fn settle_batch(
+    env: Env,
+    operator: Address,
+    batch_id: Symbol,
+    batch_hash: BytesN<32>,
+    payouts: Vec<(Address, i128)>,
+) {
+    operator.require_auth();
+
+    // Idempotency: each batch settles exactly once.
+    if env.storage().persistent().has(&batch_id) {
+        panic_with_error!(&env, Error::BatchAlreadySettled);
+    }
+
+    // Execute the transfers from the pool held by this contract.
+    let token = token::Client::new(&env, &read_payout_token(&env));
+    for (dest, amount) in payouts.iter() {
+        token.transfer(&env.current_contract_address(), &dest, &amount);
+    }
+
+    // Record the commitment; auditors can recompute and compare.
+    env.storage().persistent().set(&batch_id, &batch_hash);
+    env.events().publish((symbol_short!("settled"), batch_id), batch_hash);
+}
+```
+
+For payout counts beyond what fits in one transaction, split into chunks with ids `week-42-chunk-0..n` — each chunk idempotent on its own — and store the parent batch hash in every chunk so partial settlement is detectable.
+
+> On classic Stellar (no Soroban), the same design works with a payment-op batch from a multisig-controlled distribution account, with `batch_id` carried in the transaction memo.
+
+---
+
+## Failure Handling
+
+- **Worker crash before submit:** nothing settled; rerun the computation. Determinism (fixed input snapshot) guarantees the same result and hash.
+- **Transaction failed:** distinguish _rejected_ (fix and resubmit — same batch ID keeps it safe) from _unknown outcome_ (timeout). For unknown outcomes, query the ledger for the batch ID before resubmitting — never blind-retry a settlement.
+- **Partial chunk settlement:** on restart, read which chunk IDs exist on-chain and resume from the first missing one.
+- **Result disputed after settlement:** with a trusted operator, this is an off-chain process (recompute from the committed input snapshot, publish the diff, issue a correcting batch). Never mutate a settled batch; append a correction with its own ID.
+
+---
+
+## Auditability
+
+Even in the trusted-operator model, you can make the system _verifiable after the fact_ at almost no cost:
+
+1. **Publish input snapshots** (or their hashes) alongside each batch.
+2. **Commit the result hash on-chain** at settlement time, as in the example.
+3. **Keep the computation deterministic and open** — a third party who obtains the inputs can recompute and compare against the on-chain hash.
+
+This turns "trust me" into "trust, but verify with a script", which is a meaningful upgrade for users and a forcing function for your own engineering discipline.
+
+---
+
+## Choosing a Trust Level
+
+| Situation                                      | Recommended model                       |
+| ---------------------------------------------- | --------------------------------------- |
+| Your own product paying your own users         | Trusted operator + committed hashes     |
+| Consortium of known parties                    | M-of-N attestation via Stellar multisig |
+| Open system, watchful third parties exist      | Optimistic with bonded challenges       |
+| Adversarial environment, high value per result | Validity proofs                         |
+
+Settle the smallest thing that makes the result final — usually a set of transfers and one hash — and keep everything else off-chain where it is cheap to compute, easy to test, and possible to fix.

--- a/routes-d/issue-724-background-job-processing.md
+++ b/routes-d/issue-724-background-job-processing.md
@@ -1,0 +1,222 @@
+---
+title: Background Job Processing for Stellar Applications
+description: A comprehensive guide to running background jobs that touch the Stellar network, covering queue design, retry strategies, idempotent transaction submission, and a worked payment-worker example
+---
+
+# Background Job Processing for Stellar Applications
+
+Anything slow, failure-prone, or bursty belongs in a background job, not a request handler — and almost everything that touches the Stellar network is at least one of those. This guide covers queue design, retry strategy, and the property that makes or breaks ledger-touching jobs: idempotency. It ends with a small, complete payment worker.
+
+---
+
+## Table of Contents
+
+1. [Why Jobs, Not Request Handlers](#why-jobs-not-request-handlers)
+2. [Queue Design](#queue-design)
+3. [Retries](#retries)
+4. [Idempotency](#idempotency)
+5. [A Small Example: Payment Worker](#a-small-example-payment-worker)
+6. [Observability](#observability)
+7. [Checklist](#checklist)
+
+---
+
+## Why Jobs, Not Request Handlers
+
+A payment submission can take several seconds (build, sign, submit, await inclusion), can fail transiently (network, fee surge, sequence collision), and can arrive in bursts. Doing it inline in an HTTP handler couples your user's request latency to ledger close times and turns every transient failure into a user-facing error.
+
+The job pattern decouples them:
+
+```
+ HTTP request                Queue                    Worker
+     |                         |                        |
+     |-- enqueue(payment) ---> |                        |
+     |<- 202 Accepted, job id  |                        |
+     |                         |--- lease job --------> |
+     |                         |                        |-- submit to Stellar
+     |                         |                        |-- record result
+     |                         |<-- ack / fail -------- |
+     |-- GET /jobs/:id ------------------------------->  status: succeeded
+```
+
+The user gets an immediate acknowledgment and polls (or receives a webhook/stream) for the outcome.
+
+---
+
+## Queue Design
+
+Any real queue works — BullMQ (Redis), pg-boss (Postgres), SQS, Cloud Tasks. What matters is the properties you configure, not the brand:
+
+- **At-least-once delivery.** Assume every job can run more than once. (This is why idempotency gets its own section.)
+- **Per-job leases with visibility timeout.** A crashed worker's job must return to the queue automatically.
+- **A dead-letter queue (DLQ).** Jobs that exhaust retries must land somewhere a human can inspect, not vanish.
+- **Concurrency limits per source account.** Stellar transactions from one account are ordered by sequence number; two workers submitting concurrently from the same account will collide. Either give each worker its own channel account, or serialize jobs per account with a queue group/partition key.
+
+> **Channel accounts** are the standard Stellar answer to submission concurrency: a pool of funded accounts used only for sequence numbers, with the payment's `source` set per-operation. Partition jobs across channels and each channel stays strictly serial.
+
+---
+
+## Retries
+
+### What to retry
+
+Classify failures before writing retry code:
+
+| Failure                                | Class           | Action                                 |
+| -------------------------------------- | --------------- | -------------------------------------- |
+| Network timeout to Horizon/RPC         | Transient       | Retry with backoff                     |
+| `tx_insufficient_fee` during surge     | Transient       | Retry with bumped fee                  |
+| `tx_bad_seq` (sequence collision)      | Transient       | Refresh sequence, rebuild, retry       |
+| Timebounds expired                     | Transient       | Rebuild transaction, retry             |
+| `op_underfunded` (payer lacks balance) | Permanent       | Fail the job; notify                   |
+| `op_no_destination` (account missing)  | Permanent       | Fail or route to account-creation flow |
+| Malformed request / bad address        | Permanent (bug) | DLQ immediately, alert                 |
+
+Retrying permanent failures wastes time at best; at worst (see below) it double-pays.
+
+### How to retry
+
+- **Exponential backoff with jitter:** e.g. `delay = min(cap, base * 2^attempt) * random(0.5, 1.5)`. Jitter prevents synchronized retry storms after an outage.
+- **Cap attempts** (5–8 is typical) and route exhausted jobs to the DLQ.
+- **The dangerous window:** a timeout does _not_ mean the transaction failed — it may be in the ledger already. **Never blind-retry after an unknown outcome.** Resolve the outcome first (next section).
+
+---
+
+## Idempotency
+
+At-least-once delivery plus money movement means one thing: every job must be safe to run twice. Three layers achieve this:
+
+1. **Job-level idempotency key.** Every logical operation gets a unique key (`payout-2026-07-invoice-8841`) stored with a unique constraint. A duplicate enqueue becomes a no-op.
+
+2. **Ledger-level deduplication.** Before submitting, and after any unknown outcome, check whether the transaction already made it:
+   - Deterministically rebuild the same transaction envelope (same source, sequence, operations, memo) and look up its hash, or
+   - Query for the idempotency key carried in the transaction **memo** (classic) or in a contract event (Soroban).
+
+3. **State-machine guard in your database.** Track each job through `pending → submitting → submitted → confirmed | failed`. Transitions are compare-and-swap updates; a second worker that loads a job already in `submitted` verifies instead of resubmitting.
+
+```
+pending --> submitting --> submitted --> confirmed
+                |              |
+                |              +--> unknown --(query ledger)--> confirmed | retry
+                +--> failed (permanent)
+```
+
+---
+
+## A Small Example: Payment Worker
+
+A BullMQ worker that pays out XLM with idempotency and correct retry classification:
+
+```ts
+import { Worker } from 'bullmq';
+import {
+  Horizon,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Networks,
+  Memo,
+} from '@stellar/stellar-sdk';
+
+const horizon = new Horizon.Server('https://horizon.stellar.org');
+
+const worker = new Worker(
+  'payouts',
+  async (job) => {
+    const { idempotencyKey, destination, amountXlm } = job.data;
+
+    // Layer 3: state-machine guard (atomic claim).
+    const claimed = await db.claimJob(idempotencyKey); // UPDATE ... WHERE state='pending'
+    if (!claimed) {
+      return await verifyOutcome(idempotencyKey); // someone already ran it
+    }
+
+    // Layer 2: did a previous attempt land on-ledger?
+    const existing = await findPaymentByMemo(horizon, idempotencyKey);
+    if (existing) {
+      await db.markConfirmed(idempotencyKey, existing.transaction_hash);
+      return;
+    }
+
+    const channel = await channelPool.acquire(); // per-account serialization
+    try {
+      const account = await horizon.loadAccount(channel.publicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: await recommendedFee(horizon),
+        networkPassphrase: Networks.PUBLIC,
+      })
+        .addOperation(
+          Operation.payment({
+            source: channel.publicKey,
+            destination,
+            asset: Asset.native(),
+            amount: amountXlm,
+          })
+        )
+        .addMemo(Memo.text(idempotencyKey.slice(0, 28))) // memo carries the key
+        .setTimeout(60)
+        .build();
+
+      tx.sign(channel.keypair);
+      await db.markSubmitted(idempotencyKey, tx.hash().toString('hex'));
+
+      const res = await horizon.submitTransaction(tx);
+      await db.markConfirmed(idempotencyKey, res.hash);
+    } catch (err) {
+      if (isUnknownOutcome(err)) {
+        // Timeout: may or may not be in the ledger. Do NOT rethrow blindly —
+        // requeue a verification, not a resubmission.
+        await job.moveToDelayed(Date.now() + 15_000);
+        return;
+      }
+      if (isPermanent(err)) {
+        await db.markFailed(idempotencyKey, describeStellarError(err));
+        return; // do not rethrow: no retry for permanent failures
+      }
+      throw err; // transient: let BullMQ's backoff retry it
+    } finally {
+      channelPool.release(channel);
+    }
+  },
+  {
+    connection: redis,
+    concurrency: 8,
+    settings: {},
+  }
+);
+```
+
+Queue configuration to match:
+
+```ts
+await queue.add('payout', data, {
+  jobId: data.idempotencyKey, // layer 1: dedupe at enqueue
+  attempts: 6,
+  backoff: { type: 'exponential', delay: 2_000 },
+  removeOnComplete: 1000,
+  removeOnFail: false, // keep failures inspectable
+});
+```
+
+The three idempotency layers are doing distinct work: `jobId` stops duplicate enqueues, the DB state machine stops concurrent double-runs, and the memo lookup stops double-submission after an unknown outcome. Remove any one and there is a sequence of crashes that double-pays.
+
+---
+
+## Observability
+
+- **Metrics:** queue depth, job age (p95 time-to-confirmed), retry rate, DLQ arrivals, per-error-code counts. A rising `tx_insufficient_fee` rate is your early fee-surge alarm.
+- **Structured logs** with the idempotency key on every line, so one grep reconstructs any payment's history.
+- **Alerts** on DLQ arrivals (a human decision is needed) and on queue age breaching SLO — not on individual transient failures, which are routine.
+
+---
+
+## Checklist
+
+- [ ] Every ledger-touching operation runs in a job, not a request handler.
+- [ ] Delivery is at-least-once, with a visibility timeout and a DLQ.
+- [ ] Jobs from the same source account are serialized (or channel accounts are used).
+- [ ] Failures are classified; permanent errors do not retry.
+- [ ] Backoff is exponential with jitter and an attempt cap.
+- [ ] Unknown outcomes trigger ledger verification, never blind resubmission.
+- [ ] Idempotency exists at all three layers: enqueue, state machine, ledger.
+- [ ] DLQ arrivals page a human; transient retries do not.

--- a/routes-d/issue-734-time-weighted-average-pricing.md
+++ b/routes-d/issue-734-time-weighted-average-pricing.md
@@ -1,0 +1,202 @@
+---
+title: Time-Weighted Average Pricing on Stellar
+description: A comprehensive guide to building a TWAP oracle pattern on Stellar, covering data collection strategies, a small on-chain aggregator, and staleness handling
+---
+
+# Time-Weighted Average Pricing on Stellar
+
+A spot price is one observation; a time-weighted average price (TWAP) is the average of observations weighted by how long each one was in effect. Protocols use TWAPs instead of spot prices because a spot price can be pushed around within a single ledger — a TWAP over a sensible window cannot be moved far without sustaining the manipulation (and paying arbitrageurs) for the whole window. This guide covers where the price data comes from, a small Soroban aggregator that maintains the average, and the staleness handling that keeps consumers safe.
+
+---
+
+## Table of Contents
+
+1. [What a TWAP Buys You](#what-a-twap-buys-you)
+2. [Data Collection Strategies](#data-collection-strategies)
+3. [The Accumulator Technique](#the-accumulator-technique)
+4. [A Small Aggregator Contract](#a-small-aggregator-contract)
+5. [Staleness Handling](#staleness-handling)
+6. [Choosing a Window](#choosing-a-window)
+7. [Operational Notes](#operational-notes)
+
+---
+
+## What a TWAP Buys You
+
+For observations `p_i` each in effect for duration `t_i` over window `T = Σ t_i`:
+
+```
+TWAP = Σ (p_i * t_i) / T
+```
+
+To move a 30-minute TWAP by 10%, an attacker must hold the manipulated spot price for a meaningful fraction of 30 minutes, eating arbitrage losses the entire time — versus a spot read, which can be manipulated and restored inside one transaction. The cost of the attack scales with the window length, which is exactly the knob you control.
+
+The trade-off: a TWAP lags the real price by design. Liquidation engines and mint/redeem logic want manipulation resistance; trading UIs want freshness. Serve both by exposing spot and TWAP separately.
+
+---
+
+## Data Collection Strategies
+
+Three ways to get observations, in increasing order of infrastructure:
+
+### 1. Poll-and-push (cron keeper)
+
+An off-chain keeper reads prices on a schedule (from Stellar DEX orderbooks/liquidity pools, or external markets) and pushes them into the aggregator contract.
+
+- **Pros:** simplest to build; sources can be anything (on-ledger and off).
+- **Cons:** you now trust the keeper's key(s); missed cron runs create gaps.
+- **Mitigations:** multiple submitter keys with per-key rate limits, sanity bounds on-chain (reject a push that moves price > X% from the previous observation unless confirmed by a second key).
+
+### 2. Event-driven sampling
+
+A daemon subscribes to trades/pool events (Horizon streaming or Soroban RPC events) and pushes an observation whenever meaningful volume moves the price, with a minimum interval floor.
+
+- **Pros:** observations concentrate where price actually changes; efficient in quiet markets.
+- **Cons:** more moving parts; needs the same trust mitigations as polling; bursty markets need debouncing.
+
+### 3. On-chain accumulator at the source (AMM-embedded)
+
+If the price comes from your own Soroban AMM, update a cumulative-price accumulator inside the swap function itself. No keeper exists; every trade updates the oracle as a side effect.
+
+- **Pros:** trustless — data collection cannot be skipped or censored separately from trading itself.
+- **Cons:** only prices assets your AMM trades; adds a small cost to every swap.
+
+> Rule of thumb: if you control the AMM, embed the accumulator (strategy 3) and let anyone read it. If prices must come from external markets, run poll-and-push (strategy 1) with multiple keys and on-chain sanity bounds, and upgrade to event-driven sampling when observation quality matters.
+
+---
+
+## The Accumulator Technique
+
+Storing every observation and averaging on read is O(n) storage and compute. The standard trick stores a single running sum instead: the **cumulative price**, updated whenever the price changes:
+
+```
+cumulative += last_price * (now - last_timestamp)
+```
+
+A TWAP between any two snapshots of the accumulator is then O(1):
+
+```
+TWAP(t1, t2) = (cumulative(t2) - cumulative(t1)) / (t2 - t1)
+```
+
+Consumers (or the contract itself, via a small ring buffer of snapshots) keep checkpoints at the window edges they care about.
+
+---
+
+## A Small Aggregator Contract
+
+A Soroban aggregator using the accumulator plus a ring buffer of periodic snapshots, so consumers can query a TWAP without storing checkpoints themselves:
+
+```rust
+#[derive(Clone)]
+#[contracttype]
+pub struct Observation {
+    pub timestamp: u64,     // ledger close time of the snapshot
+    pub cumulative: i128,   // Σ price * elapsed, in price units * seconds
+}
+
+const RING_SIZE: u32 = 64;          // snapshots kept
+const MIN_SNAPSHOT_GAP: u64 = 60;   // seconds between ring entries
+
+pub fn submit(env: Env, submitter: Address, price: i128) {
+    submitter.require_auth();
+    assert_is_allowed_submitter(&env, &submitter);
+    assert_within_sanity_bounds(&env, price);   // e.g. |Δ| <= 20% per update
+
+    let now = env.ledger().timestamp();
+    let mut state = read_state(&env);
+
+    // Advance the accumulator for the time the *old* price was in effect.
+    let elapsed = (now - state.last_timestamp) as i128;
+    state.cumulative += state.last_price * elapsed;
+    state.last_price = price;
+    state.last_timestamp = now;
+
+    // Periodically snapshot into the ring buffer.
+    if now - read_last_snapshot_time(&env) >= MIN_SNAPSHOT_GAP {
+        push_ring(&env, Observation { timestamp: now, cumulative: state.cumulative });
+    }
+
+    write_state(&env, &state);
+    env.events().publish((symbol_short!("price"),), (price, now));
+}
+
+/// TWAP over at least `window` seconds, ending now.
+pub fn twap(env: Env, window: u64) -> i128 {
+    let now = env.ledger().timestamp();
+    let state = read_state(&env);
+
+    // Bring the accumulator up to `now` (read-only view).
+    let cum_now = state.cumulative + state.last_price * ((now - state.last_timestamp) as i128);
+
+    // Oldest ring entry that is at least `window` old.
+    let past = find_snapshot_at_or_before(&env, now - window)
+        .unwrap_or_else(|| panic_with_error!(&env, Error::WindowNotCovered));
+
+    let elapsed = (now - past.timestamp) as i128;
+    (cum_now - past.cumulative) / elapsed
+}
+```
+
+Design notes:
+
+- **The accumulator advances with the _previous_ price** for the elapsed interval — the new price starts accruing weight only from its own submission time. Getting this backwards silently biases the average toward fresh prices.
+- **`WindowNotCovered` is an error, not a best-effort answer.** If the ring buffer doesn't reach back `window` seconds (young oracle, long outage), refusing to answer is safer than returning an average over a shorter, unrequested window.
+- **Sanity bounds on submissions** (`assert_within_sanity_bounds`) cap how far a single compromised key can move the average, complementing — not replacing — the time weighting.
+- **Prices are fixed-point `i128`** (e.g. 7 decimals to match Stellar amounts). All math is integer; division happens last.
+
+---
+
+## Staleness Handling
+
+A TWAP that quietly stops updating is more dangerous than no oracle: it keeps answering with confident, increasingly wrong numbers. Staleness must be handled on **both** sides.
+
+**In the oracle — expose freshness, don't hide it:**
+
+```rust
+pub struct TwapResult {
+    pub price: i128,
+    pub last_update: u64,     // when data last arrived
+    pub window_covered: u64,  // actual seconds the average spans
+}
+```
+
+**In the consumer — enforce a freshness policy:**
+
+```rust
+let r = oracle.twap(&1800);
+let age = env.ledger().timestamp() - r.last_update;
+
+if age > MAX_AGE {                      // e.g. 5 minutes for a 30-min TWAP
+    panic_with_error!(&env, Error::StalePrice);  // fail closed
+}
+```
+
+Policy options when the price is stale, from safest to most permissive:
+
+1. **Fail closed** — refuse the operation (right default for liquidations, minting, borrowing).
+2. **Degrade** — allow only conservative actions (repayments, deposits) but block risk-increasing ones.
+3. **Fallback** — consult a second independent oracle; require agreement within a tolerance band.
+
+Heartbeats belong in the pipeline too: keepers should submit even when the price is unchanged (the accumulator handles this fine), so `last_update` doubles as a liveness signal, and an off-chain monitor should alert when no submission lands within the expected interval.
+
+---
+
+## Choosing a Window
+
+| Window    | Manipulation cost | Lag        | Typical use                        |
+| --------- | ----------------- | ---------- | ---------------------------------- |
+| 1–5 min   | Low–moderate      | Small      | Display, soft limits               |
+| 15–60 min | High              | Noticeable | Liquidations, collateral valuation |
+| 4–24 h    | Very high         | Large      | Fee/parameter governance, indexes  |
+
+Two windows in tandem is a common pattern: act on the short one, but only if it agrees with the long one within a band — divergence beyond the band flags either manipulation or a genuine regime change, and both deserve a pause.
+
+---
+
+## Operational Notes
+
+- **Ledger close time granularity (~5s) is your floor** — windows are made of many closes, so this is rarely a problem, but don't design sub-minute TWAPs on Stellar.
+- **Monitor the monitors:** alert on missed heartbeats, on sanity-bound rejections (someone pushed a wild price), and on consumer-side `StalePrice` errors.
+- **Snapshot retention math:** `RING_SIZE * MIN_SNAPSHOT_GAP` bounds your maximum queryable window (64 × 60s ≈ 1 hour above). Size the ring for your longest window plus outage headroom.
+- **Publish the methodology** — sources, submitters, bounds, window — so integrators can judge what your TWAP actually measures. An oracle's trust model is documentation as much as code.


### PR DESCRIPTION
## Summary
Adds four comprehensive guides as working drafts in the `routes-d` folder, named after their issues per the issue constraints. Each guide matches the existing MDX frontmatter style (`title` + `description`) and the repo's writing conventions (TOC, ASCII diagrams, worked code examples, comparison tables).

closes #716
closes #720
closes #724
closes #734

## Changes
- **#716 — AMM implementation guide** (`routes-d/issue-716-amm-implementation-guide.md`): compares pricing formulas (constant product, constant sum, StableSwap hybrid, concentrated liquidity) with a summary table and selection guidance; covers fee handling (input-side fees in basis points, integer math, rounding direction favoring the pool, bounded protocol fee) and slippage protection (`min_out`, ledger deadline bounds); provides a reference constant-product Soroban design with a full trait interface, swap math, geometric-mean share bootstrapping with minimum-liquidity burn, and invariant/rounding test examples.
- **#720 — off-chain compute with on-chain settlement** (`routes-d/issue-720-offchain-compute-onchain-settlement.md`): outlines the trust model as a four-step ladder (trusted operator, M-of-N attestation via Stellar multisig, optimistic settlement with bonded challenges, validity proofs) with guidance on choosing; shows the settlement flow end-to-end with input-commitment and idempotency rules; provides a reference batch-payout example with a TypeScript worker (snapshot → compute → canonical hash) and a Soroban `settle_batch` contract with per-batch idempotency, plus failure handling and auditability sections.
- **#724 — background job processing** (`routes-d/issue-724-background-job-processing.md`): covers queue properties (at-least-once, visibility timeouts, DLQs, per-source-account serialization via channel accounts) and retries (transient vs permanent Stellar error classification table, exponential backoff with jitter, the unknown-outcome hazard); details a three-layer idempotency strategy (enqueue key, DB state machine, ledger-level memo dedupe); provides a complete BullMQ payment-worker example wiring all three layers together, plus observability guidance and a checklist.
- **#734 — time-weighted average pricing** (`routes-d/issue-734-time-weighted-average-pricing.md`): covers data collection strategies (cron poll-and-push, event-driven sampling, AMM-embedded accumulator) with trust trade-offs; shows a small Soroban aggregator using the cumulative-price accumulator with a ring buffer of snapshots for O(1) TWAP reads; covers staleness handling on both oracle and consumer sides (freshness metadata, fail-closed/degrade/fallback policies, heartbeats) and window selection.

## Test plan
- `pnpm build:content` passes (137 documents generated). Note the build emits a pre-existing warning about `docs/guides/custom-hook-authoring-playbook.mdx` missing a required `title` field — that file is untouched by this PR.
- Files were formatted by the repo's own lint-staged/prettier pre-commit hook.
- `pnpm check:links` requires a running dev server on `localhost:3000` and validates sidebar component links only; these drafts add no sidebar entries or internal doc links (external references only), so no link-check impact is expected. Not run locally — flagging honestly.

---
Drafts are placed in `routes-d/` (not `docs/guides/`) per the issue constraint "place any working drafts in the routes-d folder at the repo root, named after this issue", matching the pattern of previously merged guide batches (e.g. #576).

_Note: this contribution was authored with AI assistance (Claude Code)._