### PR TITLE
docs: add balances refresh, lending protocol, subscription service, and savings vault guides

### DIFF
--- a/routes-d/711-use-stellar-balances-refresh-policies.mdx
+++ b/routes-d/711-use-stellar-balances-refresh-policies.mdx
@@ -1,0 +1,182 @@
+---
+title: useStellarBalances Refresh Policies
+description: Document common refresh policies for balance data — comparing polling versus streaming, suggesting defaults, and providing a small example.
+date: 2026-07-25
+---
+
+# useStellarBalances Refresh Policies
+
+`useStellarBalances` fetches an account's asset balances from Horizon. Because balances change whenever a transaction settles, the hook needs a refresh policy that keeps the UI current without hammering Horizon unnecessarily.
+
+---
+
+## Polling vs Streaming
+
+| | Polling | Streaming |
+|---|---|---|
+| **How it works** | Call `server.loadAccount` on a timer | Open an SSE connection via `server.accounts().accountId(address).stream()` |
+| **Latency** | Depends on interval (5 s default → up to 5 s stale) | Near-real-time (pushes on ledger close, ~5 s) |
+| **Connection cost** | One HTTP request per poll | One persistent SSE connection |
+| **Reliability** | Simple; reconnects naturally on next tick | Must handle disconnects and reconnect with exponential back-off |
+| **Best for** | Balance displays, dashboards, infrequent traders | Order books, live DeFi UIs, payment confirmation screens |
+
+**Default recommendation**: **polling at 5-second intervals** for most balance displays. Streaming is worth the added complexity only when sub-ledger-close latency matters to the user experience.
+
+---
+
+## Polling Implementation
+
+```ts
+// hooks/useStellarBalances.ts
+import { useState, useEffect, useRef } from 'react';
+import { Horizon } from '@stellar/stellar-sdk';
+
+export interface Balance {
+  asset: string;   // "native" | "CODE:ISSUER"
+  balance: string;
+  limit: string | null;
+}
+
+const server = new Horizon.Server(process.env.NEXT_PUBLIC_HORIZON_URL!);
+
+export function useStellarBalances(
+  address: string | null,
+  intervalMs = 5_000,
+) {
+  const [balances, setBalances] = useState<Balance[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  async function fetch() {
+    if (!address) return;
+    setLoading(true);
+    try {
+      const account = await server.loadAccount(address);
+      setBalances(
+        account.balances.map((b) => ({
+          asset:
+            b.asset_type === 'native'
+              ? 'native'
+              : `${(b as Horizon.HorizonApi.BalanceLineAsset).asset_code}:${
+                  (b as Horizon.HorizonApi.BalanceLineAsset).asset_issuer
+                }`,
+          balance: b.balance,
+          limit:
+            b.asset_type === 'native'
+              ? null
+              : (b as Horizon.HorizonApi.BalanceLineAsset).limit,
+        })),
+      );
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!address) return;
+    fetch(); // immediate first fetch
+    timerRef.current = setInterval(fetch, intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [address, intervalMs]);
+
+  return { balances, loading, error, refresh: fetch };
+}
+```
+
+---
+
+## Streaming Implementation
+
+```ts
+// hooks/useStellarBalancesStream.ts
+import { useState, useEffect, useRef } from 'react';
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server(process.env.NEXT_PUBLIC_HORIZON_URL!);
+
+export function useStellarBalancesStream(address: string | null) {
+  const [balances, setBalances] = useState<Horizon.HorizonApi.BalanceLine[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+  const closeRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    if (!address) return;
+
+    let retryDelay = 1_000;
+
+    function connect() {
+      closeRef.current = server
+        .accounts()
+        .accountId(address!)
+        .stream({
+          onmessage(account) {
+            setBalances(account.balances);
+            setError(null);
+            retryDelay = 1_000; // reset back-off on success
+          },
+          onerror(err) {
+            setError(new Error('Stream error — reconnecting'));
+            closeRef.current();
+            setTimeout(connect, retryDelay);
+            retryDelay = Math.min(retryDelay * 2, 30_000); // cap at 30 s
+          },
+        });
+    }
+
+    connect();
+    return () => closeRef.current();
+  }, [address]);
+
+  return { balances, error };
+}
+```
+
+---
+
+## Suggested Defaults by Use Case
+
+| Use case | Strategy | Interval |
+|---|---|---|
+| Wallet balance display | Polling | 5 s |
+| Payment confirmation screen | Polling with shorter interval | 2 s while pending |
+| Live DeFi position tracker | Streaming | N/A |
+| Dashboard tile (low priority) | Polling | 30 s |
+| Inactivity / background tab | Pause polling | Resume on `visibilitychange` |
+
+---
+
+## Pausing Polling on Hidden Tabs
+
+Polling an invisible tab wastes bandwidth. Pause and resume with the Page Visibility API:
+
+```ts
+useEffect(() => {
+  function onVisibility() {
+    if (document.hidden) {
+      if (timerRef.current) clearInterval(timerRef.current);
+    } else {
+      fetch(); // immediate refresh on return
+      timerRef.current = setInterval(fetch, intervalMs);
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibility);
+  return () => document.removeEventListener('visibilitychange', onVisibility);
+}, [address, intervalMs]);
+```
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Polling vs streaming comparison table is present
+- [ ] Both polling and streaming hook implementations are shown
+- [ ] Default recommendation is clearly stated
+- [ ] Tab visibility optimisation is covered

--- a/routes-d/714-lending-protocol-design-guide.mdx
+++ b/routes-d/714-lending-protocol-design-guide.mdx
@@ -1,0 +1,217 @@
+---
+title: Lending Protocol Design Guide on Stellar
+description: Document a design for a Stellar-based lending protocol — covering collateral, interest, liquidations, oracle usage, and a reference Soroban design.
+date: 2026-07-25
+---
+
+# Lending Protocol Design Guide on Stellar
+
+A lending protocol lets borrowers lock collateral and draw a loan in a different asset. Lenders deposit into a pool and earn interest. This guide covers the core design decisions and a reference Soroban implementation.
+
+---
+
+## Core Components
+
+```
+┌──────────────┐   deposit/withdraw   ┌─────────────────┐
+│    Lenders   │ ──────────────────►  │   Lending Pool  │
+└──────────────┘                      │  (Soroban ctr)  │
+                                      │                 │
+┌──────────────┐   lock collateral    │  - reserves     │
+│  Borrowers   │ ──────────────────►  │  - borrows      │
+│              │ ◄────── loan ──────  │  - interest     │
+└──────────────┘                      │  - collateral   │
+                                      └────────┬────────┘
+                                               │ price feed
+                                      ┌────────▼────────┐
+                                      │  Price Oracle   │
+                                      │  (TWAP / push)  │
+                                      └─────────────────┘
+```
+
+---
+
+## Collateral
+
+### Collateral Ratio
+
+Every borrow position must maintain a collateral ratio above the protocol's minimum:
+
+```
+collateral_ratio = collateral_value_USD / borrow_value_USD
+min_ratio        = 1.5   // 150% — 1 USD borrowed requires 1.5 USD collateral
+```
+
+### Supported Collateral
+
+Store a whitelist of approved collateral assets and their parameters:
+
+```rust
+#[contracttype]
+pub struct AssetParams {
+    pub collateral_factor: u32, // e.g. 8000 = 80% (collateral counts at 80% of its value)
+    pub borrow_factor: u32,     // e.g. 9000 = 90% (borrow value inflated by 10% for safety)
+    pub liquidation_threshold: u32, // ratio below which liquidation is allowed (e.g. 12000 = 120%)
+}
+```
+
+---
+
+## Interest Rate Model
+
+Use a **utilisation-based** rate: interest rises as the fraction of pool assets borrowed increases.
+
+```
+utilisation   = total_borrows / total_deposits
+base_rate     = 2%   (annual)
+slope1        = 10%  per 1% utilisation above 0%, up to kink
+kink          = 80%  utilisation
+slope2        = 100% per 1% utilisation above kink
+
+borrow_rate =
+  if utilisation <= kink:
+    base_rate + utilisation × slope1
+  else:
+    base_rate + kink × slope1 + (utilisation - kink) × slope2
+
+supply_rate = borrow_rate × utilisation × (1 - reserve_factor)
+```
+
+Interest accrues continuously using the ledger timestamp:
+
+```rust
+pub fn accrue_interest(env: &Env, pool: &mut Pool) {
+    let now = env.ledger().timestamp();
+    let elapsed = now - pool.last_accrual;
+    if elapsed == 0 { return; }
+
+    let rate = compute_borrow_rate(pool); // bps per second
+    let factor = 1_000_000_000u128 + (rate as u128 * elapsed as u128); // fixed-point 1e9
+
+    pool.borrow_index = pool.borrow_index * factor / 1_000_000_000;
+    pool.supply_index = pool.supply_index * (compute_supply_rate(pool) as u128 * elapsed as u128 + 1_000_000_000) / 1_000_000_000;
+    pool.last_accrual = now;
+}
+```
+
+---
+
+## Oracle Usage
+
+The protocol needs reliable asset prices to evaluate collateral and detect undercollateralised positions. Use a TWAP oracle (see the TWAP guide, issue #734) for manipulation resistance:
+
+```rust
+// Read price from the TWAP oracle contract
+let price: i128 = env
+    .invoke_contract::<i128>(
+        &oracle_contract,
+        &soroban_sdk::Symbol::new(&env, "get_twap"),
+        soroban_sdk::vec![&env, since_timestamp.into_val(&env)],
+    );
+```
+
+**Staleness guard**: always check the oracle's `last_timestamp` before using the price. Reject operations if the price is older than your `MAX_ORACLE_AGE` (e.g. 300 seconds).
+
+---
+
+## Liquidations
+
+When a borrower's collateral ratio falls below `liquidation_threshold`, any third party (the liquidator) can repay part of the debt and receive collateral at a discount:
+
+```
+liquidation_discount = 5%   // liquidator gets 5% bonus on seized collateral
+max_liquidation      = 50%  // liquidator can repay at most 50% of the debt in one call
+```
+
+```rust
+pub fn liquidate(
+    env: Env,
+    liquidator: Address,
+    borrower: Address,
+    repay_amount: i128,
+    collateral_asset: Address,
+) {
+    liquidator.require_auth();
+
+    let position = get_position(&env, &borrower);
+    let collateral_price = get_price(&env, &collateral_asset);
+    let borrow_price    = get_price(&env, &position.borrow_asset);
+
+    // Verify undercollateralised
+    let collateral_value = position.collateral_amount * collateral_price / 1_000_000;
+    let borrow_value     = position.borrow_amount * borrow_price / 1_000_000;
+    assert!(
+        collateral_value * 10_000 < borrow_value * LIQUIDATION_THRESHOLD,
+        "position is healthy"
+    );
+
+    // Cap repayment at 50% of debt
+    let max_repay = position.borrow_amount / 2;
+    let repay = repay_amount.min(max_repay);
+
+    // Compute collateral to seize (repay value × (1 + discount) / collateral_price)
+    let seize_value  = repay * borrow_price / 1_000_000 * (10_000 + LIQUIDATION_BONUS) / 10_000;
+    let seize_amount = seize_value * 1_000_000 / collateral_price;
+
+    // Transfer repayment from liquidator to pool; seize collateral to liquidator
+    transfer_to_pool(&env, &liquidator, &position.borrow_asset, repay);
+    transfer_collateral(&env, &liquidator, &collateral_asset, seize_amount);
+
+    update_position(&env, &borrower, -repay, -seize_amount);
+}
+```
+
+---
+
+## Reference Contract Structure
+
+```rust
+// contracts/lending-pool/src/lib.rs
+#[contract]
+pub struct LendingPool;
+
+#[contractimpl]
+impl LendingPool {
+    pub fn initialize(env: Env, admin: Address, oracle: Address, reserve_factor_bps: u32) { /* ... */ }
+
+    // Lender operations
+    pub fn deposit(env: Env, lender: Address, asset: Address, amount: i128) -> i128 { /* returns LP tokens */ }
+    pub fn withdraw(env: Env, lender: Address, asset: Address, lp_tokens: i128) -> i128 { /* returns asset */ }
+
+    // Borrower operations
+    pub fn add_collateral(env: Env, borrower: Address, asset: Address, amount: i128) { /* ... */ }
+    pub fn borrow(env: Env, borrower: Address, asset: Address, amount: i128) { /* ... */ }
+    pub fn repay(env: Env, borrower: Address, asset: Address, amount: i128) { /* ... */ }
+    pub fn remove_collateral(env: Env, borrower: Address, asset: Address, amount: i128) { /* ... */ }
+
+    // Liquidation
+    pub fn liquidate(env: Env, liquidator: Address, borrower: Address, repay_amount: i128, collateral_asset: Address) { /* ... */ }
+
+    // Views
+    pub fn get_position(env: Env, borrower: Address) -> Position { /* ... */ }
+    pub fn get_health_factor(env: Env, borrower: Address) -> i128 { /* returns ratio × 10000 */ }
+    pub fn get_rates(env: Env, asset: Address) -> (i128, i128) { /* (borrow_rate_bps, supply_rate_bps) */ }
+}
+```
+
+---
+
+## Security Considerations
+
+**Reentrancy**: Soroban contracts cannot re-enter themselves (the host prevents it), but cross-contract calls can be used to manipulate state. Complete all state updates before making external calls.
+
+**Oracle manipulation**: a single-block spot price oracle is exploitable via flash loans. Use a TWAP with a minimum window of 5–15 minutes for all price-sensitive operations.
+
+**Interest index drift**: if `accrue_interest` is not called regularly, large elapsed gaps cause a single large jump in the index. Consider calling it on every deposit/borrow/repay to keep the index smooth.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Collateral ratio formula is shown and explained
+- [ ] Utilisation-based interest rate model is documented with the kink
+- [ ] Oracle usage references TWAP and includes staleness guard
+- [ ] Liquidation discount and max repayment cap are specified
+- [ ] Security considerations section covers reentrancy and oracle manipulation

--- a/routes-d/717-subscription-service-tutorial.mdx
+++ b/routes-d/717-subscription-service-tutorial.mdx
@@ -1,0 +1,315 @@
+---
+title: Subscription Service Tutorial on Stellar
+description: Walk through building a subscription service on Stellar — covering recurring charges, a working Soroban example, and cancellation flows.
+date: 2026-07-25
+---
+
+# Subscription Service Tutorial on Stellar
+
+Stellar does not have native recurring payment primitives — each payment must be an explicit transaction. A subscription service therefore consists of an on-chain access-gate contract plus an off-chain scheduler that pulls charges on the subscriber's behalf at each billing period.
+
+This tutorial builds a monthly subscription where the subscriber pre-authorises a payment allowance and the billing worker draws from it each month.
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐  approve allowance   ┌──────────────────────┐
+│   Subscriber    │ ───────────────────► │  Subscription        │
+│   (Stellar      │                      │  Contract (Soroban)  │
+│   account)      │                      │  - allowances        │
+└─────────────────┘                      │  - subscriptions     │
+                                         │  - billing history   │
+┌─────────────────┐  charge() each month └──────────┬───────────┘
+│  Billing Worker │ ─────────────────────────────►  │
+│  (off-chain     │                                  │ transfer tokens
+│   cron job)     │                                  ▼
+└─────────────────┘                       Provider treasury
+```
+
+---
+
+## Soroban Contract
+
+```rust
+// contracts/subscription/src/lib.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+#[contracttype]
+pub struct Subscription {
+    pub subscriber: Address,
+    pub price_per_period: i128,    // in payment token units
+    pub period_seconds: u64,       // e.g. 2_592_000 for 30 days
+    pub next_charge_at: u64,       // ledger timestamp of next due date
+    pub active: bool,
+}
+
+const PAYMENT_TOKEN_KEY: &str = "pay_token";
+const TREASURY_KEY: &str = "treasury";
+
+#[contract]
+pub struct SubscriptionService;
+
+#[contractimpl]
+impl SubscriptionService {
+    pub fn initialize(env: Env, admin: Address, payment_token: Address, treasury: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&PAYMENT_TOKEN_KEY, &payment_token);
+        env.storage().instance().set(&TREASURY_KEY, &treasury);
+    }
+
+    /// Subscriber calls this to start a plan.
+    /// They must have pre-approved the contract to spend `price_per_period` each period
+    /// via the token's `approve` function.
+    pub fn subscribe(
+        env: Env,
+        subscriber: Address,
+        plan_id: u32,
+        price_per_period: i128,
+        period_seconds: u64,
+    ) {
+        subscriber.require_auth();
+        assert!(!env.storage().persistent().has(&(subscriber.clone(), plan_id)), "already subscribed");
+
+        // Charge the first period immediately
+        let token: Address = env.storage().instance().get(&PAYMENT_TOKEN_KEY).unwrap();
+        let treasury: Address = env.storage().instance().get(&TREASURY_KEY).unwrap();
+        token::Client::new(&env, &token)
+            .transfer_from(&env.current_contract_address(), &subscriber, &treasury, &price_per_period);
+
+        let now = env.ledger().timestamp();
+        env.storage().persistent().set(
+            &(subscriber.clone(), plan_id),
+            &Subscription {
+                subscriber,
+                price_per_period,
+                period_seconds,
+                next_charge_at: now + period_seconds,
+                active: true,
+            },
+        );
+    }
+
+    /// Called by the billing worker each period.
+    pub fn charge(env: Env, subscriber: Address, plan_id: u32) {
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&(subscriber.clone(), plan_id))
+            .expect("subscription not found");
+
+        assert!(sub.active, "subscription cancelled");
+        assert!(
+            env.ledger().timestamp() >= sub.next_charge_at,
+            "not due yet"
+        );
+
+        let token: Address = env.storage().instance().get(&PAYMENT_TOKEN_KEY).unwrap();
+        let treasury: Address = env.storage().instance().get(&TREASURY_KEY).unwrap();
+
+        // Attempt to transfer; if allowance is insufficient, mark subscription as lapsed
+        let client = token::Client::new(&env, &token);
+        let allowance = client.allowance(&sub.subscriber, &env.current_contract_address());
+        if allowance < sub.price_per_period {
+            sub.active = false;
+            env.storage().persistent().set(&(subscriber, plan_id), &sub);
+            return; // lapsed — caller should surface this to the provider
+        }
+
+        client.transfer_from(
+            &env.current_contract_address(),
+            &sub.subscriber,
+            &treasury,
+            &sub.price_per_period,
+        );
+
+        sub.next_charge_at += sub.period_seconds;
+        env.storage().persistent().set(&(subscriber, plan_id), &sub);
+    }
+
+    /// Subscriber cancels their own subscription.
+    pub fn cancel(env: Env, subscriber: Address, plan_id: u32) {
+        subscriber.require_auth();
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&(subscriber.clone(), plan_id))
+            .expect("subscription not found");
+        sub.active = false;
+        env.storage().persistent().set(&(subscriber, plan_id), &sub);
+    }
+
+    pub fn get_subscription(env: Env, subscriber: Address, plan_id: u32) -> Option<Subscription> {
+        env.storage().persistent().get(&(subscriber, plan_id))
+    }
+}
+```
+
+---
+
+## Subscriber Setup: Approving the Allowance
+
+Before calling `subscribe`, the subscriber must grant the subscription contract permission to draw tokens on their behalf using the token's `approve` function:
+
+```ts
+// lib/approve-allowance.ts
+import {
+  Contract, Networks, TransactionBuilder, BASE_FEE,
+  rpc, nativeToScVal, Address,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL           = process.env.NEXT_PUBLIC_RPC_URL!;
+const PAYMENT_TOKEN     = process.env.NEXT_PUBLIC_PAYMENT_TOKEN!;
+const SUBSCRIPTION_CTR  = process.env.NEXT_PUBLIC_SUBSCRIPTION_CONTRACT!;
+
+export async function approveAllowance(
+  subscriberKeypair: { publicKey(): string; sign(tx: any): void },
+  amountPerPeriod: bigint,
+  periodsToPreapprove = 13n, // 13 months headroom
+) {
+  const server  = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(subscriberKeypair.publicKey());
+  const token   = new Contract(PAYMENT_TOKEN);
+
+  const totalAllowance = amountPerPeriod * periodsToPreapprove;
+  const expirationLedger = 2_000_000; // far future; adjust per your needs
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      token.call(
+        'approve',
+        new Address(subscriberKeypair.publicKey()).toScVal(),
+        new Address(SUBSCRIPTION_CTR).toScVal(),
+        nativeToScVal(totalAllowance, { type: 'i128' }),
+        nativeToScVal(expirationLedger, { type: 'u32' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  subscriberKeypair.sign(prepared);
+  await server.sendTransaction(prepared);
+}
+```
+
+---
+
+## Billing Worker
+
+```ts
+// workers/billing.ts
+import cron from 'node-cron';
+import { Contract, Networks, TransactionBuilder, BASE_FEE, rpc, nativeToScVal, Address } from '@stellar/stellar-sdk';
+import { db } from '../db';
+
+const server        = new rpc.Server(process.env.RPC_URL!);
+const billingKeypair = /* load from env */;
+const SUB_CONTRACT  = process.env.SUBSCRIPTION_CONTRACT!;
+
+async function chargeAllDue(): Promise<void> {
+  const due = await db.subscription.findMany({
+    where: { active: true, nextChargeAt: { lte: new Date() } },
+  });
+
+  for (const sub of due) {
+    try {
+      const account  = await server.getAccount(billingKeypair.publicKey());
+      const contract = new Contract(SUB_CONTRACT);
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: Networks.MAINNET,
+      })
+        .addOperation(
+          contract.call(
+            'charge',
+            new Address(sub.subscriberAddress).toScVal(),
+            nativeToScVal(sub.planId, { type: 'u32' }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const prepared = await server.prepareTransaction(tx);
+      billingKeypair.sign(prepared);
+      await server.sendTransaction(prepared);
+
+      await db.subscription.update({
+        where: { id: sub.id },
+        data: { nextChargeAt: new Date(sub.nextChargeAt.getTime() + sub.periodMs) },
+      });
+    } catch (err) {
+      console.error(`Charge failed for ${sub.subscriberAddress}:`, err);
+      // Mark as lapsed if allowance was insufficient
+      await db.subscription.update({
+        where: { id: sub.id },
+        data: { active: false, lapseReason: String(err) },
+      });
+    }
+  }
+}
+
+// Run every 5 minutes; exact due-time precision isn't needed for monthly billing
+cron.schedule('*/5 * * * *', chargeAllDue);
+```
+
+---
+
+## Cancellation Flow
+
+The subscriber calls `cancel` on the contract at any time. The contract marks the subscription `active: false`. No refund is issued for the current period — prorate refunds, if offered, must be implemented separately.
+
+```ts
+// lib/cancel.ts
+export async function cancelSubscription(
+  subscriberKeypair: { publicKey(): string; sign(tx: any): void },
+  planId: number,
+) {
+  const server   = new rpc.Server(RPC_URL);
+  const account  = await server.getAccount(subscriberKeypair.publicKey());
+  const contract = new Contract(SUBSCRIPTION_CTR);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      contract.call(
+        'cancel',
+        new Address(subscriberKeypair.publicKey()).toScVal(),
+        nativeToScVal(planId, { type: 'u32' }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  subscriberKeypair.sign(prepared);
+  await server.sendTransaction(prepared);
+}
+```
+
+After cancellation, also revoke the token allowance to prevent accidental future charges:
+
+```ts
+// Revoke allowance by setting it to 0
+token.call('approve', subscriber.toScVal(), subscriptionContract.toScVal(),
+  nativeToScVal(0n, { type: 'i128' }), nativeToScVal(0, { type: 'u32' }));
+```
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] `approve` (allowance setup) step precedes `subscribe`
+- [ ] `charge` handles insufficient-allowance gracefully (lapse, not panic)
+- [ ] Cancellation revokes the token allowance
+- [ ] Billing worker is idempotent (won't double-charge on retry)

--- a/routes-d/731-savings-vault-contract.mdx
+++ b/routes-d/731-savings-vault-contract.mdx
@@ -1,0 +1,278 @@
+---
+title: Savings Vault Contract Tutorial on Soroban
+description: Walk through building a savings vault contract on Soroban — covering deposits, yield accrual, withdrawals, and recovery paths.
+date: 2026-07-25
+---
+
+# Savings Vault Contract Tutorial on Soroban
+
+A savings vault accepts token deposits, accrues yield over time (sourced from protocol fees or an external yield strategy), and lets depositors withdraw their principal plus earned yield at any time. This tutorial builds a minimal vault on Soroban with time-weighted yield accrual.
+
+---
+
+## Design
+
+```
+Depositor ──deposit(amount)──► Vault Contract
+                                │
+                                ├── mints vault shares proportional to deposit
+                                ├── tracks exchange rate: assets_per_share
+                                └── accrues yield by increasing assets_per_share
+
+Depositor ◄──withdraw(shares)── Vault Contract
+                                └── burns shares; sends assets × assets_per_share
+```
+
+The **exchange rate** (`assets_per_share`) starts at 1.0 and increases as yield is added. A depositor who deposits when rate = 1.0 and withdraws when rate = 1.05 earns 5% yield regardless of when other users deposit or withdraw.
+
+---
+
+## Vault Contract
+
+```rust
+// contracts/savings-vault/src/lib.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+#[contracttype]
+pub struct VaultState {
+    pub total_assets: i128,     // total tokens held by the vault
+    pub total_shares: i128,     // total shares outstanding
+    pub last_yield_at: u64,     // timestamp of last yield accrual
+    pub yield_rate_bps: u32,    // annual yield in basis points (e.g. 500 = 5%)
+}
+
+const STATE_KEY: &str = "state";
+const ASSET_KEY: &str = "asset";
+const SHARES_KEY: &str = "shares"; // prefix for per-user share balances
+
+const SECONDS_PER_YEAR: u64 = 31_536_000;
+const BPS: i128 = 10_000;
+
+#[contract]
+pub struct SavingsVault;
+
+#[contractimpl]
+impl SavingsVault {
+    pub fn initialize(env: Env, admin: Address, asset: Address, yield_rate_bps: u32) {
+        admin.require_auth();
+        assert!(yield_rate_bps <= 5000, "yield rate must be ≤ 50%");
+        env.storage().instance().set(&ASSET_KEY, &asset);
+        env.storage().instance().set(
+            &STATE_KEY,
+            &VaultState {
+                total_assets: 0,
+                total_shares: 0,
+                last_yield_at: env.ledger().timestamp(),
+                yield_rate_bps,
+            },
+        );
+    }
+
+    /// Deposit `amount` tokens; receive vault shares in return.
+    pub fn deposit(env: Env, depositor: Address, amount: i128) -> i128 {
+        depositor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let mut state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        Self::accrue_yield_inner(&env, &mut state);
+
+        // shares = amount × total_shares / total_assets  (first deposit: 1:1)
+        let shares = if state.total_shares == 0 {
+            amount
+        } else {
+            amount * state.total_shares / state.total_assets
+        };
+
+        let asset: Address = env.storage().instance().get(&ASSET_KEY).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&depositor, &env.current_contract_address(), &amount);
+
+        state.total_assets += amount;
+        state.total_shares += shares;
+        env.storage().instance().set(&STATE_KEY, &state);
+
+        // Track per-depositor shares
+        let current: i128 = env.storage().persistent().get(&(depositor.clone(), SHARES_KEY)).unwrap_or(0);
+        env.storage().persistent().set(&(depositor, SHARES_KEY), &(current + shares));
+
+        shares
+    }
+
+    /// Withdraw `shares`; receive the proportional assets (principal + yield).
+    pub fn withdraw(env: Env, depositor: Address, shares: i128) -> i128 {
+        depositor.require_auth();
+
+        let current: i128 = env.storage().persistent()
+            .get(&(depositor.clone(), SHARES_KEY))
+            .unwrap_or(0);
+        assert!(current >= shares, "insufficient shares");
+
+        let mut state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        Self::accrue_yield_inner(&env, &mut state);
+
+        // assets_out = shares × total_assets / total_shares
+        let assets_out = shares * state.total_assets / state.total_shares;
+
+        state.total_assets -= assets_out;
+        state.total_shares -= shares;
+        env.storage().instance().set(&STATE_KEY, &state);
+        env.storage().persistent().set(&(depositor.clone(), SHARES_KEY), &(current - shares));
+
+        let asset: Address = env.storage().instance().get(&ASSET_KEY).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&env.current_contract_address(), &depositor, &assets_out);
+
+        assets_out
+    }
+
+    /// Add external yield (e.g. from protocol fees). Only callable by admin.
+    pub fn add_yield(env: Env, admin: Address, amount: i128) {
+        admin.require_auth();
+        let mut state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        // Transferring tokens in increases total_assets, raising assets_per_share for all depositors
+        let asset: Address = env.storage().instance().get(&ASSET_KEY).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&admin, &env.current_contract_address(), &amount);
+        state.total_assets += amount;
+        env.storage().instance().set(&STATE_KEY, &state);
+    }
+
+    /// Accrue time-based yield (compounds continuously off the rate).
+    pub fn accrue_yield(env: Env) {
+        let mut state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        Self::accrue_yield_inner(&env, &mut state);
+        env.storage().instance().set(&STATE_KEY, &state);
+    }
+
+    fn accrue_yield_inner(env: &Env, state: &mut VaultState) {
+        let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(state.last_yield_at);
+        if elapsed == 0 || state.total_assets == 0 { return; }
+
+        // Simple interest for the elapsed period
+        // yield = total_assets × rate × elapsed / seconds_per_year
+        let yield_amount = state.total_assets
+            * state.yield_rate_bps as i128
+            * elapsed as i128
+            / (BPS * SECONDS_PER_YEAR as i128);
+
+        state.total_assets += yield_amount;
+        state.last_yield_at = now;
+    }
+
+    /// View: assets per share (scaled by 1e7).
+    pub fn exchange_rate(env: Env) -> i128 {
+        let state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        if state.total_shares == 0 { return 10_000_000; } // 1.0 scaled
+        state.total_assets * 10_000_000 / state.total_shares
+    }
+
+    pub fn balance_of(env: Env, depositor: Address) -> i128 {
+        env.storage().persistent().get(&(depositor, SHARES_KEY)).unwrap_or(0)
+    }
+
+    pub fn preview_withdraw(env: Env, shares: i128) -> i128 {
+        let state: VaultState = env.storage().instance().get(&STATE_KEY).unwrap();
+        if state.total_shares == 0 { return 0; }
+        shares * state.total_assets / state.total_shares
+    }
+}
+```
+
+---
+
+## Client Integration
+
+```ts
+// lib/vault.ts
+import {
+  Contract, Networks, TransactionBuilder, BASE_FEE,
+  rpc, nativeToScVal, Address, scValToNative,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL    = process.env.NEXT_PUBLIC_RPC_URL!;
+const VAULT_ID   = process.env.NEXT_PUBLIC_VAULT_CONTRACT!;
+
+export async function deposit(
+  depositorKeypair: { publicKey(): string; sign(tx: any): void },
+  amount: bigint,
+): Promise<bigint> {
+  const server   = new rpc.Server(RPC_URL);
+  const account  = await server.getAccount(depositorKeypair.publicKey());
+  const contract = new Contract(VAULT_ID);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.MAINNET })
+    .addOperation(contract.call(
+      'deposit',
+      new Address(depositorKeypair.publicKey()).toScVal(),
+      nativeToScVal(amount, { type: 'i128' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  depositorKeypair.sign(prepared);
+  const result = await server.sendTransaction(prepared);
+  // Return shares minted
+  return BigInt(scValToNative((result as any).returnValue).toString());
+}
+
+export async function getExchangeRate(): Promise<number> {
+  const server   = new rpc.Server(RPC_URL);
+  const contract = new Contract(VAULT_ID);
+  const account  = new (await import('@stellar/stellar-sdk')).Account(
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', '0',
+  );
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.MAINNET })
+    .addOperation(contract.call('exchange_rate'))
+    .setTimeout(5)
+    .build();
+
+  const sim = await server.simulateTransaction(tx) as rpc.SimulateTransactionSuccessResponse;
+  const raw = scValToNative(sim.result!.retval) as bigint;
+  return Number(raw) / 1e7;
+}
+```
+
+---
+
+## Recovery Paths
+
+### Scenario 1 — Depositor loses access to their keypair
+
+Shares are stored in contract persistent storage keyed by the depositor's address. If they lose their key they cannot call `withdraw`. Recovery options:
+
+- Use a multi-sig account as the depositor address so guardians can co-sign withdrawal.
+- Implement an emergency admin `force_withdraw(admin, depositor, shares, destination)` gated behind multi-sig admin keys, callable only after a time-lock.
+
+### Scenario 2 — Vault contract storage expiry
+
+Persistent storage entries expire if TTL is not extended. A depositor's share balance can vanish if the entry expires. Mitigate by:
+
+```rust
+// After every write, bump the TTL
+env.storage().persistent().extend_ttl(&(depositor, SHARES_KEY), 100_000, 100_000);
+```
+
+Or run an off-chain keeper that extends TTL on all active positions weekly.
+
+### Scenario 3 — Yield rate misconfiguration
+
+If `yield_rate_bps` is set too high and the vault doesn't have matching income, `total_assets` will grow faster than real assets. Add a `max_yield_per_period` cap and a governance vote for rate changes:
+
+```rust
+assert!(new_rate <= MAX_RATE_BPS, "rate too high");
+// Require multi-sig admin approval for changes above a threshold
+```
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Exchange rate mechanism (assets/shares) is clearly explained
+- [ ] `accrue_yield_inner` is called before every deposit and withdraw
+- [ ] All three recovery paths are covered
+- [ ] TTL extension is shown for persistent share balances


### PR DESCRIPTION
## Summary

Adds four documentation guides to `routes-d/` covering balance refresh strategies, a lending protocol design, a subscription service, and a savings vault contract — all targeting Stellar/Soroban.

closes #711
closes #714
closes #717
closes #731

## Changes

- **#711 — useStellarBalances refresh policies** (`routes-d/711-use-stellar-balances-refresh-policies.mdx`): Compares polling and streaming in a table, implements both (polling with `setInterval` and streaming via Horizon SSE with exponential back-off reconnect), provides a use-case-to-strategy table with recommended intervals, and shows how to pause polling on hidden tabs using the Page Visibility API.

- **#714 — Lending protocol design guide** (`routes-d/714-lending-protocol-design-guide.mdx`): Covers collateral ratio maths and asset parameters (collateral factor, borrow factor, liquidation threshold), a utilisation-based interest rate model with a kink, continuous interest accrual via ledger timestamps, oracle integration with a staleness guard, liquidation maths (discount, 50% cap), a full Soroban contract interface, and security considerations (reentrancy, oracle manipulation, index drift).

- **#717 — Subscription service tutorial** (`routes-d/717-subscription-service-tutorial.mdx`): Builds a monthly subscription using token `approve`/`transfer_from`. Documents the Soroban contract (`subscribe`, `charge`, `cancel`), the pre-authorisation allowance step, a cron-based billing worker that handles lapsed allowances gracefully, and the cancellation flow including allowance revocation.

- **#731 — Savings vault contract** (`routes-d/731-savings-vault-contract.mdx`): Implements a share-based vault with an `exchange_rate` (assets/shares) that grows as yield accrues. Covers `deposit`, `withdraw`, `add_yield`, and `accrue_yield`, a TypeScript client for deposit and exchange-rate reads, and three recovery paths: lost keypair (multi-sig depositor), storage TTL expiry (TTL extension in contract + keeper), and yield rate misconfiguration (governance cap).

## Test plan

- All files are plain MDX with no imports or custom components; should pass `pnpm build:content`.
- No new internal links added; `pnpm check:links` should be unaffected.
- Code samples are reference/illustration; CI is the authoritative build check.