### PR TITLE
docs: add fuzzing, P2P swap, badge reputation and deployment orchestration drafts (routes-d)

### DIFF
--- a/routes-d/744-soroban-contract-fuzzing.mdx
+++ b/routes-d/744-soroban-contract-fuzzing.mdx
@@ -1,0 +1,130 @@
+---
+title: Soroban Contract Fuzzing Guide
+description: Fuzz-test Soroban contracts with cargo-fuzz and proptest — tooling setup, input strategies that find real bugs, and a worked invariant-fuzzing example.
+---
+
+# Soroban Contract Fuzzing Guide
+
+Unit tests check the inputs you thought of. Fuzzing checks the ones you didn't — the `i128::MIN` amount, the zero-length symbol, the deposit-withdraw interleaving that corrupts an invariant on step 37. Because Soroban contracts are deterministic Rust with an in-process test environment, they fuzz unusually well: no network, no node, thousands of executions per second. This guide covers the tools, the input strategies worth encoding, and a complete example.
+
+---
+
+## Tooling
+
+| Tool | Style | When to use |
+|------|-------|-------------|
+| `cargo-fuzz` (libFuzzer) | Coverage-guided, raw bytes | Long-running bug hunts; finds panics and traps |
+| `proptest` | Property-based, typed strategies | Invariant checks that run inside `cargo test` |
+| `soroban-sdk` `arbitrary` feature | Derives `Arbitrary` for contract types | Feeding structured SDK values to either tool |
+
+The SDK ships first-class support: enabling the `testutils` feature gives you `Env::default()` in fuzz targets, and the `arbitrary` feature lets fuzzers generate valid `Address`es, `Symbol`s, and your own `#[contracttype]` values instead of noise bytes.
+
+```toml
+# fuzz/Cargo.toml
+[dependencies]
+libfuzzer-sys = "0.4"
+soroban-sdk = { version = "22", features = ["testutils", "arbitrary"] }
+```
+
+---
+
+## A Fuzz Target for a Token-Holding Contract
+
+Suppose a simple vault: `deposit(from, amount)` and `withdraw(to, amount)`, with the invariant that the contract's recorded total always equals the sum of individual balances.
+
+```rust
+// fuzz/fuzz_targets/vault_ops.rs
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use vault::{Vault, VaultClient};
+
+#[derive(arbitrary::Arbitrary, Debug)]
+enum Op {
+    Deposit { user: u8, amount: i128 },
+    Withdraw { user: u8, amount: i128 },
+}
+
+fuzz_target!(|ops: Vec<Op>| {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(Vault, ());
+    let client = VaultClient::new(&env, &id);
+
+    // Small fixed user pool so ops collide on the same accounts
+    let users: Vec<Address> = (0..4).map(|_| Address::generate(&env)).collect();
+
+    for op in ops {
+        match op {
+            Op::Deposit { user, amount } => {
+                let _ = client.try_deposit(&users[user as usize % 4], &amount);
+            }
+            Op::Withdraw { user, amount } => {
+                let _ = client.try_withdraw(&users[user as usize % 4], &amount);
+            }
+        }
+        // Invariant must hold after EVERY op, including rejected ones
+        let total = client.total();
+        let sum: i128 = users.iter().map(|u| client.balance(u)).sum();
+        assert_eq!(total, sum, "total diverged from sum of balances");
+    }
+});
+```
+
+Run it:
+
+```bash
+cargo +nightly fuzz run vault_ops -- -max_len=512
+```
+
+Two details do the heavy lifting: `try_` client variants let *rejected* calls continue the sequence (a rejected call that still mutated state is exactly the bug class you want), and the invariant is asserted after every operation, not just at the end.
+
+---
+
+## Input Strategies That Pay Off
+
+- **Sequences of operations, not single calls.** Most contract bugs are stateful. Fuzz `Vec<Op>` so the fuzzer explores interleavings.
+- **Small identity pools.** Four users hitting the same balances find aliasing bugs; thousands of unique users never collide.
+- **Boundary-heavy integers.** Coverage guidance finds these eventually, but you can help: in proptest, union uniform ranges with explicit `0`, `1`, `-1`, `i128::MAX`, `i128::MIN` cases.
+- **Let invalid inputs through.** Don't pre-filter negative amounts in the fuzz target — the contract must reject them itself; filtering hides missing validation.
+- **Fuzz auth boundaries separately.** Run one target with `mock_all_auths()` for logic bugs, and another mocking only specific users to catch missing `require_auth` calls.
+
+---
+
+## Property Tests for CI
+
+`cargo-fuzz` needs nightly and runs open-ended, so pair it with a bounded proptest that runs in every CI pass:
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn deposit_then_withdraw_is_identity(amount in 1i128..1_000_000_000) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = VaultClient::new(&env, &env.register(Vault, ()));
+        let user = Address::generate(&env);
+
+        client.deposit(&user, &amount);
+        client.withdraw(&user, &amount);
+        prop_assert_eq!(client.balance(&user), 0);
+    }
+}
+```
+
+Check the generated `proptest-regressions/` files into the repo — every past failure becomes a permanent regression test.
+
+---
+
+## Triage and Corpus Hygiene
+
+- Reproduce crashes with `cargo +nightly fuzz run vault_ops fuzz/artifacts/vault_ops/<crash-file>` — it replays a single input deterministically.
+- Minimize before debugging: `cargo fuzz tmin vault_ops <crash-file>`.
+- Keep the corpus (`fuzz/corpus/`) in CI cache so nightly runs resume where they left off rather than rediscovering the same coverage.
+
+---
+
+## Summary
+
+Fuzz Soroban contracts as sequences of typed operations against a small user pool, assert your invariants after every step, and let rejected calls flow through `try_` clients. cargo-fuzz hunts overnight; proptest keeps a bounded version of the same properties in CI; the regression corpus makes every found bug unrepeatable. For token-adjacent contracts, the total-equals-sum invariant above catches a remarkable share of real accounting bugs on its own.

--- a/routes-d/745-p2p-swap-dapp-tutorial.mdx
+++ b/routes-d/745-p2p-swap-dapp-tutorial.mdx
@@ -1,0 +1,159 @@
+---
+title: Peer-to-Peer Swap dApp Tutorial
+description: Build a small P2P asset swap dApp on Stellar — off-chain offer matching, atomic on-chain settlement through a Soroban swap contract, and the checks that keep both sides fraud-safe.
+---
+
+# Peer-to-Peer Swap dApp Tutorial
+
+This tutorial builds a small peer-to-peer swap dApp: Alice wants to trade 100 USDC for Bob's 500 XLM, directly, with no order book or intermediary custody. The design splits cleanly in two — **matching** happens off-chain (cheap, fast, revocable), while **settlement** happens in one atomic Soroban transaction (neither side can take the other's asset without giving up their own).
+
+---
+
+## Architecture
+
+```
+Maker UI ──create offer──▶ Offer store (your backend / shared db)
+                                 │  browse / accept
+Taker UI ◀───────────────────────┘
+    │ build settlement tx (both transfers)
+    ▼
+Swap contract ── transfer A→B and B→A atomically ──▶ Stellar network
+```
+
+Nothing is locked during matching: an offer is just signed intent. Funds only move inside the settlement transaction, and only both-or-neither.
+
+---
+
+## The Swap Contract
+
+One function does the entire settlement. Both parties' `require_auth` calls put both authorizations into a single transaction:
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct Swap;
+
+#[contractimpl]
+impl Swap {
+    /// Atomically swap `amount_a` of `token_a` (from `a`) for
+    /// `amount_b` of `token_b` (from `b`).
+    pub fn swap(
+        env: Env,
+        a: Address,
+        b: Address,
+        token_a: Address,
+        token_b: Address,
+        amount_a: i128,
+        amount_b: i128,
+    ) {
+        assert!(amount_a > 0 && amount_b > 0, "amounts must be positive");
+
+        // Both parties must have authorized THIS exact call
+        a.require_auth();
+        b.require_auth();
+
+        let ta = token::Client::new(&env, &token_a);
+        let tb = token::Client::new(&env, &token_b);
+
+        ta.transfer(&a, &b, &amount_a);
+        tb.transfer(&b, &a, &amount_b);
+    }
+}
+```
+
+Because both transfers execute in one invocation, a failure in either — insufficient balance, missing trustline, revoked authorization — rolls back the whole transaction. There is no state where one side has paid and the other hasn't. That atomicity *is* the fraud protection.
+
+---
+
+## Off-Chain Offers
+
+An offer is a plain record plus the maker's signature over its canonical form:
+
+```ts
+interface SwapOffer {
+  id: string;
+  maker: string;              // G... address
+  sellToken: string;          // token contract id
+  sellAmount: string;
+  buyToken: string;
+  buyAmount: string;
+  expiresAt: number;          // unix seconds
+}
+```
+
+The backend only stores and lists offers; it never touches funds, so a compromised backend can at worst show stale or fake offers — which settlement then rejects, because the maker never signs the corresponding transaction.
+
+---
+
+## Settlement Flow in the dApp
+
+The taker builds the contract invocation with both transfers, signs their part, and passes it to the maker for the counter-signature:
+
+```tsx
+import { useSorobanContract } from '@/hooks/useSorobanContract';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+
+export function AcceptOffer({ offer }: { offer: SwapOffer }) {
+  const { publicKey, connected } = useStellarWallet();
+  const { call } = useSorobanContract(SWAP_CONTRACT_ID);
+
+  const accept = async () => {
+    if (!connected || !publicKey) return;
+    if (offer.expiresAt * 1000 < Date.now()) {
+      throw new Error('offer expired');
+    }
+
+    // Invocation mirrors the offer exactly — any tampering with
+    // amounts or tokens invalidates the maker's auth entry.
+    await call('swap', [
+      offer.maker,        // a
+      publicKey,          // b (taker)
+      offer.sellToken,    // token_a
+      offer.buyToken,     // token_b
+      offer.sellAmount,   // amount_a
+      offer.buyAmount,    // amount_b
+    ]);
+  };
+
+  return <button onClick={accept}>Accept swap</button>;
+}
+```
+
+With Soroban auth, each party's wallet signs an authorization entry bound to the exact contract, function, and arguments. The maker can pre-sign their entry when creating the offer (with an expiration ledger), so the taker can settle unilaterally later — that is what makes the flow feel instant.
+
+---
+
+## Fraud-Avoidance Checklist
+
+- **Never settle from displayed data.** The taker's client must rebuild the invocation from the *signed* offer fields, not from UI state a malicious backend could have rewritten.
+- **Expirations everywhere.** Offers carry `expiresAt`, and pre-signed auth entries carry a signature expiration ledger, so stale intent cannot be replayed weeks later.
+- **One-shot offers.** Auth entries include a nonce, so a captured settlement transaction cannot be replayed to drain a maker twice.
+- **Price sanity in the UI.** Warn the taker when an offer deviates sharply from a reference price — atomicity protects against theft, not against agreeing to a bad deal.
+- **Trustline preflight.** Check both sides hold trustlines/balances before submitting; it converts a confusing on-chain failure into a clear UI message (settlement would have safely failed anyway).
+
+---
+
+## Trying It on Testnet
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/swap.wasm \
+  --source deployer --network testnet
+
+# Alice and Bob need testnet balances of the two tokens, then:
+stellar contract invoke --id <SWAP_ID> --source alice --network testnet \
+  -- swap --a <ALICE_G> --b <BOB_G> \
+  --token_a <USDC_CONTRACT> --token_b <XLM_SAC_CONTRACT> \
+  --amount_a 100_0000000 --amount_b 500_0000000
+```
+
+(For a two-signer invocation from the CLI you attach Bob's signature to the same transaction; in the dApp the wallets handle this exchange.)
+
+---
+
+## Summary
+
+Keep matching off-chain where it is free to create and cancel, and make settlement a single atomic contract call authorized by both parties over the exact swap terms. The contract stays ~30 lines, custody never leaves the users, and every fraud vector reduces to "the transaction simply fails."

--- a/routes-d/753-badge-reputation-tutorial.mdx
+++ b/routes-d/753-badge-reputation-tutorial.mdx
@@ -1,0 +1,189 @@
+---
+title: Badge-Based Reputation System Tutorial
+description: Build a badge-based reputation system on Soroban — authorized issuers, non-transferable badges, revocation with reasons, and patterns for portability across dApps.
+---
+
+# Badge-Based Reputation System Tutorial
+
+Reputation on-chain works best as **evidence, not scores**: instead of a single mutable number, accounts accumulate badges — "completed 10 escrows", "verified anchor partner", "hackathon winner" — each issued by a party whose word carries the weight. This tutorial builds a Soroban badge registry with controlled issuance, first-class revocation, and a shape other dApps can consume.
+
+Badges here are deliberately **non-transferable** (soulbound): a reputation you can sell is not a reputation.
+
+---
+
+## Data Model
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Badge {
+    pub kind: Symbol,        // e.g. "escrow_10", "kyc_tier1"
+    pub issuer: Address,
+    pub issued_at: u64,
+    pub revoked: bool,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Issuer(Address),           // is this address an authorized issuer?
+    Badges(Address),           // Vec<Badge> held by an account
+}
+```
+
+Revocation is a flag, not a deletion — a revoked badge remains visible history. Consumers decide whether "held then revoked" means something different from "never held" (for fraud signals, it usually does).
+
+---
+
+## Issuer Management
+
+The admin curates who may issue. Issuers are the trust root of the whole system, so this list should be short and public:
+
+```rust
+#[contract]
+pub struct BadgeRegistry;
+
+#[contractimpl]
+impl BadgeRegistry {
+    pub fn initialize(env: Env, admin: Address) {
+        assert!(
+            !env.storage().instance().has(&DataKey::Admin),
+            "already initialized"
+        );
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn set_issuer(env: Env, issuer: Address, allowed: bool) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Issuer(issuer), &allowed);
+    }
+
+    fn require_issuer(env: &Env, issuer: &Address) {
+        let ok: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Issuer(issuer.clone()))
+            .unwrap_or(false);
+        assert!(ok, "not an authorized issuer");
+        issuer.require_auth();
+    }
+}
+```
+
+---
+
+## Issuance
+
+```rust
+pub fn issue(env: Env, issuer: Address, holder: Address, kind: Symbol) {
+    Self::require_issuer(&env, &issuer);
+
+    let key = DataKey::Badges(holder.clone());
+    let mut badges: Vec<Badge> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(&env));
+
+    // One live badge per (kind, issuer) pair
+    for b in badges.iter() {
+        assert!(
+            !(b.kind == kind && b.issuer == issuer && !b.revoked),
+            "badge already held"
+        );
+    }
+
+    badges.push_back(Badge {
+        kind: kind.clone(),
+        issuer: issuer.clone(),
+        issued_at: env.ledger().timestamp(),
+        revoked: false,
+    });
+    env.storage().persistent().set(&key, &badges);
+
+    env.events()
+        .publish((Symbol::new(&env, "badge_issued"), holder, issuer), kind);
+}
+```
+
+The duplicate check keeps holders from farming the same credential; the event gives indexers a cheap way to build reputation views without walking storage.
+
+---
+
+## Revocation
+
+Only the original issuer (or the admin, as a safety valve) can revoke, and only their own badges:
+
+```rust
+pub fn revoke(env: Env, by: Address, holder: Address, kind: Symbol) {
+    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    if by != admin {
+        Self::require_issuer(&env, &by);
+    } else {
+        admin.require_auth();
+    }
+
+    let key = DataKey::Badges(holder.clone());
+    let mut badges: Vec<Badge> =
+        env.storage().persistent().get(&key).expect("no badges");
+
+    let mut found = false;
+    for i in 0..badges.len() {
+        let mut b = badges.get(i).unwrap();
+        if b.kind == kind && !b.revoked && (by == admin || b.issuer == by) {
+            b.revoked = true;
+            badges.set(i, b);
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "no matching live badge");
+    env.storage().persistent().set(&key, &badges);
+
+    env.events()
+        .publish((Symbol::new(&env, "badge_revoked"), holder, by), kind);
+}
+```
+
+---
+
+## Reading Reputation
+
+Consumers get the raw evidence and apply their own policy:
+
+```rust
+pub fn badges_of(env: Env, holder: Address) -> Vec<Badge> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Badges(holder))
+        .unwrap_or(Vec::new(&env))
+}
+
+pub fn has_live_badge(env: Env, holder: Address, kind: Symbol) -> bool {
+    Self::badges_of(env, holder)
+        .iter()
+        .any(|b| b.kind == kind && !b.revoked)
+}
+```
+
+A lending dApp might require `has_live_badge(user, "kyc_tier1")`; a marketplace might weight users by how many distinct issuers have badged them. The registry stays policy-free.
+
+---
+
+## Portability Considerations
+
+- **Shared registry, per-dApp policy.** Portability comes from many dApps reading one registry, not from moving badges. Publish the contract ID and the badge-kind vocabulary as part of your ecosystem docs.
+- **Issuer identity is the semantics.** `"kyc_tier1"` from an anchor means something; from an anonymous account it means nothing. Consumers must filter by issuer, which is why `Badge` carries the issuer inside it.
+- **Cross-contract reads are cheap.** Other Soroban contracts can call `has_live_badge` directly (via a contract client) to gate their own logic on-chain, not just in UIs.
+- **Don't put personal data in badges.** `kind` should encode a claim class, never identity details — the holder's address is already the join key, and ledgers are forever.
+- **Migration path.** If the registry must move (new contract ID), old badges can't be transferred by holders — the *issuers* re-attest into the new registry. Keeping issuance events indexed makes that replay mechanical.
+
+---
+
+## Summary
+
+The system is three small pieces: an admin-curated issuer set, append-only badges with revocation flags, and read functions that hand consumers evidence instead of verdicts. Non-transferability keeps reputation honest, events keep it indexable, and keeping policy out of the registry is what lets many dApps share it — which is where badge reputation actually becomes worth more than a score in one app's database.

--- a/routes-d/754-multi-contract-deployment-orchestration.mdx
+++ b/routes-d/754-multi-contract-deployment-orchestration.mdx
@@ -1,0 +1,121 @@
+---
+title: Multi-Contract Deployment Orchestration
+description: Orchestrate deployments of multiple dependent Soroban contracts — dependency ordering, configuration wiring, idempotent deploy scripts, and environment manifests.
+---
+
+# Multi-Contract Deployment Orchestration
+
+A real protocol is rarely one contract. A lending system might be a price oracle, a liquidity pool, a governance contract, and a router that ties them together — each needing the others' addresses at initialization. Deploy them in the wrong order, or wire a stale address, and you get a system that deploys "successfully" and fails on the first call. This guide covers ordering, configuration wiring, and building a deploy script you can run twice without breaking anything.
+
+---
+
+## Establish the Dependency Order
+
+Draw the graph before writing any script. An edge means "needs the other's address to initialize":
+
+```
+oracle          (no dependencies)
+  ▲
+pool            (needs oracle)
+  ▲
+router          (needs pool, oracle)
+  ▲
+governance      (needs router; becomes admin of everything)
+```
+
+Deploy in topological order — dependencies first. Two situations complicate it:
+
+- **Cycles** (A needs B, B needs A): break them by deploying one side with a placeholder and adding an admin-gated `set_dependency` call to patch it afterwards. Prefer redesigning so one side looks the other up through a registry instead.
+- **Late-bound admin**: it is normal (and good) for a governance contract deployed *last* to end up admin of contracts deployed *first*. Deploy with your deployer key as temporary admin, then transfer admin as the final step.
+
+---
+
+## Separate Deploy, Initialize, and Wire
+
+Treat each contract's rollout as three explicit phases rather than one blob:
+
+1. **Upload + deploy** — pure, produces an address, needs no configuration.
+2. **Initialize** — sets internal state (its own admin, its own parameters).
+3. **Wire** — tells contracts about each other (addresses, allowlists, roles).
+
+Keeping wiring separate is what makes partial failure recoverable: if step 7 of 9 fails, the addresses from steps 1–6 are still valid and reusable.
+
+---
+
+## A Worked Deploy Script
+
+A shell script with a manifest file keeps this auditable. Every produced address is written to `deploy.<network>.json` immediately, and every step checks the manifest before acting — making the whole script idempotent:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+NETWORK="${1:-testnet}"
+SOURCE="deployer"
+MANIFEST="deploy.${NETWORK}.json"
+[ -f "$MANIFEST" ] || echo '{}' > "$MANIFEST"
+
+get()  { jq -r ".$1 // empty" "$MANIFEST"; }
+save() { jq ".$1 = \"$2\"" "$MANIFEST" > "$MANIFEST.tmp" && mv "$MANIFEST.tmp" "$MANIFEST"; }
+
+deploy() { # deploy <name> <wasm-path>
+  local existing; existing=$(get "$1")
+  if [ -n "$existing" ]; then echo "$1 already deployed: $existing"; return; fi
+  local id
+  id=$(stellar contract deploy --wasm "$2" --source "$SOURCE" --network "$NETWORK")
+  save "$1" "$id"
+  echo "$1 deployed: $id"
+}
+
+# ── Phase 1: deploy in dependency order ─────────────────────
+deploy oracle     target/wasm32-unknown-unknown/release/oracle.wasm
+deploy pool       target/wasm32-unknown-unknown/release/pool.wasm
+deploy router     target/wasm32-unknown-unknown/release/router.wasm
+deploy governance target/wasm32-unknown-unknown/release/governance.wasm
+
+DEPLOYER_G=$(stellar keys address "$SOURCE")
+
+# ── Phase 2: initialize each contract ───────────────────────
+stellar contract invoke --id "$(get oracle)" --source "$SOURCE" --network "$NETWORK" \
+  -- initialize --admin "$DEPLOYER_G" || true   # safe: initialize rejects repeats
+
+stellar contract invoke --id "$(get pool)" --source "$SOURCE" --network "$NETWORK" \
+  -- initialize --admin "$DEPLOYER_G" --oracle "$(get oracle)" || true
+
+stellar contract invoke --id "$(get router)" --source "$SOURCE" --network "$NETWORK" \
+  -- initialize --admin "$DEPLOYER_G" --pool "$(get pool)" --oracle "$(get oracle)" || true
+
+# ── Phase 3: wire + hand over admin ─────────────────────────
+stellar contract invoke --id "$(get governance)" --source "$SOURCE" --network "$NETWORK" \
+  -- initialize --router "$(get router)" || true
+
+for c in oracle pool router; do
+  stellar contract invoke --id "$(get $c)" --source "$SOURCE" --network "$NETWORK" \
+    -- set_admin --new_admin "$(get governance)"
+done
+
+echo "Done. Manifest:"; cat "$MANIFEST"
+```
+
+The `|| true` on initialize calls relies on each contract's own "already initialized" guard — the on-chain check is the source of truth, the script just tolerates re-runs. Admin transfer runs last, after everything is proven wired, because it is the one step that locks the deployer out.
+
+---
+
+## Configuration Wiring Rules
+
+- **The manifest is the single source of addresses.** UIs, indexers, and tests read `deploy.<network>.json` (or a generated TS module); nobody hardcodes contract IDs.
+- **One manifest per network**, checked into the repo. Diffs on this file *are* your deployment history.
+- **Wire by invocation, not by constructor-only.** Contracts should expose admin-gated setters for their dependencies — it enables cycle-breaking, address rotation, and staged rollouts.
+- **Verify wiring explicitly** at the end: call a read function on each contract (`router.get_pool()`, `pool.get_oracle()`) and compare against the manifest before announcing the deploy.
+
+---
+
+## Upgrades Across the Set
+
+Orchestration doesn't end at first deploy. When one contract upgrades in place (same ID, new Wasm), dependents need no rewiring — that is the main reason to prefer upgradeable contracts over redeploy-and-repoint. When you *must* change an address, run the same phases in miniature: deploy new, initialize, wire dependents to it via their setters, verify, then retire the old one.
+
+---
+
+## Summary
+
+Topologically order the graph, split every contract's rollout into deploy → initialize → wire, record each address in a per-network manifest the moment it exists, and make every step check state before acting. The result is a deploy script that is boring to run — which, for the step that puts your whole protocol on-chain, is exactly the goal.


### PR DESCRIPTION
## Summary
Adds four documentation drafts to the `routes-d` staging folder, one per assigned issue: a Soroban contract fuzzing guide, a peer-to-peer swap dApp tutorial, a badge-based reputation system tutorial, and a multi-contract deployment orchestration guide. All drafts follow the folder's `<issue>-<slug>.mdx` naming convention and match the frontmatter and section style of previously merged routes-d drafts.

closes #744
closes #745
closes #753
closes #754

## Changes
- **#744 — Soroban contract fuzzing**: `routes-d/744-soroban-contract-fuzzing.mdx` covers the applicable tooling (`cargo-fuzz`, `proptest`, the SDK's `arbitrary` feature), input strategies that find stateful bugs (operation sequences, small identity pools, boundary-heavy integers, letting invalid inputs through, separate auth-boundary targets), a complete libFuzzer target that fuzzes a vault's deposit/withdraw interleavings while asserting a total-equals-sum invariant after every op, a bounded proptest for CI, and crash triage/corpus workflow.
- **#745 — peer-to-peer swap dApp**: `routes-d/745-p2p-swap-dapp-tutorial.mdx` splits the design into off-chain matching (signed offers in a custody-free backend) and atomic on-chain settlement via a ~30-line Soroban swap contract with dual `require_auth`, walks through the taker-side settlement component using `useSorobanContract`/`useStellarWallet`, includes testnet CLI steps, and closes with a fraud-avoidance checklist (rebuild invocation from signed offer fields, expirations, auth nonces, price sanity warnings, trustline preflight).
- **#753 — badge-based reputation system**: `routes-d/753-badge-reputation-tutorial.mdx` builds a soulbound badge registry: admin-curated issuer set, issuance with per-(kind, issuer) duplicate guards and indexer events, revocation as a flag (visible history) restricted to the original issuer or admin, policy-free read functions (`badges_of`, `has_live_badge`), and a portability section on shared registries, issuer-anchored semantics, cross-contract reads, and issuer re-attestation as the migration path.
- **#754 — multi-contract deployment orchestration**: `routes-d/754-multi-contract-deployment-orchestration.mdx` covers topological dependency ordering (including cycle-breaking and late-bound governance admin), separating deploy/initialize/wire phases, a full idempotent bash deploy script with a per-network JSON manifest as the single source of contract addresses, wiring rules, end-of-deploy verification, and how upgrades interact with the wired set.

## Test plan
- Fuzzing guide's SDK feature flags and client `try_` semantics checked against soroban-sdk 22.x conventions; script in #754 reviewed for idempotency (re-run safe: manifest checks before deploy, `initialize` guarded on-chain).
- Hook names and usage in #745 match the existing hook docs under `docs/hooks/`.
- Drafts live in `routes-d/`, outside `contentlayer`'s `contentDirPath: 'docs'`, so `pnpm build:content` output is unaffected; frontmatter matches the docs schema for later promotion.

---
Note: `pnpm build:content` and `pnpm check:links` fail on a clean checkout of `main` for pre-existing reasons unrelated to this PR; these changes add files only under `routes-d/`.