### PR TITLE
docs: add asset selection UX and Soroban composability drafts (routes-d)

### DIFF
--- a/routes-d/712-user-friendly-asset-selection.mdx
+++ b/routes-d/712-user-friendly-asset-selection.mdx
@@ -1,0 +1,177 @@
+---
+title: User-Friendly Asset Selection
+description: Build an asset selection UI for Stellar dApps — curated lists plus search, issuer validation against homedomain TOML data, and a working picker component.
+---
+
+# User-Friendly Asset Selection
+
+On Stellar, an asset is a code **plus an issuer** — `USDC` from Circle's issuer and `USDC` from a scam account are entirely different assets that render identically if your UI only shows the code. A good asset selector therefore has two jobs: make the common choice effortless, and make the dangerous choice visibly dangerous. This guide covers data sources, validation, and a working picker component.
+
+---
+
+## Data Sources
+
+| Source | What it gives you | Trust level |
+|--------|-------------------|-------------|
+| Curated list (your app's config) | Handful of vetted assets with logos | High — you vetted them |
+| User's own trustlines | Assets the account already holds | High — user opted in already |
+| Horizon `/assets?asset_code=` | Every asset matching a code, with holder counts | Low — anyone can issue any code |
+| Issuer's `stellar.toml` (home domain) | Self-published metadata: name, logo, org | Medium — proves domain control |
+
+Layer them: curated list first, the user's existing trustlines second, and open Horizon search only behind an explicit "find other assets" action.
+
+```ts
+// curated-assets.ts
+export interface CuratedAsset {
+  code: string;
+  issuer: string;
+  name: string;
+  logo?: string;
+}
+
+export const CURATED: CuratedAsset[] = [
+  { code: 'XLM',  issuer: 'native', name: 'Stellar Lumens' },
+  { code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN', name: 'USD Coin' },
+];
+```
+
+---
+
+## Search with Validation
+
+When the user searches beyond the curated set, query Horizon and immediately enrich each candidate with signals a human can judge:
+
+```ts
+const HORIZON = 'https://horizon-testnet.stellar.org';
+
+export interface AssetCandidate {
+  code: string;
+  issuer: string;
+  holders: number;
+  homeDomain?: string;
+  verified: boolean;   // TOML at home domain lists this asset
+}
+
+export async function searchAssets(code: string): Promise<AssetCandidate[]> {
+  const res = await fetch(
+    `${HORIZON}/assets?asset_code=${encodeURIComponent(code)}&limit=20`,
+  );
+  const { _embedded } = await res.json();
+
+  return Promise.all(
+    _embedded.records.map(async (r: any) => {
+      const homeDomain = await fetchHomeDomain(r.asset_issuer);
+      return {
+        code: r.asset_code,
+        issuer: r.asset_issuer,
+        holders: Number(r.accounts?.authorized ?? 0),
+        homeDomain,
+        verified: homeDomain
+          ? await tomlListsAsset(homeDomain, r.asset_code, r.asset_issuer)
+          : false,
+      };
+    }),
+  );
+}
+
+async function fetchHomeDomain(issuer: string): Promise<string | undefined> {
+  const res = await fetch(`${HORIZON}/accounts/${issuer}`);
+  if (!res.ok) return undefined;
+  return (await res.json()).home_domain || undefined;
+}
+
+async function tomlListsAsset(domain: string, code: string, issuer: string) {
+  try {
+    const res = await fetch(`https://${domain}/.well-known/stellar.toml`);
+    const text = await res.text();
+    // A currency entry must name both the code and this exact issuer
+    return text.includes(code) && text.includes(issuer);
+  } catch {
+    return false;
+  }
+}
+```
+
+The `verified` flag is the key signal: the issuer's home domain serving a `stellar.toml` that lists this exact code+issuer pair proves whoever controls that domain claims the asset. Combined with holder counts, users get a fast heuristic — verified + many holders is probably the asset they meant; unverified + 3 holders deserves a warning banner.
+
+---
+
+## The Picker Component
+
+```tsx
+import { useState } from 'react';
+import { useTrustlines } from '@/hooks/useTrustlines';
+import { CURATED } from './curated-assets';
+
+export function AssetPicker({
+  publicKey,
+  onSelect,
+}: {
+  publicKey: string;
+  onSelect: (a: { code: string; issuer: string }) => void;
+}) {
+  const { trustlines } = useTrustlines(publicKey);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<AssetCandidate[]>([]);
+
+  const held = trustlines.map((t) => ({
+    code: t.asset_code,
+    issuer: t.asset_issuer,
+  }));
+
+  const search = async () => setResults(await searchAssets(query.trim().toUpperCase()));
+
+  return (
+    <div>
+      <h4>Popular</h4>
+      {CURATED.map((a) => (
+        <button key={a.code + a.issuer} onClick={() => onSelect(a)}>
+          {a.name} ({a.code})
+        </button>
+      ))}
+
+      <h4>Your assets</h4>
+      {held.length === 0 ? (
+        <p>No trustlines yet — only XLM available.</p>
+      ) : (
+        held.map((a) => (
+          <button key={a.code + a.issuer} onClick={() => onSelect(a)}>
+            {a.code} · {a.issuer.slice(0, 4)}…{a.issuer.slice(-4)}
+          </button>
+        ))
+      )}
+
+      <h4>Find other assets</h4>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Asset code, e.g. USDC"
+      />
+      <button onClick={search} disabled={query.trim().length === 0}>Search</button>
+
+      {results.map((r) => (
+        <button key={r.code + r.issuer} onClick={() => onSelect(r)}>
+          {r.code} · {r.homeDomain ?? 'no domain'} · {r.holders.toLocaleString()} holders
+          {r.verified ? ' ✓ verified' : ' ⚠ unverified'}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+---
+
+## UX Rules Worth Keeping
+
+- **Always show the issuer** (truncated) next to the code everywhere an asset appears — it is the only unambiguous identity.
+- **Never auto-select a search result.** Search populates choices; the user confirms one, seeing domain, holders, and verification state at the moment of choice.
+- **Warn, don't block, on unverified assets** — but require an extra confirmation step before building a trustline to one.
+- **Normalize input**: uppercase the code, trim whitespace, and validate against the 1–12 alphanumeric constraint before ever calling Horizon.
+- **Cache TOML lookups** (per issuer, ~1h) — they are slow, and pickers re-render often.
+
+---
+
+## Summary
+
+Curated assets for the 95% case, the user's own trustlines for continuity, and validated open search for the long tail — with issuer identity and TOML-backed verification visible at every step. The picker's real product is not the list; it is the confidence that the `USDC` the user tapped is the `USDC` they meant.

--- a/routes-d/722-soroban-composability-patterns.mdx
+++ b/routes-d/722-soroban-composability-patterns.mdx
@@ -1,0 +1,129 @@
+---
+title: Soroban Composability Patterns
+description: Patterns for composing Soroban contracts — typed cross-contract clients, interface-based composition with contractimport, registry indirection, and how upgrades ripple through composed systems.
+---
+
+# Soroban Composability Patterns
+
+Soroban contracts compose by invocation: any contract can call any other, synchronously, inside one atomic transaction. The interesting decisions are about *coupling* — whether a caller names its dependency at compile time, holds it as swappable configuration, or looks it up at runtime. This guide compares the composition patterns, shows a working example, and traces what each choice means when contracts start upgrading.
+
+---
+
+## The Three Coupling Levels
+
+| Pattern | Dependency known at… | Swappable? | Typical use |
+|---|---|---|---|
+| `contractimport!` typed client | Compile time (interface), init time (address) | By admin setter | Calling a known protocol (token, oracle) |
+| Interface-only (`contractclient` trait) | Compile time (interface only) | Freely — any implementer | Plugins, strategies, adapters |
+| Registry indirection | Runtime lookup | Centrally | Ecosystems with many interchangeable parts |
+
+---
+
+## Typed Clients from an Interface
+
+The cleanest composition is against an **interface, not an implementation**. Define the trait with `#[contractclient]`, and any contract satisfying it becomes a valid dependency:
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractclient, contractimpl, Address, Env, Symbol};
+
+// The interface this contract composes against
+#[contractclient(name = "OracleClient")]
+pub trait PriceOracle {
+    fn price(env: Env, asset: Symbol) -> i128;
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Oracle,
+}
+
+#[contract]
+pub struct Lending;
+
+#[contractimpl]
+impl Lending {
+    pub fn set_oracle(env: Env, oracle: Address) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Oracle, &oracle);
+    }
+
+    pub fn collateral_value(env: Env, asset: Symbol, amount: i128) -> i128 {
+        let oracle: Address = env.storage().instance().get(&DataKey::Oracle).unwrap();
+        let price = OracleClient::new(&env, &oracle).price(&asset);
+        price * amount / 10_000_000 // 7-decimal price
+    }
+}
+```
+
+`Lending` never names a concrete oracle contract — any deployment whose `price` matches the signature works, and the admin can repoint `set_oracle` to a better oracle later without touching this contract's code. This is dependency injection, on-chain.
+
+For composing against a contract whose Wasm you have (e.g., the standard token), `contractimport!` generates the same style of typed client from the binary:
+
+```rust
+mod token {
+    soroban_sdk::contractimport!(file = "../wasm/soroban_token_contract.wasm");
+}
+// token::Client::new(&env, &token_address).transfer(...)
+```
+
+---
+
+## Atomicity Is the Superpower
+
+A composed call chain — user → router → pool → token — is one transaction. If the deepest call traps, every intermediate state change unwinds. That means you can compose aggressively without writing compensation logic: a swap that takes payment, updates pool state, and pays out either fully happens or fully doesn't.
+
+Two costs come with it:
+
+- **Auth flows through the tree.** `require_auth` works at any depth, but the user signs authorization entries describing the exact sub-invocations. Deep or dynamic call trees make wallet prompts harder to render meaningfully — keep user-authorized paths shallow.
+- **Budgets are shared.** CPU/memory limits apply to the whole transaction; each hop spends from the same budget. Chains more than a few contracts deep deserve load testing against realistic state.
+
+---
+
+## Registry Indirection
+
+When many contracts need many others, pairwise wiring becomes O(n²) admin churn. A registry contract centralizes it:
+
+```rust
+#[contractimpl]
+impl Registry {
+    pub fn resolve(env: Env, name: Symbol) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Entry(name))
+            .expect("unknown component")
+    }
+    // admin-gated set(name, address) elided
+}
+```
+
+Callers hold one address (the registry) and resolve `Symbol`-named components per call. The tradeoff is explicit: one lookup of extra cost per interaction and a high-value admin surface — registry governance *is* protocol governance, so gate writes accordingly (multisig or a governance contract, plus events on every change).
+
+---
+
+## Upgrade Impacts
+
+Composition and upgrades interact in exactly two ways, and knowing which one you're in tells you what breaks:
+
+**In-place upgrade (same contract ID, new Wasm).** Callers notice nothing — addresses they hold stay valid. The upgraded contract must keep its exported interface *source-compatible*: removing a function or changing a signature breaks every composed caller at runtime, at call time, with no compile error anywhere. Treat exported interfaces like public APIs: additive changes only, or version the function (`price_v2`) alongside the old one.
+
+**Redeploy at a new address.** Every dependent must be repointed. This is where the earlier patterns pay off or don't:
+
+- Typed-client contracts with admin setters: one `set_oracle` call per dependent.
+- Registry-based systems: one registry update fixes every caller at once.
+- Hardcoded addresses (the anti-pattern): a coordinated redeploy of everything downstream.
+
+A practical checklist when upgrading a contract others compose with:
+
+- [ ] Diff the exported interface against the previous Wasm — additions only.
+- [ ] Keep storage readable by the new code (see the upgrade-safety guidance).
+- [ ] If behavior changes semantically (units, rounding, auth expectations), publish a new function name or address rather than silently changing the old one.
+- [ ] Emit an event on upgrade so composed protocols' indexers can flag the change.
+
+---
+
+## Summary
+
+Compose against traits with `#[contractclient]`, hold dependency addresses as admin-swappable state, and add registry indirection only when pairwise wiring stops scaling. Lean on transaction atomicity instead of compensation logic, keep user-authorized call paths shallow, and treat every exported function as a forever-API — because in a composed ecosystem, your interface is somebody else's compile-time assumption running against your runtime behavior.


### PR DESCRIPTION
## Summary
Adds two documentation drafts to the `routes-d` staging folder: a guide on building a user-friendly asset selection UI and a comprehensive guide on Soroban composability patterns. Both follow the folder's `<issue>-<slug>.mdx` naming convention and match the frontmatter and section style of the merged drafts already there.

closes #712
closes #722

## Changes
- **#712 — user-friendly asset selection**: `routes-d/712-user-friendly-asset-selection.mdx` covers layered data sources (curated list → user's own trustlines via `useTrustlines` → Horizon `/assets` open search), validation of search results by enriching candidates with holder counts, issuer home domain, and a `stellar.toml` verification check that the domain actually lists the exact code+issuer pair, a working `AssetPicker` React component wiring all three layers together, and UX rules (always show the issuer, never auto-select search results, warn-don't-block on unverified assets, normalize/validate codes before querying, cache TOML lookups).
- **#722 — Soroban composability patterns**: `routes-d/722-soroban-composability-patterns.mdx` compares the three coupling levels (typed clients via `contractimport!`, interface-based composition with `#[contractclient]` traits, and registry indirection), includes a working lending-contract example that composes against a `PriceOracle` trait with an admin-swappable oracle address, explains what transaction atomicity buys in composed call chains and its costs (auth entry depth, shared CPU/memory budgets), and details upgrade impacts for both in-place upgrades (interface source-compatibility, additive-only changes) and redeploys at new addresses (repointing cost under each pattern), with a pre-upgrade checklist.

## Test plan
- Hook usage in #712 matches the API reference in `docs/hooks/use-trustlines.mdx` (return shape, parameters); Horizon endpoints and `stellar.toml` well-known path checked against Stellar public docs.
- `#[contractclient]` / `contractimport!` usage in #722 follows soroban-sdk conventions used in existing merged routes-d drafts.
- Drafts live in `routes-d/`, outside `contentlayer`'s `contentDirPath: 'docs'`, so `pnpm build:content` output is unaffected; frontmatter matches the docs schema for later promotion.

---
Note: `pnpm build:content` and `pnpm check:links` fail on a clean checkout of `main` for pre-existing reasons unrelated to this PR; these changes add files only under `routes-d/`.