### PR TITLE
docs: add useSorobanContract, path payments, asset issuance, and SDK upgrade guides

### DIFF
--- a/routes-d/388-use-soroban-contract-invocation.mdx
+++ b/routes-d/388-use-soroban-contract-invocation.mdx
@@ -1,0 +1,195 @@
+---
+title: useSorobanContract Invocation Pattern
+description: Document the standard invocation pattern for useSorobanContract — covering parameter encoding, signing requirements, and a minimal working example.
+date: 2026-07-25
+---
+
+# useSorobanContract Invocation Pattern
+
+`useSorobanContract` is a React hook that wraps the Soroban RPC simulation-and-submission flow. It handles account loading, transaction assembly, simulation, fee estimation, signing, and submission so calling code only needs to specify the contract, function name, and arguments.
+
+---
+
+## Parameter Encoding
+
+Soroban contract arguments are XDR-encoded `ScVal` objects. The SDK's `nativeToScVal` helper converts JavaScript primitives to the correct type:
+
+| JavaScript type | ScVal type | Example |
+|---|---|---|
+| `string` | `Sym` or `Str` | `nativeToScVal('transfer', { type: 'symbol' })` |
+| `bigint` | `I128` or `U128` | `nativeToScVal(1000n, { type: 'i128' })` |
+| `number` (integer) | `U32` or `I32` | `nativeToScVal(5, { type: 'u32' })` |
+| Stellar address string | `Address` | `new Address('G...').toScVal()` |
+| `boolean` | `Bool` | `nativeToScVal(true)` |
+| `Buffer` / `Uint8Array` | `Bytes` | `nativeToScVal(buf, { type: 'bytes' })` |
+
+Always match the Rust function signature exactly. Passing `u32` where the contract expects `i128` causes a `Value(InvalidInput)` error at simulation time.
+
+---
+
+## Signing Requirements
+
+Every state-changing invocation (`#[contractimpl]` functions that call `require_auth`) must be signed by the authorised address before submission. Read-only calls (simulated only) do not need a signature.
+
+The hook separates these two paths:
+
+- **`simulate()`** — builds the transaction, runs it through `server.simulateTransaction()`, returns the result without broadcasting. Free; no signature needed.
+- **`invoke()`** — simulates first, then calls the provided `signTransaction` callback, then submits via `server.sendTransaction()`. Requires a signer.
+
+---
+
+## Minimal Example
+
+```tsx
+// hooks/useTransfer.ts
+import { useSorobanContract } from '@/hooks/useSorobanContract';
+import { Address, nativeToScVal } from '@stellar/stellar-sdk';
+
+const TOKEN_CONTRACT = process.env.NEXT_PUBLIC_TOKEN_CONTRACT!;
+
+export function useTransfer() {
+  const { invoke, loading, error } = useSorobanContract(TOKEN_CONTRACT);
+
+  async function transfer(
+    from: string,
+    to: string,
+    amount: bigint,
+    signTransaction: (xdr: string) => Promise<string>,
+  ) {
+    return invoke({
+      method: 'transfer',
+      args: [
+        new Address(from).toScVal(),
+        new Address(to).toScVal(),
+        nativeToScVal(amount, { type: 'i128' }),
+      ],
+      signTransaction,
+    });
+  }
+
+  return { transfer, loading, error };
+}
+```
+
+```tsx
+// components/TransferButton.tsx
+import { useTransfer } from '@/hooks/useTransfer';
+import { useWallet } from '@/hooks/useWallet'; // provides signTransaction
+
+export function TransferButton({
+  to,
+  amount,
+}: {
+  to: string;
+  amount: bigint;
+}) {
+  const { publicKey, signTransaction } = useWallet();
+  const { transfer, loading, error } = useTransfer();
+
+  async function handleClick() {
+    if (!publicKey) return;
+    await transfer(publicKey, to, amount, signTransaction);
+  }
+
+  return (
+    <button onClick={handleClick} disabled={loading}>
+      {loading ? 'Sending…' : 'Transfer'}
+    </button>
+  );
+}
+```
+
+---
+
+## Hook Implementation Reference
+
+```ts
+// hooks/useSorobanContract.ts
+import { useState, useCallback } from 'react';
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  Account,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+interface InvokeOptions {
+  method: string;
+  args: xdr.ScVal[];
+  signTransaction: (xdr: string) => Promise<string>;
+  sourcePublicKey?: string;
+}
+
+export function useSorobanContract(contractId: string) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const server = new rpc.Server(process.env.NEXT_PUBLIC_RPC_URL!);
+  const contract = new Contract(contractId);
+
+  const invoke = useCallback(
+    async ({ method, args, signTransaction, sourcePublicKey }: InvokeOptions) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const source = sourcePublicKey ?? (await server.getAccount('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'));
+        const account = source instanceof Account ? source : await server.getAccount(source);
+
+        const tx = new TransactionBuilder(account, {
+          fee: BASE_FEE,
+          networkPassphrase: Networks.MAINNET,
+        })
+          .addOperation(contract.call(method, ...args))
+          .setTimeout(30)
+          .build();
+
+        const simResult = await server.simulateTransaction(tx);
+        if (rpc.Api.isSimulationError(simResult)) {
+          throw new Error(simResult.error);
+        }
+
+        const assembled = rpc.assembleTransaction(tx, simResult).build();
+        const signedXdr = await signTransaction(assembled.toXDR());
+        const signedTx = TransactionBuilder.fromXDR(signedXdr, Networks.MAINNET);
+
+        const sendResult = await server.sendTransaction(signedTx);
+        if (sendResult.status === 'ERROR') throw new Error(sendResult.errorResult?.result().toString());
+
+        return sendResult;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        setError(e);
+        throw e;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [contractId],
+  );
+
+  return { invoke, loading, error };
+}
+```
+
+---
+
+## Common Mistakes
+
+**Wrong ScVal type**: if `nativeToScVal(amount)` without a type hint produces `I64` but the contract expects `I128`, simulation returns `Value(InvalidInput)`. Always pass `{ type: 'i128' }` explicitly for 128-bit integers.
+
+**Missing `require_auth` signer**: if the `signTransaction` callback signs with a key that doesn't match the address passed to `require_auth`, the contract panics with `InvalidAction(OperationNotPermitted)`. Ensure `sourcePublicKey` matches the address argument the contract will call `require_auth` on.
+
+**Stale sequence number**: if `getAccount` is called once and reused across multiple rapid invocations, the second invocation will fail with `tx_bad_seq`. Call `getAccount` fresh for each invocation.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Parameter encoding table covers all common types
+- [ ] `simulate` vs `invoke` distinction is clear
+- [ ] Common mistakes section covers type mismatch and auth errors

--- a/routes-d/395-path-payments-strict-send-receive.mdx
+++ b/routes-d/395-path-payments-strict-send-receive.mdx
@@ -1,0 +1,221 @@
+---
+title: Path Payments — Strict Send and Strict Receive
+description: Explain Stellar path payments and the strict send and strict receive variants, with examples and pathfinding considerations.
+date: 2026-07-25
+---
+
+# Path Payments — Strict Send and Strict Receive
+
+A path payment lets a sender pay in one asset while the recipient receives a different asset. Stellar's DEX automatically finds a conversion route through intermediate assets. Two variants control which end of the trade is fixed: **strict send** fixes the input amount; **strict receive** fixes the output amount.
+
+---
+
+## Variant Comparison
+
+| | Strict Send | Strict Receive |
+|---|---|---|
+| **Fixed end** | Source amount | Destination amount |
+| **Slippage guard** | `destination_min` — minimum the recipient receives | `send_max` — maximum the sender will spend |
+| **Use case** | "Send exactly 10 USDC, recipient gets as much XLM as possible" | "Recipient must receive exactly 50 XLM, charge sender whatever it costs (up to a cap)" |
+| **Operation** | `pathPaymentStrictSend` | `pathPaymentStrictReceive` |
+
+---
+
+## Pathfinding Considerations
+
+Stellar's Horizon and RPC nodes will find conversion paths automatically, but the quality of the path depends on DEX liquidity:
+
+- **Provide the path explicitly** when you know the best route (reduces slippage, avoids failed lookups).
+- **Let Horizon find it** using `/paths/strict-send` or `/paths/strict-receive` when the optimal path is unknown.
+- **Intermediate assets** are typically XLM or a high-liquidity stablecoin (USDC). Paths through illiquid assets increase slippage.
+- **Empty path** (`[]`) performs a direct trade between source and destination assets — only works if an orderbook exists for that pair.
+
+```ts
+// lib/find-path.ts
+import { Horizon, Asset } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+
+export async function findStrictSendPath(
+  sourceAsset: Asset,
+  sourceAmount: string,
+  destinationAsset: Asset,
+  destinationAccount: string,
+) {
+  const result = await server
+    .strictSendPaths(sourceAsset, sourceAmount, [destinationAsset])
+    .call();
+  return result.records[0]; // best path, highest destination amount first
+}
+
+export async function findStrictReceivePath(
+  destinationAsset: Asset,
+  destinationAmount: string,
+  sourceAsset: Asset,
+  sourceAccount: string,
+) {
+  const result = await server
+    .strictReceivePaths([sourceAsset], destinationAsset, destinationAmount)
+    .call();
+  return result.records[0]; // best path, lowest source cost first
+}
+```
+
+---
+
+## Strict Send Example
+
+The sender fixes their outlay. The recipient gets at least `destination_min`.
+
+```ts
+// lib/strict-send.ts
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  Asset,
+  Operation,
+} from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+
+export async function strictSend(
+  senderKeypair: Keypair,
+  sourceAsset: Asset,
+  sourceAmount: string,        // exact amount sender will spend
+  destinationAsset: Asset,
+  destinationAccount: string,
+  destinationMin: string,      // minimum recipient must receive
+  path: Asset[] = [],
+) {
+  const account = await server.loadAccount(senderKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      Operation.pathPaymentStrictSend({
+        sendAsset: sourceAsset,
+        sendAmount: sourceAmount,
+        destination: destinationAccount,
+        destAsset: destinationAsset,
+        destMin: destinationMin,
+        path,
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(senderKeypair);
+  return server.submitTransaction(tx);
+}
+```
+
+### Example call
+
+```ts
+import { Asset } from '@stellar/stellar-sdk';
+
+const USDC = new Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+
+await strictSend(
+  senderKeypair,
+  USDC,
+  '10',                          // send exactly 10 USDC
+  Asset.native(),                // recipient gets XLM
+  recipientAddress,
+  '45',                          // revert if recipient would get < 45 XLM
+);
+```
+
+---
+
+## Strict Receive Example
+
+The recipient's amount is fixed. The sender pays up to `send_max`.
+
+```ts
+// lib/strict-receive.ts
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  Asset,
+  Operation,
+} from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+
+export async function strictReceive(
+  senderKeypair: Keypair,
+  sourceAsset: Asset,
+  sendMax: string,               // maximum sender will spend
+  destinationAsset: Asset,
+  destinationAmount: string,     // exact amount recipient will receive
+  destinationAccount: string,
+  path: Asset[] = [],
+) {
+  const account = await server.loadAccount(senderKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      Operation.pathPaymentStrictReceive({
+        sendAsset: sourceAsset,
+        sendMax,
+        destination: destinationAccount,
+        destAsset: destinationAsset,
+        destAmount: destinationAmount,
+        path,
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(senderKeypair);
+  return server.submitTransaction(tx);
+}
+```
+
+### Example call
+
+```ts
+await strictReceive(
+  senderKeypair,
+  Asset.native(),               // sender pays in XLM
+  '60',                         // spend at most 60 XLM
+  USDC,
+  '10',                         // recipient receives exactly 10 USDC
+  recipientAddress,
+);
+```
+
+---
+
+## Handling Path Payment Failures
+
+| Error code | Cause | Fix |
+|---|---|---|
+| `op_too_few_offers` | No path found with enough liquidity | Widen the path, increase slippage tolerance, or try later |
+| `op_under_dest_min` | Best available rate is below `destMin` | Raise slippage tolerance or reduce `sourceAmount` |
+| `op_over_send_max` | Cost exceeds `sendMax` | Raise `sendMax` or reduce `destAmount` |
+| `op_no_trust` | Recipient has no trustline for `destAsset` | Ask recipient to add trustline first |
+| `op_src_no_trust` | Sender has no trustline for `sendAsset` | Add trustline before sending |
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Comparison table clearly distinguishes strict send from strict receive
+- [ ] Both code examples include slippage guard parameters
+- [ ] Path-finding helper shows both Horizon endpoints
+- [ ] Error code table is accurate

--- a/routes-d/400-custom-asset-issuance.mdx
+++ b/routes-d/400-custom-asset-issuance.mdx
@@ -1,0 +1,204 @@
+---
+title: Custom Asset Issuance on Stellar
+description: Document the basic flow for issuing a custom asset on Stellar — covering issuer and distribution accounts, trustline and payment steps, and compliance considerations.
+date: 2026-07-25
+---
+
+# Custom Asset Issuance on Stellar
+
+Any Stellar account can issue a custom asset. A standard two-account pattern — issuer and distribution — minimises risk by keeping the issuing keypair offline after the initial mint and routing all secondary market activity through the distribution account.
+
+---
+
+## Issuer and Distribution Accounts
+
+| Account | Role | Key storage |
+|---|---|---|
+| **Issuer** | Creates the asset; its public key forms the asset's identifier. Signing with it mints new supply. | Cold (offline). Only used to mint or lock supply. |
+| **Distribution** | Holds the initial supply; sells to the market. Has a trustline to the issuer. | Hot (online). Used for normal operations. |
+
+Keeping the issuer keypair offline prevents an attacker who compromises the distribution account from minting unbounded supply.
+
+---
+
+## Step-by-Step Issuance Flow
+
+### 1 — Create and fund both accounts
+
+```bash
+# On testnet use friendbot; on mainnet fund via an exchange or existing account
+stellar account fund --account $ISSUER_ADDRESS  --network testnet
+stellar account fund --account $DIST_ADDRESS    --network testnet
+```
+
+### 2 — Distribution account creates a trustline
+
+The distribution account must explicitly trust the issuer's asset before it can hold it:
+
+```ts
+// scripts/create-trustline.ts
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  Asset,
+  Operation,
+} from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+const distKeypair = Keypair.fromSecret(process.env.DIST_SECRET!);
+const issuerAddress = process.env.ISSUER_ADDRESS!;
+
+const ACME = new Asset('ACME', issuerAddress);
+
+async function createTrustline() {
+  const account = await server.loadAccount(distKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      Operation.changeTrust({
+        asset: ACME,
+        limit: '1000000000', // maximum supply the distribution account will ever hold
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(distKeypair);
+  await server.submitTransaction(tx);
+  console.log('Trustline created');
+}
+```
+
+### 3 — Issuer mints supply to the distribution account
+
+```ts
+// scripts/mint.ts
+import {
+  Horizon,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  Asset,
+  Operation,
+} from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.HORIZON_URL!);
+const issuerKeypair = Keypair.fromSecret(process.env.ISSUER_SECRET!); // keep offline!
+const distAddress = process.env.DIST_ADDRESS!;
+
+const ACME = new Asset('ACME', issuerKeypair.publicKey());
+
+async function mint(amount: string) {
+  const account = await server.loadAccount(issuerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: distAddress,
+        asset: ACME,
+        amount,
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(issuerKeypair);
+  await server.submitTransaction(tx);
+  console.log(`Minted ${amount} ACME to distribution account`);
+}
+
+mint('1000000').catch(console.error);
+```
+
+### 4 — Lock supply (optional but recommended)
+
+After minting, set the issuer account's master weight to 0. This makes the issuer account unable to sign further transactions, permanently capping the supply:
+
+```ts
+// scripts/lock-issuer.ts
+import { Operation, AuthFlag } from '@stellar/stellar-sdk';
+
+// Add to a transaction signed by the issuer keypair BEFORE destroying it
+Operation.setOptions({
+  masterWeight: 0,       // issuer can no longer sign
+  setFlags: AuthFlag.AuthRevocableFlag, // optional: lets issuer revoke trustlines
+});
+```
+
+---
+
+## Enabling Holders to Receive the Asset
+
+Every account that wants to hold the custom asset must create a trustline. In a dApp flow, prompt the user before the first transfer:
+
+```ts
+// lib/ensure-trustline.ts
+import { Horizon, Asset } from '@stellar/stellar-sdk';
+
+export async function hasTrustline(
+  server: Horizon.Server,
+  account: string,
+  asset: Asset,
+): Promise<boolean> {
+  const { balances } = await server.loadAccount(account);
+  return balances.some(
+    (b) =>
+      b.asset_type !== 'native' &&
+      (b as Horizon.HorizonApi.BalanceLineAsset).asset_code === asset.code &&
+      (b as Horizon.HorizonApi.BalanceLineAsset).asset_issuer === asset.issuer,
+  );
+}
+```
+
+---
+
+## Compliance Considerations
+
+**TOML file (`stellar.toml`)**: publish a `stellar.toml` at `https://yourdomain.com/.well-known/stellar.toml` describing your asset. Wallets and exchanges use this to display asset name, logo, and documentation links. Minimum required fields:
+
+```toml
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+[[CURRENCIES]]
+code="ACME"
+issuer="G<ISSUER_ADDRESS>"
+display_decimals=2
+name="Acme Token"
+desc="A description of what ACME represents."
+is_asset_anchored=false
+```
+
+**Authorization flags**: if your asset requires KYC or is regulated, set `AUTH_REQUIRED` on the issuer account. Holders must be explicitly authorised before receiving the asset:
+
+```ts
+Operation.setOptions({
+  setFlags: AuthFlag.AuthRequiredFlag,
+});
+// Later, authorise a specific trustline:
+Operation.setTrustLineFlags({
+  trustor: customerAddress,
+  asset: ACME,
+  flags: { authorized: true },
+});
+```
+
+**Clawback**: setting `AUTH_CLAWBACK_ENABLED_FLAG` on the issuer lets you reclaim tokens from any holder (relevant for regulated assets or stablecoins under central bank requirements). Enable only if required by your use case, as it reduces holder trust.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Issuer vs distribution account roles are clearly distinguished
+- [ ] All four steps (fund, trustline, mint, lock) are shown with code
+- [ ] `stellar.toml` fields are listed
+- [ ] Auth flags (required, clawback) are noted with appropriate warnings

--- a/routes-d/406-stellar-sdk-upgrade.mdx
+++ b/routes-d/406-stellar-sdk-upgrade.mdx
@@ -1,0 +1,167 @@
+---
+title: Stellar SDK Upgrade Procedure
+description: Document how to safely upgrade the Stellar SDK version in a project — checking the changelog, handling common API changes, and verifying with a test plan.
+date: 2026-07-25
+---
+
+# Stellar SDK Upgrade Procedure
+
+The `@stellar/stellar-sdk` package ships major versions roughly once or twice a year, aligned with Stellar Protocol upgrades. Breaking changes are common between major versions. This guide walks through the safe upgrade path.
+
+---
+
+## Before You Start
+
+1. **Pin your current version** in `package.json` (no `^` or `~`) so the lockfile is the source of truth.
+2. **Read the changelog**: [github.com/stellar/js-stellar-sdk/releases](https://github.com/stellar/js-stellar-sdk/releases). Focus on the **Breaking changes** section of each version between your current and target.
+3. **Check protocol compatibility**: each SDK major targets a specific Stellar protocol version. Confirm testnet and mainnet are on a compatible protocol before upgrading.
+
+---
+
+## Common API Changes Between Major Versions
+
+### v10 → v11 (illustrative — check actual release notes)
+
+| Old API | New API | Notes |
+|---|---|---|
+| `Server` (from `stellar-sdk`) | `Horizon.Server` | Horizon client moved to `Horizon` namespace |
+| `SorobanRpc.Server` | `rpc.Server` | RPC client moved to `rpc` namespace |
+| `xdr.ScInt128Parts` | `nativeToScVal(n, { type: 'i128' })` | Direct XDR construction replaced by helpers |
+| `Transaction.toEnvelope().toXDR('base64')` | `tx.toXDR()` | Shorthand added |
+| `server.submitTransaction` (sync result) | `server.sendTransaction` + poll | Soroban submission is async; poll with `getTransaction` |
+
+Always cross-reference with the actual release notes — this table is illustrative.
+
+---
+
+## Step-by-Step Upgrade
+
+### 1 — Install the new version in isolation
+
+```bash
+# Install without updating other deps
+npm install @stellar/stellar-sdk@<target-version> --save-exact
+```
+
+### 2 — Run TypeScript compilation immediately
+
+```bash
+npx tsc --noEmit 2>&1 | head -60
+```
+
+Type errors surface the majority of breaking changes. Fix them file by file — don't move on until `tsc` is clean.
+
+### 3 — Search for removed or renamed identifiers
+
+```bash
+# Find all SDK imports in the project
+grep -rE "from '@stellar/stellar-sdk'" src/ --include="*.ts" --include="*.tsx" -l
+
+# Check for patterns known to change between versions
+grep -rn "SorobanRpc\." src/
+grep -rn "new Server(" src/
+grep -rn "\.toXDR\('base64'\)" src/
+```
+
+### 4 — Update namespace imports
+
+A common rename pattern:
+
+```ts
+// Before (old)
+import { SorobanRpc, Server } from '@stellar/stellar-sdk';
+const server = new SorobanRpc.Server(RPC_URL);
+const horizonServer = new Server(HORIZON_URL);
+
+// After (new)
+import { rpc, Horizon } from '@stellar/stellar-sdk';
+const server = new rpc.Server(RPC_URL);
+const horizonServer = new Horizon.Server(HORIZON_URL);
+```
+
+### 5 — Update Soroban submission flow if needed
+
+From v10 onward, Soroban transaction submission is split into send + poll:
+
+```ts
+// Old (synchronous illusion)
+const result = await server.submitTransaction(tx);
+
+// New (explicit async)
+const sendResult = await server.sendTransaction(tx);
+if (sendResult.status === 'ERROR') throw new Error('submission failed');
+
+// Poll until confirmed
+let getResult;
+do {
+  await new Promise(r => setTimeout(r, 2000));
+  getResult = await server.getTransaction(sendResult.hash);
+} while (getResult.status === 'NOT_FOUND');
+
+if (getResult.status === 'FAILED') throw new Error('transaction failed');
+const returnValue = getResult.returnValue;
+```
+
+---
+
+## Test Plan
+
+After fixing all TypeScript errors, run through this checklist before deploying:
+
+### Automated
+
+```bash
+# Unit and integration tests
+npm test
+
+# Type check
+npx tsc --noEmit
+
+# Lint
+npm run lint
+```
+
+### Manual smoke test on testnet
+
+- [ ] Connect wallet (Freighter or test keypair)
+- [ ] Load account and display balances
+- [ ] Submit a simple XLM payment
+- [ ] Invoke a Soroban contract function (simulate only)
+- [ ] Invoke a Soroban contract function (full submission)
+- [ ] Subscribe to a Soroban event stream
+- [ ] Path payment (strict send or strict receive)
+
+### Regression areas to watch
+
+| Area | Why it breaks |
+|---|---|
+| Fee estimation | `simulateTransaction` response shape can change |
+| Auth assembly | `rpc.assembleTransaction` signature may change |
+| XDR encoding helpers | `nativeToScVal` / `scValToNative` behaviour for edge types |
+| Event pagination | `getEvents` cursor format can change |
+| Error codes | `sendTransaction` error shape may differ |
+
+---
+
+## Rollback Plan
+
+If a breaking issue is found in production after deployment:
+
+```bash
+# Revert to pinned previous version
+npm install @stellar/stellar-sdk@<previous-version> --save-exact
+npm ci  # restore from lockfile
+```
+
+Keep the previous version pinned in a separate branch until the upgrade is fully validated.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Changelog check step comes before any code changes
+- [ ] Common API rename table is present
+- [ ] Async submission flow is shown for Soroban
+- [ ] Rollback plan is documented


### PR DESCRIPTION
## Summary

Adds four documentation guides to `routes-d/` covering core Stellar and Soroban development patterns: the `useSorobanContract` invocation hook, path payments (strict send/receive), custom asset issuance, and the Stellar SDK upgrade procedure.

closes #388
closes #395
closes #400
closes #406

## Changes

- **#388 — useSorobanContract invocation pattern** (`routes-d/388-use-soroban-contract-invocation.mdx`): Documents `nativeToScVal` type encoding with a full table, the `simulate` vs `invoke` distinction, a complete hook implementation covering account loading → simulation → signing → submission, and a common-mistakes section covering type mismatches, missing auth signers, and stale sequence numbers.

- **#395 — Path payments strict send and strict receive** (`routes-d/395-path-payments-strict-send-receive.mdx`): Compares both variants in a table (fixed end, slippage guard, use case), shows Horizon path-finding with `strictSendPaths`/`strictReceivePaths`, provides a full TypeScript example for each operation, and lists all common error codes with causes and fixes.

- **#400 — Custom asset issuance** (`routes-d/400-custom-asset-issuance.mdx`): Covers the two-account issuer/distribution pattern, all four issuance steps (fund, trustline, mint, lock supply), how to prompt end users to add trustlines, `stellar.toml` minimum fields, and compliance flags (`AUTH_REQUIRED`, `AUTH_REVOCABLE`, `AUTH_CLAWBACK`).

- **#406 — Stellar SDK upgrade procedure** (`routes-d/406-stellar-sdk-upgrade.mdx`): Documents pre-upgrade steps (pin version, read changelog, check protocol), a table of common API renames between major versions, the updated async Soroban submission flow, a manual smoke-test checklist, regression areas to watch, and a rollback plan.

## Test plan

- All files are plain MDX with no imports or custom components; should pass `pnpm build:content`.
- No new internal links added; `pnpm check:links` should be unaffected.
- Code samples are reference/illustration; CI is the authoritative build check.