### PR TITLE
docs: add NFT marketplace, Soroban debugging, payroll, and data monetization guides

### DIFF
--- a/routes-d/715-nft-marketplace-soroban-tutorial.mdx
+++ b/routes-d/715-nft-marketplace-soroban-tutorial.mdx
@@ -1,0 +1,300 @@
+---
+title: NFT Marketplace on Soroban — Tutorial
+description: Write a tutorial for a small NFT marketplace on Soroban covering mint, list, buy, and royalty flows.
+date: 2026-07-24
+---
+
+# NFT Marketplace on Soroban — Tutorial
+
+This tutorial walks through building a minimal NFT marketplace on Soroban. By the end you will have a contract that lets a creator mint tokens, list them for sale in XLM, and pay a royalty to the original creator on every resale.
+
+---
+
+## Concepts
+
+| Term | Meaning in this tutorial |
+|---|---|
+| **NFT** | A unique token identified by a `token_id` (u64). Ownership is stored in contract persistent storage. |
+| **Listing** | A price (in stroops) posted by the current owner. Anyone can buy at that price. |
+| **Royalty** | A percentage of every sale forwarded to the original creator, enforced by the contract. |
+
+Soroban does not have a native ERC-721 equivalent. This tutorial implements a minimal ownership map and marketplace logic in a single contract for clarity. Production systems should separate token logic from marketplace logic.
+
+---
+
+## Contract
+
+```rust
+// contracts/nft-marketplace/src/lib.rs
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, token,
+    Address, Env, Map, String,
+};
+
+#[contracttype]
+pub struct NftMeta {
+    pub creator: Address,
+    pub owner: Address,
+    pub uri: String,
+}
+
+#[contracttype]
+pub struct Listing {
+    pub price: i128,  // in stroops
+    pub seller: Address,
+}
+
+const NEXT_ID_KEY: &str = "next_id";
+const ROYALTY_BPS_KEY: &str = "royalty_bps";
+const PAYMENT_TOKEN_KEY: &str = "payment_token";
+
+#[contract]
+pub struct NftMarketplace;
+
+#[contractimpl]
+impl NftMarketplace {
+    /// One-time setup: configure royalty rate and the payment token (XLM wrapper).
+    pub fn initialize(env: Env, admin: Address, royalty_bps: u32, payment_token: Address) {
+        admin.require_auth();
+        assert!(royalty_bps <= 1000, "royalty must be ≤ 10%");
+        env.storage().instance().set(&NEXT_ID_KEY, &0u64);
+        env.storage().instance().set(&ROYALTY_BPS_KEY, &royalty_bps);
+        env.storage().instance().set(&PAYMENT_TOKEN_KEY, &payment_token);
+    }
+
+    /// Mint a new NFT. The caller becomes both creator and initial owner.
+    pub fn mint(env: Env, creator: Address, uri: String) -> u64 {
+        creator.require_auth();
+        let id: u64 = env.storage().instance().get(&NEXT_ID_KEY).unwrap_or(0);
+        env.storage().persistent().set(
+            &id,
+            &NftMeta {
+                creator: creator.clone(),
+                owner: creator,
+                uri,
+            },
+        );
+        env.storage().instance().set(&NEXT_ID_KEY, &(id + 1));
+        id
+    }
+
+    /// List an NFT for sale at `price` stroops.
+    pub fn list(env: Env, token_id: u64, price: i128) {
+        assert!(price > 0, "price must be positive");
+        let meta: NftMeta = env.storage().persistent().get(&token_id)
+            .expect("token not found");
+        meta.owner.require_auth();
+
+        env.storage().persistent().set(
+            &(token_id, "listing"),
+            &Listing { price, seller: meta.owner },
+        );
+    }
+
+    /// Delist an NFT (remove listing without selling).
+    pub fn delist(env: Env, token_id: u64) {
+        let meta: NftMeta = env.storage().persistent().get(&token_id)
+            .expect("token not found");
+        meta.owner.require_auth();
+        env.storage().persistent().remove(&(token_id, "listing"));
+    }
+
+    /// Buy a listed NFT. Transfers price from buyer to seller (minus royalty to creator).
+    pub fn buy(env: Env, buyer: Address, token_id: u64) {
+        buyer.require_auth();
+
+        let mut meta: NftMeta = env.storage().persistent().get(&token_id)
+            .expect("token not found");
+        let listing: Listing = env.storage().persistent().get(&(token_id, "listing"))
+            .expect("not listed");
+
+        let royalty_bps: u32 = env.storage().instance().get(&ROYALTY_BPS_KEY).unwrap();
+        let payment_token: Address = env.storage().instance().get(&PAYMENT_TOKEN_KEY).unwrap();
+        let client = token::Client::new(&env, &payment_token);
+
+        let royalty_amount = listing.price * royalty_bps as i128 / 10_000;
+        let seller_amount = listing.price - royalty_amount;
+
+        // Collect full price from buyer
+        client.transfer(&buyer, &env.current_contract_address(), &listing.price);
+
+        // Forward seller's share
+        if seller_amount > 0 {
+            client.transfer(&env.current_contract_address(), &listing.seller, &seller_amount);
+        }
+
+        // Forward royalty to original creator
+        if royalty_amount > 0 {
+            client.transfer(&env.current_contract_address(), &meta.creator, &royalty_amount);
+        }
+
+        // Transfer ownership; remove listing
+        meta.owner = buyer;
+        env.storage().persistent().set(&token_id, &meta);
+        env.storage().persistent().remove(&(token_id, "listing"));
+    }
+
+    /// Transfer ownership directly (no payment; bypasses royalty).
+    /// Useful for gifting; production contracts may want to block this or still charge royalty.
+    pub fn transfer(env: Env, token_id: u64, to: Address) {
+        let mut meta: NftMeta = env.storage().persistent().get(&token_id)
+            .expect("token not found");
+        meta.owner.require_auth();
+        // Remove any active listing before transfer
+        env.storage().persistent().remove(&(token_id, "listing"));
+        meta.owner = to;
+        env.storage().persistent().set(&token_id, &meta);
+    }
+
+    pub fn get_meta(env: Env, token_id: u64) -> NftMeta {
+        env.storage().persistent().get(&token_id).expect("token not found")
+    }
+
+    pub fn get_listing(env: Env, token_id: u64) -> Option<Listing> {
+        env.storage().persistent().get(&(token_id, "listing"))
+    }
+}
+```
+
+---
+
+## Royalty Flow
+
+```
+Buyer pays 100 XLM (price)
+     │
+     ├── 97.5 XLM → Seller          (price × (1 - royalty_bps/10000))
+     └──  2.5 XLM → Original Creator (price × royalty_bps/10000, here 250 bps = 2.5%)
+```
+
+The royalty is paid to `meta.creator`, which is set at mint time and never changes even as ownership transfers. A buyer who later re-sells will pay the same creator again.
+
+---
+
+## Client Integration
+
+```ts
+// lib/nft.ts
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  nativeToScVal,
+  Address,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+const CONTRACT_ID = process.env.NEXT_PUBLIC_NFT_CONTRACT!;
+
+export async function mintNft(
+  creatorKeypair: { publicKey(): string; sign(tx: any): void },
+  uri: string,
+): Promise<bigint> {
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(creatorKeypair.publicKey());
+  const contract = new Contract(CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'mint',
+        new Address(creatorKeypair.publicKey()).toScVal(),
+        nativeToScVal(uri, { type: 'string' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  creatorKeypair.sign(prepared);
+  const result = await server.sendTransaction(prepared);
+  const tokenId = xdr.ScVal.fromXDR(
+    (result as any).returnValue,
+    'base64',
+  ).u64();
+  return BigInt(tokenId.toString());
+}
+
+export async function buyNft(
+  buyerKeypair: { publicKey(): string; sign(tx: any): void },
+  tokenId: bigint,
+): Promise<void> {
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(buyerKeypair.publicKey());
+  const contract = new Contract(CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'buy',
+        new Address(buyerKeypair.publicKey()).toScVal(),
+        nativeToScVal(tokenId, { type: 'u64' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  buyerKeypair.sign(prepared);
+  await server.sendTransaction(prepared);
+}
+```
+
+---
+
+## End-to-End Example
+
+```ts
+// scripts/demo.ts
+import { Keypair } from '@stellar/stellar-sdk';
+import { mintNft, buyNft } from '../lib/nft';
+
+async function run() {
+  const creator = Keypair.random(); // funded on testnet via friendbot
+  const buyer   = Keypair.random();
+
+  // 1. Creator mints NFT
+  const tokenId = await mintNft(creator, 'ipfs://QmExampleHash');
+  console.log('Minted token', tokenId);
+
+  // 2. Creator lists for 10 XLM (= 100_000_000 stroops)
+  // (call list() via contract client — omitted for brevity)
+
+  // 3. Buyer purchases
+  await buyNft(buyer, tokenId);
+  console.log('Bought token', tokenId);
+  // Creator receives 2.5% royalty automatically
+}
+
+run().catch(console.error);
+```
+
+---
+
+## Design Notes
+
+**Single-contract vs. separate token/marketplace contracts**: combining them simplifies the tutorial but means every NFT collection needs its own marketplace. Production systems typically have a shared marketplace contract that calls into standardised token contracts (similar to Stellar Asset Contract wrappers).
+
+**Persistent storage TTL**: Soroban persistent storage entries expire unless rent is paid (via `extend_ttl`). Your minting UI or a background keeper should call `extend_ttl` on long-lived NFTs to prevent data loss.
+
+**Approval pattern**: this contract has no separate "approval" step — listing is proof of intent to sell. If you want delegated marketplaces, add an `approvals` map similar to ERC-721.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Mint, list, buy, and transfer functions are all documented
+- [ ] Royalty flow diagram and maths are accurate
+- [ ] Persistent storage TTL caveat is noted

--- a/routes-d/718-soroban-debugging-guide.mdx
+++ b/routes-d/718-soroban-debugging-guide.mdx
@@ -1,0 +1,243 @@
+---
+title: Soroban Debugging Guide
+description: Practical debugging approaches for Soroban contracts — covering logs, traces, tooling, and a worked example diagnosing a common failure.
+date: 2026-07-24
+---
+
+# Soroban Debugging Guide
+
+Soroban contracts run inside a sandboxed WASM environment. The standard development loop — print a value, re-run, inspect — requires knowing which tool surfaces which information at which stage. This guide covers the full debugging stack from unit tests through testnet diagnosis.
+
+---
+
+## Debugging at a Glance
+
+| Tool / approach | When to use | What it shows |
+|---|---|---|
+| `env.log().error()` / `log!` macro | Contract development | Structured log entries in simulation output |
+| `soroban contract invoke --simulate-only` | Local testing without submitting | Full simulation trace: auth, storage reads, CPU/mem |
+| `stellar-cli contract invoke` | Testnet smoke test | Return value, events, error codes |
+| `stellar-cli contract read` | Inspect on-chain storage | Persistent/instance/temporary keys and values |
+| `soroban contract fetch` | Reproducibility | Download on-chain WASM for local re-analysis |
+| `soroban-sdk` test harness | Unit + integration tests | Panics, events, storage state via `Env::mock` |
+
+---
+
+## Log Macros Inside Contracts
+
+Soroban provides a `log!` macro that writes diagnostic messages into the simulation result. Logs are **discarded on mainnet** — they only surface during simulation or local tests, so there is no privacy or gas concern with leaving them in.
+
+```rust
+// contracts/my-contract/src/lib.rs
+use soroban_sdk::{log, Env};
+
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    log!(&env, "transfer: from={} to={} amount={}", from, to, amount);
+    // ... rest of logic
+}
+```
+
+`log!` accepts format strings with `{}` placeholders for any type that implements `soroban_sdk::IntoVal`. The output appears in the CLI's simulation trace under `"diagnostic_events"`.
+
+---
+
+## Simulation Trace
+
+Running `stellar contract invoke` without `--send` (or with `--simulate-only`) returns a JSON simulation result that includes:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ACCOUNT_SECRET> \
+  --network testnet \
+  --simulate-only \
+  -- transfer \
+  --from <FROM_ADDRESS> \
+  --to <TO_ADDRESS> \
+  --amount 1000
+```
+
+The result includes:
+
+```json
+{
+  "result": "...",
+  "cost": {
+    "cpu_insns": "123456",
+    "mem_bytes": "98765"
+  },
+  "diagnostic_events": [
+    {
+      "event": {
+        "type": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [["Symbol", "log"]],
+            "data": ["String", "transfer: from=G... to=G... amount=1000"]
+          }
+        }
+      }
+    }
+  ],
+  "auth": [...]
+}
+```
+
+### Reading the Auth Array
+
+The `"auth"` field shows which `require_auth()` calls the simulation expects the submitted transaction to satisfy. If your transaction is missing a signer, compare the required addresses here against what you passed.
+
+---
+
+## Unit Testing with the Mock Environment
+
+The fastest debugging loop is a unit test using `soroban_sdk::testutils`:
+
+```rust
+// contracts/my-contract/src/test.rs
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+    use crate::{MyContract, MyContractClient};
+
+    #[test]
+    fn test_transfer_insufficient_balance() {
+        let env = Env::default();
+        env.mock_all_auths(); // bypass auth checks in unit tests
+
+        let contract_id = env.register_contract(None, MyContract);
+        let client = MyContractClient::new(&env, &contract_id);
+
+        let from = Address::generate(&env);
+        let to   = Address::generate(&env);
+
+        // Expect a panic because `from` has no balance
+        let result = std::panic::catch_unwind(|| {
+            client.transfer(&from, &to, &1000);
+        });
+        assert!(result.is_err(), "should have panicked");
+    }
+}
+```
+
+Run with:
+
+```bash
+cargo test -p my-contract -- --nocapture 2>&1
+```
+
+The `--nocapture` flag lets `log!` output appear in the terminal during tests.
+
+---
+
+## Inspecting On-Chain Storage
+
+After a transaction is submitted, read the contract's storage directly:
+
+```bash
+# List all storage keys for a contract
+stellar contract read \
+  --id <CONTRACT_ID> \
+  --network testnet
+
+# Read a specific key
+stellar contract read \
+  --id <CONTRACT_ID> \
+  --key '["Symbol","balance"]' \
+  --network testnet
+```
+
+The output is XDR-decoded JSON. If a value you expect is missing, the most common causes are:
+- Wrong `storage_type` used in the contract (`instance` vs `persistent` vs `temporary`).
+- The entry expired (persistent entries need TTL bumps; temporary entries expire after a fixed ledger count).
+- The key type doesn't match (e.g. you stored under a `String` but are querying a `Symbol`).
+
+---
+
+## Worked Example — Diagnosing `HostError: WasmVm(VmCallerError(...))`
+
+A `WasmVm` error during simulation usually means a contract panic (e.g. an `assert!` or an `unwrap()` on `None`). Here is how to trace it end-to-end.
+
+### Step 1 — Reproduce in simulation
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $SECRET \
+  --network testnet \
+  --simulate-only \
+  -- buy --buyer $BUYER --token_id 99
+```
+
+Output (truncated):
+```
+error: transaction simulation failed: HostError: WasmVm ... "token not found"
+```
+
+### Step 2 — Inspect storage to verify the token exists
+
+```bash
+stellar contract read --id $CONTRACT_ID --network testnet | grep "99"
+```
+
+No output → token 99 was never minted, or the storage entry expired.
+
+### Step 3 — Add a diagnostic log to narrow the failure site
+
+```rust
+pub fn buy(env: Env, buyer: Address, token_id: u64) {
+    let meta: Option<NftMeta> = env.storage().persistent().get(&token_id);
+    log!(&env, "buy: token_id={} meta_found={}", token_id, meta.is_some());
+    let meta = meta.expect("token not found");
+    // ...
+}
+```
+
+Re-run with `--simulate-only` and inspect `diagnostic_events` to confirm whether `meta_found=false`.
+
+### Step 4 — Check TTL if the entry existed previously
+
+```bash
+stellar contract read \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --key $(stellar contract id asset ...)
+```
+
+If the key is absent but you know it was set, check when the contract was last deployed and whether the ledger age exceeds the default persistent TTL (roughly 30 days on testnet).
+
+Fix: add `env.storage().persistent().extend_ttl(&token_id, 5000, 5000)` after every write.
+
+---
+
+## Common Error Codes
+
+| Error | Likely cause |
+|---|---|
+| `WasmVm(VmCallerError)` | `unwrap()` on `None`, `assert!` fired, integer overflow |
+| `Context(InvalidAction(OperationNotPermitted))` | `require_auth` not satisfied by the transaction's signers |
+| `Budget(CpuLimitExceeded)` | Contract loop too large; reduce iteration count or break into multiple transactions |
+| `Storage(ExpirationLedgerLessThanMinimum)` | TTL extension value too small for the platform's minimum |
+| `Value(InvalidInput)` | Wrong type passed to an `IntoVal` conversion; check arg types against the function signature |
+
+---
+
+## Useful CLI Aliases
+
+```bash
+# ~/.zshrc or ~/.bashrc
+alias sc-sim='stellar contract invoke --simulate-only --network testnet'
+alias sc-read='stellar contract read --network testnet'
+alias sc-test='cargo test -p my-contract -- --nocapture'
+```
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] At-a-glance table covers all major debugging tools
+- [ ] `log!` macro usage is shown with sample output
+- [ ] Worked example covers inspect-storage → add-log → check-TTL workflow
+- [ ] Common error codes table is accurate

--- a/routes-d/719-payroll-flow-tutorial.mdx
+++ b/routes-d/719-payroll-flow-tutorial.mdx
@@ -1,0 +1,293 @@
+---
+title: Payroll Flow Tutorial on Stellar
+description: Walk through building a small payroll flow on Stellar — covering schedules, batch payouts, and failure recovery.
+date: 2026-07-24
+---
+
+# Payroll Flow Tutorial on Stellar
+
+This tutorial builds a minimal payroll system that sends XLM (or a Stellar asset) to a list of employees on a schedule. By the end you will have a background worker that reads a payroll schedule, batches the payments into a single Stellar transaction, and recovers cleanly from failures.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────┐    cron / timer    ┌─────────────────────┐
+│  Payroll DB     │ ──────────────────► │  Payroll Worker     │
+│  (employees,    │                    │  - reads schedule   │
+│   schedules,    │                    │  - builds batch tx  │
+│   run history)  │                    │  - submits to Horizon│
+└─────────────────┘                    └──────────┬──────────┘
+                                                  │
+                                         success / fail
+                                                  │
+                                       ┌──────────▼──────────┐
+                                       │  Run Log            │
+                                       │  (idempotent state) │
+                                       └─────────────────────┘
+```
+
+A **payroll run** is a snapshot of employees and their amounts at a point in time. Separating the run record from the submission ensures idempotency: if the worker crashes mid-submission, the next run detects the pending record and picks up from where it left off.
+
+---
+
+## Data Model
+
+```ts
+// db/schema.ts (using Prisma as an example)
+// Employee roster
+model Employee {
+  id         String   @id @default(cuid())
+  name       String
+  address    String   // Stellar G-address
+  amountXLM  Decimal  // gross pay per period
+  active     Boolean  @default(true)
+}
+
+// Payroll schedule
+model Schedule {
+  id          String   @id @default(cuid())
+  cronExpr    String   // e.g. "0 9 1,15 * *" (1st and 15th at 09:00 UTC)
+  assetCode   String   @default("XLM")
+  assetIssuer String?  // null for native XLM
+  active      Boolean  @default(true)
+}
+
+// Immutable record of each payroll run
+model PayrollRun {
+  id          String       @id @default(cuid())
+  scheduleId  String
+  periodStart DateTime
+  periodEnd   DateTime
+  status      RunStatus    @default(PENDING)
+  txHash      String?      // filled on success
+  errorMsg    String?      // filled on failure
+  createdAt   DateTime     @default(now())
+}
+
+enum RunStatus { PENDING SUBMITTED CONFIRMED FAILED }
+```
+
+---
+
+## Building the Batch Transaction
+
+Stellar supports up to 100 operations per transaction. A payroll run batches one `payment` operation per employee:
+
+```ts
+// workers/payroll.worker.ts
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  Asset,
+  Operation,
+  Memo,
+} from '@stellar/stellar-sdk';
+import { db } from '../db';
+import { RunStatus } from '@prisma/client';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+const signerKeypair = Keypair.fromSecret(process.env.PAYROLL_SIGNER_SECRET!);
+
+const BATCH_SIZE = 100; // Stellar's per-transaction operation limit
+
+export async function runPayroll(runId: string): Promise<void> {
+  const run = await db.payrollRun.findUniqueOrThrow({ where: { id: runId } });
+
+  // Idempotency: already submitted — check confirmation status instead
+  if (run.status === RunStatus.SUBMITTED && run.txHash) {
+    await checkAndConfirm(runId, run.txHash);
+    return;
+  }
+
+  if (run.status !== RunStatus.PENDING) return; // nothing to do
+
+  const employees = await db.employee.findMany({ where: { active: true } });
+  const schedule  = await db.schedule.findUniqueOrThrow({
+    where: { id: run.scheduleId },
+  });
+
+  const asset =
+    schedule.assetCode === 'XLM'
+      ? Asset.native()
+      : new Asset(schedule.assetCode, schedule.assetIssuer!);
+
+  // Send in batches of 100 operations
+  const chunks: typeof employees[] = [];
+  for (let i = 0; i < employees.length; i += BATCH_SIZE) {
+    chunks.push(employees.slice(i, i + BATCH_SIZE));
+  }
+
+  for (const [idx, chunk] of chunks.entries()) {
+    const account  = await server.loadAccount(signerKeypair.publicKey());
+    const feeStats = await server.feeStats();
+    const fee      = String(Number(feeStats.fee_charged.p90) * 2);
+
+    const builder = new TransactionBuilder(account, {
+      fee,
+      networkPassphrase: Networks.MAINNET,
+    }).addMemo(Memo.text(`payroll:${runId}:batch${idx}`));
+
+    for (const emp of chunk) {
+      builder.addOperation(
+        Operation.payment({
+          destination: emp.address,
+          asset,
+          amount: emp.amountXLM.toString(),
+        }),
+      );
+    }
+
+    const tx = builder.setTimeout(30).build();
+    tx.sign(signerKeypair);
+
+    const result = await server.submitTransaction(tx);
+
+    await db.payrollRun.update({
+      where: { id: runId },
+      data: { status: RunStatus.SUBMITTED, txHash: result.hash },
+    });
+  }
+}
+```
+
+---
+
+## Scheduling Runs
+
+Use a cron library (e.g. `node-cron`) to trigger payroll runs on schedule:
+
+```ts
+// scripts/scheduler.ts
+import cron from 'node-cron';
+import { db } from '../db';
+import { runPayroll } from '../workers/payroll.worker';
+import { RunStatus } from '@prisma/client';
+
+async function triggerScheduledRuns() {
+  const now = new Date();
+  const schedules = await db.schedule.findMany({ where: { active: true } });
+
+  for (const schedule of schedules) {
+    // Check whether a run for this period already exists
+    const existing = await db.payrollRun.findFirst({
+      where: {
+        scheduleId: schedule.id,
+        periodStart: { lte: now },
+        periodEnd:   { gte: now },
+      },
+    });
+    if (existing) continue; // already created or ran
+
+    const run = await db.payrollRun.create({
+      data: {
+        scheduleId: schedule.id,
+        periodStart: startOfPeriod(now),
+        periodEnd:   endOfPeriod(now),
+        status: RunStatus.PENDING,
+      },
+    });
+
+    await runPayroll(run.id).catch(async (err: Error) => {
+      await db.payrollRun.update({
+        where: { id: run.id },
+        data: { status: RunStatus.FAILED, errorMsg: err.message },
+      });
+      console.error('Payroll run failed:', err.message);
+    });
+  }
+}
+
+// Run every minute; node-cron evaluates whether a scheduled window just opened
+cron.schedule('* * * * *', triggerScheduledRuns);
+
+function startOfPeriod(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+function endOfPeriod(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0, 23, 59, 59));
+}
+```
+
+---
+
+## Failure Recovery
+
+### Scenario 1 — Transaction submitted but not confirmed
+
+Horizon's `submitTransaction` can time out while the transaction is still in flight. The worker stores the `txHash` at submission time. On the next scheduled run, it detects `status = SUBMITTED` and polls Horizon for confirmation:
+
+```ts
+async function checkAndConfirm(runId: string, txHash: string): Promise<void> {
+  try {
+    const tx = await server.transactions().transaction(txHash).call();
+    if (tx.successful) {
+      await db.payrollRun.update({
+        where: { id: runId },
+        data: { status: RunStatus.CONFIRMED },
+      });
+    }
+  } catch (err: any) {
+    if (err?.response?.status === 404) {
+      // Transaction not found — safe to retry with a new transaction
+      await db.payrollRun.update({
+        where: { id: runId },
+        data: { status: RunStatus.PENDING, txHash: null },
+      });
+    }
+  }
+}
+```
+
+### Scenario 2 — Insufficient fee (surge pricing)
+
+If `submitTransaction` throws `tx_insufficient_fee`, retry immediately with a fee drawn from the current `p99` percentile:
+
+```ts
+const feeStats = await server.feeStats();
+const surgeFee = String(Number(feeStats.fee_charged.p99));
+// rebuild and resubmit with surgeFee
+```
+
+### Scenario 3 — Employee address invalid
+
+An invalid destination causes the whole batch to fail. Validate all addresses before building the transaction:
+
+```ts
+import { StrKey } from '@stellar/stellar-sdk';
+
+const invalid = employees.filter(e => !StrKey.isValidEd25519PublicKey(e.address));
+if (invalid.length > 0) {
+  throw new Error(`Invalid employee addresses: ${invalid.map(e => e.name).join(', ')}`);
+}
+```
+
+### Scenario 4 — Partial batch failure (multi-batch runs)
+
+If the run has multiple batches and batch 2 fails after batch 1 succeeds, record which batches completed. On retry, skip already-confirmed batches and only resubmit the failed ones.
+
+---
+
+## Audit Trail
+
+Every `PayrollRun` record is immutable after creation — only `status`, `txHash`, and `errorMsg` are ever updated. Combined with the `Memo` on-chain, you have a full audit trail:
+
+- **Who paid**: signer's Stellar address (visible on Horizon).
+- **When**: `PayrollRun.periodStart` + ledger close time.
+- **How much**: `Employee.amountXLM` at run time (consider snapshotting into a `PayrollRunDetail` join table for immutability).
+- **Reference**: `txHash` links the DB record to the on-chain transaction.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Batch-size limit (100 ops) is clearly noted
+- [ ] All four failure scenarios are covered
+- [ ] Idempotency is guaranteed by checking `status` before re-submitting
+- [ ] Address validation step is present

--- a/routes-d/728-data-monetization-patterns-guide.mdx
+++ b/routes-d/728-data-monetization-patterns-guide.mdx
@@ -1,0 +1,325 @@
+---
+title: Data Monetization Patterns for Stellar dApps
+description: Document data monetization patterns for dApps on Stellar — covering pricing models, payment and access flows, and a small worked example.
+date: 2026-07-24
+---
+
+# Data Monetization Patterns for Stellar dApps
+
+Stellar's low fees and fast settlement make it well-suited for fine-grained data access payments — charging per API call, per dataset download, or via a subscription enforced on-chain. This guide covers the main pricing models, the payment-and-access flow, and a reference implementation.
+
+---
+
+## Pricing Model Comparison
+
+| Model | How payment works | Best for |
+|---|---|---|
+| **Pay-per-call** | Buyer sends micro-payment before each request; server validates on-chain | High-frequency, variable usage |
+| **Subscription** | Buyer pre-pays for a time window; contract enforces access until expiry | Predictable recurring usage |
+| **Dataset purchase** | One-time payment unlocks a download token or decryption key | Large, infrequent transfers |
+| **Metered / post-pay** | Usage is tallied off-chain; buyer settles periodically | Enterprise, trusted-partner contexts |
+
+**Recommendation for most dApps**: start with the **subscription** model. It has the lowest per-request overhead (no on-chain check per call once the subscription is verified), and Soroban's persistent storage makes expiry checks cheap.
+
+---
+
+## Payment and Access Flow
+
+### Subscription Flow
+
+```
+1. Buyer calls subscribe(buyer, duration_days) on the Subscription contract
+   ├── Transfers payment token to the contract treasury
+   └── Stores { expires_at: now + duration } under buyer's address
+
+2. Buyer's client includes buyer_address in every API request header
+
+3. API server calls has_access(buyer_address) on the contract (read-only sim)
+   ├── expires_at > current_ledger_timestamp → 200 OK + data
+   └── expired or missing → 402 Payment Required
+
+4. Buyer renews by calling subscribe() again before expiry
+   └── Contract extends expires_at from max(now, old_expires_at) + duration
+```
+
+### Pay-Per-Call Flow
+
+```
+1. Buyer constructs a Stellar payment of `price_per_call` stroops to the data provider
+2. Buyer includes the transaction hash in the API request
+3. Server verifies the tx on Horizon (confirmed, correct amount, correct destination)
+4. Server returns the data and marks the tx hash as spent (prevent replay)
+```
+
+The pay-per-call model requires a "spent hash" store on the server side. Use Redis with a TTL matching Stellar's ledger close time (approximately 5 seconds) plus a buffer.
+
+---
+
+## Soroban Subscription Contract
+
+```rust
+// contracts/subscription/src/lib.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+#[contracttype]
+pub struct Subscription {
+    pub expires_at: u64, // ledger timestamp
+}
+
+const PRICE_PER_DAY_KEY: &str = "price_day"; // in payment token units
+const PAYMENT_TOKEN_KEY: &str = "pay_token";
+const TREASURY_KEY: &str = "treasury";
+const SECONDS_PER_DAY: u64 = 86_400;
+
+#[contract]
+pub struct SubscriptionGate;
+
+#[contractimpl]
+impl SubscriptionGate {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        payment_token: Address,
+        treasury: Address,
+        price_per_day: i128,
+    ) {
+        admin.require_auth();
+        env.storage().instance().set(&PRICE_PER_DAY_KEY, &price_per_day);
+        env.storage().instance().set(&PAYMENT_TOKEN_KEY, &payment_token);
+        env.storage().instance().set(&TREASURY_KEY, &treasury);
+    }
+
+    /// Purchase or extend a subscription for `duration_days`.
+    pub fn subscribe(env: Env, buyer: Address, duration_days: u64) {
+        buyer.require_auth();
+        assert!(duration_days > 0 && duration_days <= 365, "duration 1–365 days");
+
+        let price_per_day: i128 = env.storage().instance().get(&PRICE_PER_DAY_KEY).unwrap();
+        let payment_token: Address = env.storage().instance().get(&PAYMENT_TOKEN_KEY).unwrap();
+        let treasury: Address = env.storage().instance().get(&TREASURY_KEY).unwrap();
+
+        let total = price_per_day * duration_days as i128;
+        token::Client::new(&env, &payment_token)
+            .transfer(&buyer, &treasury, &total);
+
+        let now = env.ledger().timestamp();
+        let current_expiry: u64 = env
+            .storage()
+            .persistent()
+            .get(&buyer)
+            .map(|s: Subscription| s.expires_at)
+            .unwrap_or(now);
+
+        // Extend from max(now, current_expiry) so early renewals stack
+        let new_expiry = current_expiry.max(now) + duration_days * SECONDS_PER_DAY;
+        env.storage().persistent().set(&buyer, &Subscription { expires_at: new_expiry });
+    }
+
+    /// Returns true if `buyer` has an active subscription.
+    pub fn has_access(env: Env, buyer: Address) -> bool {
+        match env.storage().persistent().get::<Address, Subscription>(&buyer) {
+            Some(sub) => env.ledger().timestamp() < sub.expires_at,
+            None => false,
+        }
+    }
+
+    pub fn get_expiry(env: Env, buyer: Address) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get::<Address, Subscription>(&buyer)
+            .map(|s| s.expires_at)
+    }
+}
+```
+
+---
+
+## API Middleware
+
+The API server performs a **read-only simulation** of `has_access` — no transaction, no fee, instant:
+
+```ts
+// middleware/subscription.ts
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  Account,
+  rpc,
+  BASE_FEE,
+  nativeToScVal,
+  Address,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+import type { NextRequest, NextFetchEvent } from 'next/server';
+
+const RPC_URL      = process.env.RPC_URL!;
+const CONTRACT_ID  = process.env.SUBSCRIPTION_CONTRACT!;
+const DUMMY_SOURCE = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'; // public key only, not signed
+
+export async function checkSubscription(buyerAddress: string): Promise<boolean> {
+  const server   = new rpc.Server(RPC_URL);
+  const contract = new Contract(CONTRACT_ID);
+  const account  = new Account(DUMMY_SOURCE, '0');
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      contract.call(
+        'has_access',
+        new Address(buyerAddress).toScVal(),
+      ),
+    )
+    .setTimeout(5)
+    .build();
+
+  const result = await server.simulateTransaction(tx) as rpc.SimulateTransactionSuccessResponse;
+  return scValToNative(result.result!.retval) as boolean;
+}
+```
+
+Wrap your data endpoints:
+
+```ts
+// app/api/data/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { checkSubscription } from '@/middleware/subscription';
+
+export async function GET(req: NextRequest) {
+  const buyer = req.headers.get('x-buyer-address');
+  if (!buyer) return NextResponse.json({ error: 'missing buyer address' }, { status: 401 });
+
+  const active = await checkSubscription(buyer);
+  if (!active) {
+    return NextResponse.json(
+      { error: 'subscription required', subscribeUrl: '/subscribe' },
+      { status: 402 },
+    );
+  }
+
+  const data = await fetchYourData();
+  return NextResponse.json(data);
+}
+
+async function fetchYourData() {
+  return { records: [] }; // replace with real data source
+}
+```
+
+---
+
+## Pay-Per-Call Example
+
+For pay-per-call, the buyer sends a Stellar payment and passes the transaction hash:
+
+```ts
+// lib/pay-per-call.ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server      = new Horizon.Server(process.env.HORIZON_URL!);
+const PROVIDER    = process.env.PROVIDER_ADDRESS!;
+const PRICE_STR   = process.env.PRICE_PER_CALL_STROOPS!; // e.g. "1000"
+const SPENT_CACHE = new Map<string, number>(); // in production, use Redis
+
+export async function verifyPayment(txHash: string): Promise<boolean> {
+  // Prevent replay
+  if (SPENT_CACHE.has(txHash)) return false;
+
+  const tx = await server.transactions().transaction(txHash).call();
+  if (!tx.successful) return false;
+
+  // Parse operations to confirm a payment of the right amount to the right address
+  const ops = await tx.operations();
+  const payment = ops.records.find(
+    (op: any) =>
+      op.type === 'payment' &&
+      op.to === PROVIDER &&
+      op.asset_type === 'native' &&
+      parseInt(op.amount, 10) * 10_000_000 >= parseInt(PRICE_STR, 10),
+  );
+
+  if (!payment) return false;
+
+  SPENT_CACHE.set(txHash, Date.now());
+  return true;
+}
+```
+
+---
+
+## Handling Subscription Expiry on the Client
+
+Show the user their remaining access and prompt renewal before expiry:
+
+```ts
+// hooks/useSubscription.ts
+import { useEffect, useState } from 'react';
+import { Contract, rpc, scValToNative, nativeToScVal, Address, Account, TransactionBuilder, BASE_FEE, Networks } from '@stellar/stellar-sdk';
+
+export function useSubscription(buyerAddress: string | null) {
+  const [expiresAt, setExpiresAt] = useState<Date | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!buyerAddress) return;
+    setLoading(true);
+
+    async function load() {
+      const server   = new rpc.Server(process.env.NEXT_PUBLIC_RPC_URL!);
+      const contract = new Contract(process.env.NEXT_PUBLIC_SUBSCRIPTION_CONTRACT!);
+      const account  = new Account('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', '0');
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: Networks.MAINNET,
+      })
+        .addOperation(contract.call('get_expiry', new Address(buyerAddress).toScVal()))
+        .setTimeout(5)
+        .build();
+
+      const result = await server.simulateTransaction(tx) as rpc.SimulateTransactionSuccessResponse;
+      const raw    = scValToNative(result.result!.retval) as bigint | null;
+      setExpiresAt(raw ? new Date(Number(raw) * 1000) : null);
+    }
+
+    load().finally(() => setLoading(false));
+  }, [buyerAddress]);
+
+  const daysRemaining = expiresAt
+    ? Math.ceil((expiresAt.getTime() - Date.now()) / 86_400_000)
+    : 0;
+
+  return { expiresAt, daysRemaining, loading };
+}
+```
+
+---
+
+## Design Decisions
+
+### Why simulate instead of calling `has_access` in a submitted transaction?
+
+Simulating is free and instant — no transaction fee, no ledger wait. The contract is deterministic so simulation and execution will agree. Only use a submitted transaction when you need the check to be part of an atomic on-chain operation (e.g. "transfer tokens AND verify access in one tx").
+
+### Preventing clock skew
+
+Soroban timestamps come from the ledger close time, which lags wall-clock time by a few seconds. Add a grace buffer (e.g. 60 seconds) on the server side when comparing `has_access` results to avoid false-negative rejections near expiry.
+
+### Revenue sharing
+
+If multiple data providers share the subscription revenue, replace the single `treasury` address with a Soroban revenue-share contract that distributes payments proportionally on receipt.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Pricing model comparison table covers at least 3 models
+- [ ] Payment and access flow is shown for both subscription and pay-per-call
+- [ ] API middleware uses read-only simulation (no fee) for `has_access`
+- [ ] Replay attack prevention is addressed for pay-per-call
+- [ ] Clock-skew caveat is noted


### PR DESCRIPTION
## Summary

Adds four comprehensive documentation guides to `routes-d/` covering advanced Stellar/Soroban patterns: an NFT marketplace tutorial, a Soroban debugging guide, a payroll flow tutorial, and a data monetization patterns guide. Each guide follows the existing MDX frontmatter conventions and writing style, with worked code examples throughout.

closes #715
closes #718
closes #719
closes #728

## Changes

- **#715 — NFT marketplace on Soroban** (`routes-d/715-nft-marketplace-soroban-tutorial.mdx`): Implements a single Soroban contract covering `mint`, `list`, `delist`, `buy`, and `transfer`. The `buy` function splits the payment between the seller and the original creator (royalty enforced as basis-points on every resale). Includes a TypeScript `mintNft` / `buyNft` client, an end-to-end demo script, and design notes on persistent storage TTL and the single-vs-separate-contract tradeoff.

- **#718 — Soroban debugging guide** (`routes-d/718-soroban-debugging-guide.mdx`): Covers the full debugging stack — the `log!` macro and how it surfaces in simulation `diagnostic_events`, `stellar contract invoke --simulate-only` output anatomy, the mock-env unit test harness, `stellar contract read` for on-chain storage inspection, and a worked example tracing a `WasmVm(VmCallerError)` to a missing persistent entry and an expired TTL. Includes a common error codes table and CLI aliases.

- **#719 — Payroll flow tutorial** (`routes-d/719-payroll-flow-tutorial.mdx`): Walks through a Node.js payroll worker using BullMQ/cron + the Stellar SDK. Covers the data model (Schedule, Employee, PayrollRun with status enum), batching up to 100 payment operations per transaction, idempotency via `status` checks, and four failure-recovery scenarios: unconfirmed submission, surge-fee rejection, invalid addresses, and partial-batch failure.

- **#728 — Data monetization patterns** (`routes-d/728-data-monetization-patterns-guide.mdx`): Compares pay-per-call, subscription, dataset purchase, and metered/post-pay models. Implements a Soroban `SubscriptionGate` contract with `subscribe`, `has_access`, and `get_expiry`, and shows API middleware that uses a free read-only simulation for every request. Also covers the pay-per-call pattern with replay prevention via a spent-hash cache, a React hook for displaying remaining access, and clock-skew handling.

## Test plan

- All four files are plain MDX with no imports or custom components; they should pass `pnpm build:content` without errors.
- No new internal links to other pages were added; `pnpm check:links` should remain clean.
- Code samples are for reference/illustration and have not been compiled or run locally — CI build verification is the authoritative check.