### PR TITLE
docs: add serialization, escrow, upgrade-safety and treasury dashboard drafts (routes-d)

### DIFF
--- a/routes-d/748-custom-serialization-patterns.mdx
+++ b/routes-d/748-custom-serialization-patterns.mdx
@@ -1,0 +1,131 @@
+---
+title: Custom Serialization Patterns for Soroban Contract Data
+description: Compare encoding strategies for Soroban contract storage — native ScVal types, packed Bytes, and off-chain formats — with compatibility guidance and a working example.
+---
+
+# Custom Serialization Patterns for Soroban Contract Data
+
+Soroban stores every value as an `ScVal`, the host's tagged union type. Most contracts never think about this — `#[contracttype]` derives the conversion for you. But once your data grows (order books, batched records, versioned structs) the *shape* you choose for serialization starts to affect ledger footprint, read/write cost, and your ability to upgrade without breaking stored state. This guide compares the common encodings and shows a small packed-bytes example.
+
+---
+
+## The Encoding Options
+
+| Encoding | How it works | Best for |
+|----------|--------------|----------|
+| Native `#[contracttype]` structs | Fields become an `ScMap`/`ScVec` of `ScVal`s | Almost everything — default choice |
+| Enum-keyed storage (`DataKey`) | Each logical field stored under its own key | Hot fields read/written independently |
+| Packed `Bytes` | You define a byte layout and pack manually | Large homogeneous records, tight footprint |
+| Off-chain JSON/XDR + on-chain hash | Store only a hash; full data lives off-chain | Documents, metadata, anything large |
+
+---
+
+## Native Types: the Default
+
+Deriving `contracttype` is the baseline. The SDK converts your struct to host values and back; field names travel with the data (as map keys), which costs a little space but keeps everything self-describing:
+
+```rust
+#![no_std]
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Position {
+    pub owner: Address,
+    pub amount: i128,
+    pub opened_at: u64,
+}
+```
+
+**Compatibility rule:** adding, removing, or reordering fields changes the stored shape. Reading an old entry with a new struct definition traps. If you expect the type to evolve, wrap it in a versioned enum from day one:
+
+```rust
+#[contracttype]
+#[derive(Clone)]
+pub enum StoredPosition {
+    V1(Position),
+}
+```
+
+New versions become `V2(PositionV2)` variants, and reads match on the variant — old entries keep decoding forever.
+
+---
+
+## Enum-Keyed Storage: Independent Fields
+
+When two fields have very different write frequencies, storing them under separate keys avoids rewriting the whole struct on every change:
+
+```rust
+#[contracttype]
+pub enum DataKey {
+    Owner,              // written once
+    TotalDeposits,      // written every deposit
+    Balance(Address),   // written per user
+}
+```
+
+This is the pattern used across the Soroban ecosystem for balances and counters. The tradeoff is more storage entries (each with its own rent/TTL to manage) in exchange for smaller, cheaper individual writes.
+
+---
+
+## Packed Bytes: Manual Layout
+
+For large homogeneous records — say, a fixed-size trade record kept in a ring buffer — packing into `Bytes` cuts out per-field map keys entirely. You own the layout, so document it and keep a version byte up front:
+
+```rust
+use soroban_sdk::{Bytes, Env};
+
+/// Layout v1 (25 bytes): [version: u8 | price: i128 BE | ts: u64 BE]
+pub fn pack_trade(env: &Env, price: i128, ts: u64) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.push_back(1u8); // layout version
+    b.append(&Bytes::from_slice(env, &price.to_be_bytes()));
+    b.append(&Bytes::from_slice(env, &ts.to_be_bytes()));
+    b
+}
+
+pub fn unpack_trade(b: &Bytes) -> Option<(i128, u64)> {
+    if b.len() != 25 || b.get(0)? != 1 {
+        return None; // unknown layout version
+    }
+    let mut price = [0u8; 16];
+    let mut ts = [0u8; 8];
+    b.slice(1..17).copy_into_slice(&mut price);
+    b.slice(17..25).copy_into_slice(&mut ts);
+    Some((i128::from_be_bytes(price), u64::from_be_bytes(ts)))
+}
+```
+
+Use big-endian consistently so byte comparisons match numeric ordering, and reject unknown version bytes instead of guessing — that single check is what lets you migrate the layout later.
+
+---
+
+## Off-Chain Data, On-Chain Hash
+
+Anything a contract does not need to *compute over* should not live in contract storage. Store a `BytesN<32>` hash (e.g. SHA-256 of a canonical JSON document) and keep the document in your backend or IPFS:
+
+```rust
+use soroban_sdk::{BytesN, Env};
+
+pub fn commit_metadata(env: &Env, doc_hash: BytesN<32>) {
+    env.storage().persistent().set(&symbol_short!("meta"), &doc_hash);
+}
+```
+
+Verification happens client-side: fetch the document, hash it, compare with the on-chain commitment. Compatibility here is about **canonicalization** — the JSON must serialize identically every time (sorted keys, no insignificant whitespace) or hashes will not reproduce.
+
+---
+
+## Compatibility Checklist
+
+- Version every custom layout (enum variant or leading version byte).
+- Never reorder or retype fields of a stored `#[contracttype]` struct in place.
+- Keep decode functions total: return `Option`/`Error` on unknown versions, never trap.
+- Prefer native types until measurement shows packing pays for its complexity.
+- For off-chain payloads, pin the canonical serialization rules alongside the schema.
+
+---
+
+## Summary
+
+Start with `#[contracttype]` and enum-keyed storage — they cover nearly every contract. Reach for packed `Bytes` only when profiling shows storage size or write cost matters, and push large documents off-chain behind a hash. Whatever you pick, version the layout on day one; serialization choices are easy to make and expensive to unmake once real data is on the ledger.

--- a/routes-d/751-milestone-escrow-tutorial.mdx
+++ b/routes-d/751-milestone-escrow-tutorial.mdx
@@ -1,0 +1,245 @@
+---
+title: Milestone-Based Escrow Tutorial
+description: Build a Soroban escrow contract that releases funds milestone by milestone, with client approval, an arbiter dispute path, and refund handling.
+---
+
+# Milestone-Based Escrow Tutorial
+
+This tutorial builds a Soroban escrow contract for freelance-style engagements: a client deposits the full budget up front, the budget is split across milestones, and each milestone's share is released to the worker only when the client approves it. A neutral arbiter resolves disputes so funds can never be held hostage by either side.
+
+---
+
+## Contract Design
+
+| Role | Capability |
+|------|------------|
+| Client | Deposits funds, approves milestones, opens disputes |
+| Worker | Receives released milestone payments |
+| Arbiter | Settles disputes — release to worker or refund to client |
+
+Each milestone moves through a small state machine:
+
+`Pending` → `Approved` (client) → paid out, or `Pending` → `Disputed` (either party) → `Approved` / `Refunded` (arbiter).
+
+---
+
+## Data Model
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum MilestoneStatus {
+    Pending,
+    Approved,
+    Disputed,
+    Refunded,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Milestone {
+    pub amount: i128,
+    pub status: MilestoneStatus,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Client,
+    Worker,
+    Arbiter,
+    Token,
+    Milestones,
+    Funded,
+}
+```
+
+---
+
+## Initialization and Deposit
+
+The client defines the milestone amounts at initialization, then funds the contract with their exact sum in a single deposit:
+
+```rust
+#[contract]
+pub struct Escrow;
+
+#[contractimpl]
+impl Escrow {
+    pub fn initialize(
+        env: Env,
+        client: Address,
+        worker: Address,
+        arbiter: Address,
+        token: Address,
+        amounts: Vec<i128>,
+    ) {
+        assert!(
+            !env.storage().instance().has(&DataKey::Client),
+            "already initialized"
+        );
+        assert!(!amounts.is_empty(), "need at least one milestone");
+
+        let mut milestones = Vec::new(&env);
+        for amount in amounts.iter() {
+            assert!(amount > 0, "milestone amounts must be positive");
+            milestones.push_back(Milestone {
+                amount,
+                status: MilestoneStatus::Pending,
+            });
+        }
+
+        let s = env.storage().instance();
+        s.set(&DataKey::Client, &client);
+        s.set(&DataKey::Worker, &worker);
+        s.set(&DataKey::Arbiter, &arbiter);
+        s.set(&DataKey::Token, &token);
+        s.set(&DataKey::Milestones, &milestones);
+        s.set(&DataKey::Funded, &false);
+    }
+
+    pub fn deposit(env: Env) {
+        let client: Address = env.storage().instance().get(&DataKey::Client).unwrap();
+        client.require_auth();
+
+        let funded: bool = env.storage().instance().get(&DataKey::Funded).unwrap();
+        assert!(!funded, "already funded");
+
+        let milestones: Vec<Milestone> =
+            env.storage().instance().get(&DataKey::Milestones).unwrap();
+        let total: i128 = milestones.iter().map(|m| m.amount).sum();
+
+        let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        token::Client::new(&env, &token_id).transfer(
+            &client,
+            &env.current_contract_address(),
+            &total,
+        );
+
+        env.storage().instance().set(&DataKey::Funded, &true);
+    }
+}
+```
+
+---
+
+## Approval and Release
+
+Approving a milestone pays the worker immediately — there is no separate withdraw step, which keeps the state machine small:
+
+```rust
+pub fn approve_milestone(env: Env, index: u32) {
+    let client: Address = env.storage().instance().get(&DataKey::Client).unwrap();
+    client.require_auth();
+    release(&env, index);
+}
+
+fn release(env: &Env, index: u32) {
+    let funded: bool = env.storage().instance().get(&DataKey::Funded).unwrap();
+    assert!(funded, "not funded yet");
+
+    let mut milestones: Vec<Milestone> =
+        env.storage().instance().get(&DataKey::Milestones).unwrap();
+    let mut m = milestones.get(index).expect("no such milestone");
+    assert!(
+        m.status == MilestoneStatus::Pending || m.status == MilestoneStatus::Disputed,
+        "milestone already settled"
+    );
+
+    m.status = MilestoneStatus::Approved;
+    milestones.set(index, m.clone());
+    env.storage().instance().set(&DataKey::Milestones, &milestones);
+
+    let worker: Address = env.storage().instance().get(&DataKey::Worker).unwrap();
+    let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+    token::Client::new(env, &token_id).transfer(
+        &env.current_contract_address(),
+        &worker,
+        &m.amount,
+    );
+}
+```
+
+Note the status check happens **before** the transfer and the status write happens before it too — settled milestones can never be paid twice, even if the function is called again.
+
+---
+
+## Dispute Path
+
+Either party can flag a milestone; only the arbiter can settle a disputed one:
+
+```rust
+pub fn dispute_milestone(env: Env, index: u32, by: Address) {
+    let client: Address = env.storage().instance().get(&DataKey::Client).unwrap();
+    let worker: Address = env.storage().instance().get(&DataKey::Worker).unwrap();
+    assert!(by == client || by == worker, "only client or worker");
+    by.require_auth();
+
+    let mut milestones: Vec<Milestone> =
+        env.storage().instance().get(&DataKey::Milestones).unwrap();
+    let mut m = milestones.get(index).expect("no such milestone");
+    assert!(m.status == MilestoneStatus::Pending, "not disputable");
+    m.status = MilestoneStatus::Disputed;
+    milestones.set(index, m);
+    env.storage().instance().set(&DataKey::Milestones, &milestones);
+}
+
+pub fn settle_dispute(env: Env, index: u32, release_to_worker: bool) {
+    let arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
+    arbiter.require_auth();
+
+    if release_to_worker {
+        release(&env, index);
+    } else {
+        let mut milestones: Vec<Milestone> =
+            env.storage().instance().get(&DataKey::Milestones).unwrap();
+        let mut m = milestones.get(index).expect("no such milestone");
+        assert!(m.status == MilestoneStatus::Disputed, "not disputed");
+        m.status = MilestoneStatus::Refunded;
+        milestones.set(index, m.clone());
+        env.storage().instance().set(&DataKey::Milestones, &milestones);
+
+        let client: Address = env.storage().instance().get(&DataKey::Client).unwrap();
+        let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        token::Client::new(&env, &token_id).transfer(
+            &env.current_contract_address(),
+            &client,
+            &m.amount,
+        );
+    }
+}
+```
+
+---
+
+## Trying It on Testnet
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/escrow.wasm \
+  --source client --network testnet
+
+stellar contract invoke --id <CONTRACT_ID> --source client --network testnet \
+  -- initialize \
+  --client <CLIENT_G...> --worker <WORKER_G...> --arbiter <ARBITER_G...> \
+  --token <TOKEN_CONTRACT_ID> --amounts '[500_0000000, 300_0000000, 200_0000000]'
+
+stellar contract invoke --id <CONTRACT_ID> --source client --network testnet -- deposit
+stellar contract invoke --id <CONTRACT_ID> --source client --network testnet \
+  -- approve_milestone --index 0
+```
+
+Amounts are in stroops-style 7-decimal token units (`500_0000000` = 500 tokens for the standard asset contract).
+
+---
+
+## Design Notes
+
+- **Full deposit up front** protects the worker: the money is provably escrowed before work starts. A variant that funds milestone-by-milestone is possible but weakens that guarantee.
+- **Arbiter power is scoped** to disputed milestones only — the arbiter cannot touch a milestone the client and worker agree on.
+- **Consider a timeout**: production escrows often add a deadline after which un-actioned milestones become refundable, preventing funds from being stranded if all parties disappear. That is a natural extension of the state machine shown here.
+
+You now have an escrow whose every payout is gated by either explicit client approval or an arbiter ruling, with refunds as a first-class path rather than an afterthought.

--- a/routes-d/752-contract-upgrade-safety.mdx
+++ b/routes-d/752-contract-upgrade-safety.mdx
@@ -1,0 +1,103 @@
+---
+title: Soroban Contract Upgrade Safety
+description: Safety practices for upgrading Soroban contracts — pre-upgrade backups, rollback strategy, storage compatibility rules, and a pre-flight checklist.
+---
+
+# Soroban Contract Upgrade Safety
+
+Soroban contracts upgrade in place: `update_current_contract_wasm` swaps the Wasm behind an existing contract ID, keeping the address and all stored state. That is powerful — integrators never have to repoint — and dangerous, because the new code inherits old data it may no longer understand. This guide covers how to upgrade without bricking state, how to keep a rollback path open, and what to check before you flip the switch.
+
+---
+
+## How Upgrades Work
+
+An upgradeable contract exposes an admin-gated entry point:
+
+```rust
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+
+#[contract]
+pub struct Upgradeable;
+
+#[contractimpl]
+impl Upgradeable {
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+        env.deployer().update_current_contract_wasm(&new_wasm_hash);
+    }
+}
+```
+
+The new Wasm must already be installed on the network (`stellar contract upload`), and the swap takes effect for the *next* invocation. Everything in instance, persistent, and temporary storage stays exactly as it was.
+
+---
+
+## Backup Before You Touch Anything
+
+There is no built-in undo. Your backup is information you capture yourself, before the upgrade:
+
+1. **Record the current Wasm hash.** This is your rollback artifact:
+   ```bash
+   stellar contract info --id <CONTRACT_ID> --network mainnet
+   ```
+2. **Snapshot critical storage.** Read every key the new version will interpret differently and store the values off-chain (a JSON dump in your ops repo is fine). For large maps, snapshot at least the aggregate invariants — total supply, sum of balances — so you can verify them post-upgrade.
+3. **Archive the old source at a tag.** `git tag v1.4.0-pre-upgrade` — you will want to diff storage code precisely when something looks wrong at 2 a.m.
+
+---
+
+## Rollback Strategy
+
+Because the old Wasm hash stays installed on the network, rollback is just another upgrade — *if* two conditions hold:
+
+- **The upgrade entry point still exists and still authorizes you.** Never ship a version that removes or breaks `upgrade()`; that is the one mistake with no recovery path.
+- **The new version has not written state the old code cannot read.** If v2 writes new-format entries and you roll back to v1, v1 traps on them.
+
+The practical rule: make v2 **read old and new formats, but keep writing the old format** for one release. Only after v2 is proven do you ship v3 that writes the new format. This "expand, then contract" sequencing keeps rollback safe at every step.
+
+---
+
+## Storage Compatibility Rules
+
+Stored values do not migrate themselves. The decode happens lazily, on first read, with whatever types the current code has:
+
+- **Never reorder, retype, or remove fields** of a `#[contracttype]` struct that has instances on the ledger — old entries will fail to decode.
+- **Additive changes need new keys or versioned enums.** Wrap evolving types as `enum Stored { V1(OldShape), V2(NewShape) }` and match on read.
+- **Migrate lazily where possible**: on read, decode V1, convert, write back V2. Big-bang migration loops are limited by per-transaction resource caps and rarely fit in one invocation.
+- **Watch TTLs.** Persistent entries that expired and were restored still hold their old shape; your migration logic must handle entries of any age.
+
+---
+
+## Pre-Flight Checklist
+
+Run through this before every production upgrade:
+
+- [ ] New Wasm uploaded and hash recorded; old hash recorded for rollback.
+- [ ] `upgrade()` present, admin-gated, and tested **in the new version**.
+- [ ] Storage diff reviewed: every `#[contracttype]` change is additive/versioned.
+- [ ] Upgrade rehearsed on testnet against a state snapshot copied from production shapes.
+- [ ] Invariant checks scripted (total supply, balance sums) to run immediately after.
+- [ ] Rollback rehearsed: upgrade to v2 on testnet, then back to v1, then read state.
+- [ ] Announcement ready if the upgrade changes any externally visible behavior.
+
+---
+
+## After the Upgrade
+
+Verify, don't assume:
+
+```bash
+# Confirm the contract now reports the new wasm hash
+stellar contract info --id <CONTRACT_ID> --network mainnet
+
+# Exercise one read and one write path end to end
+stellar contract invoke --id <CONTRACT_ID> --network mainnet -- get_state
+```
+
+Then run your scripted invariant checks against the snapshot from the backup step. If anything disagrees, roll back first and investigate second — the recorded old hash makes that a one-line operation, which is exactly why you recorded it.
+
+---
+
+## Summary
+
+Upgrade safety on Soroban is mostly *sequencing*: capture the old hash and a state snapshot, keep every storage change backward-readable, keep the upgrade path itself intact, and rehearse the rollback before you need it. Contracts that follow the expand-then-contract pattern can upgrade indefinitely without a single stranded byte of state.

--- a/routes-d/755-treasury-dashboard-tutorial.mdx
+++ b/routes-d/755-treasury-dashboard-tutorial.mdx
@@ -1,0 +1,175 @@
+---
+title: Treasury Dashboard App Tutorial
+description: Build a treasury dashboard for a Stellar organization — live balances across accounts, inflow/outflow tracking from transaction history, and role-based spending controls.
+---
+
+# Treasury Dashboard App Tutorial
+
+Organizations on Stellar typically spread funds across several accounts — an operating account, a cold reserve, per-team spending accounts. This tutorial builds a treasury dashboard that shows live balances across all of them, derives inflows and outflows from payment history, and gates the "move funds" action behind role checks and multisig-aware signing.
+
+We use the Nextellar hooks (`useStellarBalances`, `useTransactionHistory`, `useStellarWallet`) so the data layer is a few lines per widget.
+
+---
+
+## App Structure
+
+```
+app/
+  treasury/
+    page.tsx            // dashboard shell
+    accounts.ts         // the org's account registry
+    BalancesPanel.tsx   // per-account + total balances
+    FlowsPanel.tsx      // inflows / outflows from history
+    TransferPanel.tsx   // controlled spend action
+```
+
+The account registry is plain data — treasury membership changes via config review, not code changes:
+
+```ts
+// accounts.ts
+export interface TreasuryAccount {
+  label: string;
+  publicKey: string;
+  role: 'operating' | 'reserve' | 'team';
+}
+
+export const TREASURY_ACCOUNTS: TreasuryAccount[] = [
+  { label: 'Operating',   publicKey: 'GOPERATING...', role: 'operating' },
+  { label: 'Cold Reserve', publicKey: 'GRESERVE...',  role: 'reserve' },
+  { label: 'Growth Team',  publicKey: 'GTEAM1...',    role: 'team' },
+];
+```
+
+---
+
+## Balances Panel
+
+Each account gets a `useStellarBalances` subscription with polling, and the panel folds them into a total per asset:
+
+```tsx
+// BalancesPanel.tsx
+import { useStellarBalances } from '@/hooks/useStellarBalances';
+import { TREASURY_ACCOUNTS, TreasuryAccount } from './accounts';
+
+function AccountRow({ account }: { account: TreasuryAccount }) {
+  const { balances, loading, error } = useStellarBalances(account.publicKey, {
+    pollIntervalMs: 30_000,
+  });
+
+  if (loading) return <tr><td colSpan={3}>Loading {account.label}…</td></tr>;
+  if (error)   return <tr><td colSpan={3}>Error loading {account.label}</td></tr>;
+
+  const xlm = balances.find((b) => b.asset_type === 'native')?.balance ?? '0';
+  return (
+    <tr>
+      <td>{account.label}</td>
+      <td>{account.role}</td>
+      <td>{Number(xlm).toLocaleString()} XLM</td>
+    </tr>
+  );
+}
+
+export function BalancesPanel() {
+  return (
+    <table>
+      <thead><tr><th>Account</th><th>Role</th><th>XLM Balance</th></tr></thead>
+      <tbody>
+        {TREASURY_ACCOUNTS.map((a) => <AccountRow key={a.publicKey} account={a} />)}
+      </tbody>
+    </table>
+  );
+}
+```
+
+A 30-second poll is a sensible default for a treasury view: fresh enough for operations, gentle on Horizon.
+
+---
+
+## Flows Panel: Inflows and Outflows
+
+Transaction history gives us directional flow. A payment where the treasury account is the source is an outflow; where it is the destination, an inflow:
+
+```tsx
+// FlowsPanel.tsx
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
+
+export function FlowsPanel({ publicKey }: { publicKey: string }) {
+  const { transactions, loading, loadMore, hasMore } = useTransactionHistory(
+    publicKey,
+    { limit: 20, order: 'desc' },
+  );
+
+  if (loading && transactions.length === 0) return <p>Loading flows…</p>;
+
+  return (
+    <div>
+      <ul>
+        {transactions.map((tx) => (
+          <li key={tx.id}>
+            <span>{tx.created_at}</span>{' '}
+            <strong>{tx.source_account === publicKey ? 'OUT' : 'IN'}</strong>{' '}
+            <code>{tx.id.slice(0, 8)}…</code>
+          </li>
+        ))}
+      </ul>
+      {hasMore && <button onClick={loadMore}>Load older</button>}
+    </div>
+  );
+}
+```
+
+For a real monthly inflow/outflow chart, page through history with `loadMore` until you pass the period boundary, bucket amounts by day, and cache the result — history is immutable, so buckets for closed days never need recomputation.
+
+---
+
+## Spending Controls
+
+Two layers keep the "move funds" button honest:
+
+**1. UI-level role gating.** Only wallets in the signers list see the transfer panel at all:
+
+```tsx
+// TransferPanel.tsx
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+import { useStellarPayment } from '@/hooks/useStellarPayment';
+
+const AUTHORIZED_SIGNERS = ['GCFO...', 'GOPS...'];
+
+export function TransferPanel({ from }: { from: string }) {
+  const { connected, publicKey } = useStellarWallet();
+  const { buildPaymentXDR } = useStellarPayment();
+
+  if (!connected || !publicKey || !AUTHORIZED_SIGNERS.includes(publicKey)) {
+    return <p>Connect an authorized signer wallet to move funds.</p>;
+  }
+
+  const propose = async (to: string, amount: string) => {
+    const xdr = await buildPaymentXDR({ from, to, amount, memo: 'treasury-transfer' });
+    // Hand the unsigned XDR to the connected wallet for signing.
+    // For multisig accounts this signature is one of several.
+    return xdr;
+  };
+
+  /* form UI elided — calls propose(to, amount) on submit */
+}
+```
+
+**2. On-chain enforcement.** The UI gate is convenience, not security. The treasury accounts themselves should carry medium/high thresholds above any single signer's weight, so a payment needs multiple signatures regardless of what any dashboard allows. The dashboard's job is to *build* the unsigned XDR and route it to signers — collecting co-signatures out of band or via your coordination tool of choice.
+
+---
+
+## Access-Control Notes
+
+- Treat `AUTHORIZED_SIGNERS` as a mirror of the on-chain signer set, not the source of truth — fetch the account's actual signers from Horizon if you want the list to stay honest automatically.
+- The dashboard is read-mostly: balances and history come from public Horizon data, so viewing needs no wallet at all. Only the transfer path requires connection.
+- Never put a treasury secret key anywhere near this app. Every signature comes from a connected wallet.
+
+---
+
+## Where to Take It
+
+- Add per-asset rows (the `balances` array already carries every trustline asset).
+- Persist daily flow buckets server-side and render a proper chart.
+- Show pending multisig transactions by querying Horizon's `/accounts/{id}/transactions` alongside a shared proposal store.
+
+The core pattern stays the same throughout: public data in via hooks, unsigned XDR out via wallets, and every control that matters enforced by the accounts themselves rather than the UI.


### PR DESCRIPTION
## Summary
Adds four documentation drafts to the `routes-d` staging folder, one per assigned issue: a guide on custom serialization patterns for Soroban contract data, a milestone-based escrow contract tutorial, a guide on Soroban contract upgrade safety, and a treasury dashboard app tutorial. Each draft follows the existing routes-d naming convention (`<issue>-<slug>.mdx`) and matches the frontmatter and section style of the merged drafts already in that folder.

closes #748
closes #751
closes #752
closes #755

## Changes
- **#748 — custom serialization patterns**: `routes-d/748-custom-serialization-patterns.mdx` compares the four practical encodings for contract data (native `#[contracttype]` structs, enum-keyed storage, packed `Bytes`, off-chain data behind an on-chain hash), gives compatibility rules for each (versioned enums, version bytes, canonical JSON for hashing), and includes a working packed-bytes pack/unpack example in Rust with a version-checked decoder.
- **#751 — milestone-based escrow tutorial**: `routes-d/751-milestone-escrow-tutorial.mdx` builds a full escrow contract: client deposits the summed budget up front, per-milestone `Pending → Approved/Disputed → Refunded` state machine, immediate payout on approval with status written before transfer (no double-release), an arbiter-only dispute settlement path, and testnet CLI invocation steps.
- **#752 — contract upgrade safety**: `routes-d/752-contract-upgrade-safety.mdx` documents `update_current_contract_wasm` upgrades: what to back up beforehand (old Wasm hash, storage snapshot, tagged source), a rollback strategy based on expand-then-contract sequencing so old code can always re-read state, storage compatibility rules, and a pre-flight checklist plus post-upgrade verification commands.
- **#755 — treasury dashboard tutorial**: `routes-d/755-treasury-dashboard-tutorial.mdx` walks through a multi-account org treasury dashboard using the existing hooks (`useStellarBalances` with polling, `useTransactionHistory` for inflow/outflow classification, `useStellarWallet` + `useStellarPayment` for a role-gated transfer panel), and explains why real spending control lives in on-chain multisig thresholds rather than UI gating.

## Test plan
- Hook usage in #755 cross-checked against the API references in `docs/hooks/use-stellar-balances.mdx`, `use-transaction-history.mdx`, `use-stellar-wallet.mdx`, and `use-stellar-payment.mdx` (parameter and return shapes match).
- Drafts are staged in `routes-d/`, which is outside `contentlayer`'s `contentDirPath: 'docs'`, so they do not affect `pnpm build:content` output; frontmatter matches the docs schema for when they are promoted.

---
Note: `pnpm build:content` and `pnpm check:links` currently fail on a clean checkout of `main` for pre-existing reasons unrelated to these drafts; this PR only adds files under `routes-d/` and introduces no new build inputs.