### PR TITLE
docs: add first-account CLI, trustlines, payment app and order book drafts (routes-d)

### DIFF
--- a/routes-d/380-first-stellar-account-cli.mdx
+++ b/routes-d/380-first-stellar-account-cli.mdx
@@ -1,0 +1,122 @@
+---
+title: Creating Your First Stellar Account via the CLI
+description: A start-to-finish testnet walkthrough — generate a keypair with the Stellar CLI, fund it through Friendbot, and verify the account on Horizon.
+---
+
+# Creating Your First Stellar Account via the CLI
+
+A Stellar "account" doesn't exist until it holds lumens: you generate a keypair locally, and the account springs into existence on the ledger the moment something funds its public key. This tutorial walks that whole arc on **testnet** — generate, fund, verify — using the [Stellar CLI](https://developers.stellar.org/docs/tools/cli). Everything here is safe to repeat; testnet lumens are free and reset periodically.
+
+---
+
+## Prerequisites
+
+Install the Stellar CLI:
+
+```bash
+# macOS
+brew install stellar-cli
+
+# or via cargo on any platform
+cargo install --locked stellar-cli
+
+stellar --version
+```
+
+---
+
+## Step 1 — Generate a Keypair
+
+```bash
+stellar keys generate alice --network testnet
+```
+
+This creates an identity named `alice` in the CLI's local keystore. Print its public key (safe to share — it *is* your address):
+
+```bash
+stellar keys address alice
+# GDKX... (56 characters, starts with G)
+```
+
+The secret key (starts with `S`) stays in the keystore. You can reveal it with `stellar keys show alice`, but on testnet you rarely need to — and building the habit of never printing secrets serves you well on mainnet.
+
+> `stellar keys generate` with `--network testnet` funds the account automatically by default. The steps below fund explicitly anyway — it is the part you'll actually need to understand on mainnet, where funding comes from a real payment instead of a faucet.
+
+---
+
+## Step 2 — Fund It with Friendbot
+
+An unfunded keypair is just math; the ledger has no record of it yet. On testnet, Friendbot creates the account with 10,000 test XLM:
+
+```bash
+stellar keys fund alice --network testnet
+```
+
+(Equivalently: `curl "https://friendbot.stellar.org/?addr=$(stellar keys address alice)"`.)
+
+This is the step that executes a `create_account` operation under the hood — the same operation a wallet or exchange performs when it first sends XLM to a new address on mainnet.
+
+---
+
+## Step 3 — Verify the Account Exists
+
+Query Horizon, Stellar's API server, directly:
+
+```bash
+curl -s "https://horizon-testnet.stellar.org/accounts/$(stellar keys address alice)" \
+  | jq '{ id, sequence, balances }'
+```
+
+Expected output:
+
+```json
+{
+  "id": "GDKX...",
+  "sequence": "1750342533513216",
+  "balances": [
+    {
+      "balance": "10000.0000000",
+      "asset_type": "native"
+    }
+  ]
+}
+```
+
+Three things worth noticing:
+
+- **`balances`** — one entry, `native` (XLM). Other assets appear here only after you create trustlines.
+- **`sequence`** — every account carries a sequence number; each transaction it submits increments it. Fresh accounts start at a value derived from the ledger that created them.
+- Before funding, this same request returns **`404 Not Found`** — a useful reminder that "account" means "funded entry on the ledger", not "keypair".
+
+---
+
+## Step 4 — Prove It Works: Send a Payment
+
+Create a second account and move lumens between them:
+
+```bash
+stellar keys generate bob --network testnet
+stellar keys fund bob --network testnet
+
+stellar tx new payment \
+  --source alice \
+  --destination "$(stellar keys address bob)" \
+  --amount 250_0000000 \
+  --network testnet
+```
+
+Amounts are in **stroops** — ten-millionths of an XLM, i.e. 7 decimal places — so `250_0000000` is 250 XLM. Re-check Bob's balance:
+
+```bash
+curl -s "https://horizon-testnet.stellar.org/accounts/$(stellar keys address bob)" \
+  | jq '.balances[0].balance'
+# "10250.0000000"
+```
+
+---
+
+## Where This Leads
+
+- **Minimum balance:** accounts must keep a base reserve (currently 1 XLM total for a bare account: 2 × 0.5 XLM base reserve). Every trustline, offer, and signer adds 0.5 XLM to the requirement — this is why you can't send your *entire* balance away.
+- **Mainnet difference:** identical flow, except funding comes from a real XLM transfer instead of Friendbot, and `--network testnet` becomes `--network mainnet`. Secrets become real money — store them accordingly.
+- **Next steps:** with a funded testnet account you can create trustlines, place DEX offers, and invoke Soroban contracts — every other tutorial in these docs starts where this one ends.

--- a/routes-d/383-trustline-creation-flow.mdx
+++ b/routes-d/383-trustline-creation-flow.mdx
@@ -1,0 +1,125 @@
+---
+title: Trustline Creation Flow with useTrustlines
+description: Walk through creating a trustline with the useTrustlines hook — building the change-trust XDR, wallet signing, reserve implications, and a complete working component.
+---
+
+# Trustline Creation Flow with useTrustlines
+
+Stellar accounts can only hold assets they have explicitly opted into. That opt-in is a **trustline** — a ledger entry created by a `change_trust` operation that says "this account accepts asset X from issuer Y, up to limit L". The `useTrustlines` hook wraps the whole flow: querying what the account already trusts, building the change-trust transaction as unsigned XDR, and refreshing after the wallet submits it. This guide walks the full creation flow.
+
+---
+
+## The Flow at a Glance
+
+```
+useTrustlines(publicKey)
+   │ buildChangeTrustXDR({ code, issuer, limit? })
+   ▼
+unsigned XDR ──▶ wallet signs ──▶ network ──▶ refresh()
+                                               │
+                                trustlines now includes the asset
+```
+
+The hook deliberately stops at unsigned XDR: signing belongs to the user's wallet. (There is a `submitChangeTrustWithSecret` variant for test scripts — never use it with real keys in a UI.)
+
+---
+
+## Building the Change-Trust Call
+
+```tsx
+import { useTrustlines } from '@/hooks/useTrustlines';
+
+const USDC = {
+  code: 'USDC',
+  issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+};
+
+export function AddTrustline({ publicKey }: { publicKey: string }) {
+  const { trustlines, loading, error, refresh, buildChangeTrustXDR } =
+    useTrustlines(publicKey);
+
+  const alreadyTrusted = trustlines.some(
+    (t) => t.asset_code === USDC.code && t.asset_issuer === USDC.issuer,
+  );
+
+  const addTrustline = async () => {
+    // 1. Build the unsigned change-trust transaction
+    const xdr = await buildChangeTrustXDR({
+      code: USDC.code,
+      issuer: USDC.issuer,
+      limit: '10000', // optional — omit for the maximum
+    });
+
+    // 2. Hand it to the connected wallet for signing + submission
+    //    (Freighter shown; any wallet that accepts XDR works)
+    const signed = await window.freighterApi.signTransaction(xdr, {
+      network: 'TESTNET',
+    });
+    await submitToHorizon(signed); // your submit helper
+
+    // 3. Re-query so the UI reflects the new trustline
+    await refresh();
+  };
+
+  if (loading) return <p>Loading trustlines…</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return alreadyTrusted ? (
+    <p>✓ USDC trustline active</p>
+  ) : (
+    <button onClick={addTrustline}>Enable USDC</button>
+  );
+}
+```
+
+The `alreadyTrusted` guard matters: submitting a change-trust for an existing trustline isn't harmful (it just updates the limit), but showing "Enable" for an enabled asset erodes user trust in the UI.
+
+---
+
+## Reserve Implications
+
+Every trustline raises the account's minimum XLM balance by **0.5 XLM** (one base reserve). This is the part users trip over:
+
+- An account holding 1.2 XLM *cannot* add a trustline if doing so would push its required reserve above its balance — the transaction fails with `op_low_reserve`.
+- The 0.5 XLM isn't spent; it's locked. Removing the trustline (limit `0`, balance `0`) releases it.
+- Check before building, and turn the failure into guidance:
+
+```ts
+function canAffordTrustline(balances: Balance[], subentryCount: number): boolean {
+  const xlm = Number(balances.find((b) => b.asset_type === 'native')?.balance ?? 0);
+  const requiredAfter = (2 + subentryCount + 1) * 0.5; // base + subentries + new line
+  return xlm >= requiredAfter + 0.1; // headroom for fees
+}
+```
+
+A friendly UI says "You need at least 0.6 more XLM to add this asset" *before* the wallet prompt, not a raw `op_low_reserve` after it.
+
+---
+
+## Removing a Trustline
+
+The same `change_trust` operation with `limit: '0'` deletes the line — but only once the asset balance is zero. Expose removal next to creation; orphaned trustlines are locked reserves the user forgot about:
+
+```ts
+const xdr = await buildChangeTrustXDR({ ...USDC, limit: '0' });
+```
+
+---
+
+## Edge Cases Worth Handling
+
+| Case | What happens | What to do |
+|------|--------------|------------|
+| Trustline exists already | change_trust just updates the limit | Guard in UI, show current state |
+| Insufficient reserve | `op_low_reserve` failure | Pre-check balance, explain the 0.5 XLM |
+| Issuer requires authorization | Trustline created but `is_authorized: false` | Show "pending issuer approval" state |
+| Non-zero balance on removal | change_trust to 0 fails | Require emptying the balance first |
+| Wrong/typo'd issuer | Trustline to a worthless asset | Validate issuer against a curated list |
+
+The `is_authorized` flag comes back on each entry in `trustlines` — for regulated assets (SEP-8), holding a trustline is necessary but not sufficient, and your UI should distinguish "trusted, awaiting authorization" from "ready to receive".
+
+---
+
+## Summary
+
+The creation flow is three calls — `buildChangeTrustXDR`, wallet sign/submit, `refresh` — wrapped in two checks: don't offer what's already trusted, and verify the reserve *before* the wallet prompt. Handle the authorization flag for regulated assets and offer trustline removal to give reserves back. Users experience all of this as one button that simply works, which is the point.

--- a/routes-d/384-simple-payment-app.mdx
+++ b/routes-d/384-simple-payment-app.mdx
@@ -1,0 +1,181 @@
+---
+title: Building a Simple Payment App
+description: Build a minimal Stellar payment app with the Nextellar toolkit — wallet connect, XDR-based send flow, and on-screen confirmation, all on testnet.
+---
+
+# Building a Simple Payment App
+
+This guide builds the smallest payment app that is still honest about the hard parts: connect a wallet, send XLM to an address, and show the user a confirmation they can verify independently. Everything runs on **testnet**, and every signature comes from the user's wallet — the app never sees a secret key.
+
+The toolkit pieces: `WalletProvider` for configuration, `useStellarWallet` for connection state, and `useStellarPayment` for building and submitting the payment.
+
+---
+
+## Setup
+
+Wrap the app once so every hook shares the same network configuration:
+
+```tsx
+// app/layout.tsx
+import { WalletProvider } from '@/components/WalletProvider';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <WalletProvider
+      horizonUrl="https://horizon-testnet.stellar.org"
+      network="TESTNET"
+    >
+      {children}
+    </WalletProvider>
+  );
+}
+```
+
+---
+
+## Step 1 — Wallet Connect
+
+```tsx
+// PaymentApp.tsx
+import { useState } from 'react';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+import { useStellarPayment } from '@/hooks/useStellarPayment';
+
+export function PaymentApp() {
+  const { connected, publicKey, walletName, balances, connect, refreshBalances } =
+    useStellarWallet();
+
+  if (!connected) {
+    return (
+      <div>
+        <h2>Send XLM</h2>
+        <button onClick={connect}>Connect wallet</button>
+      </div>
+    );
+  }
+
+  const xlm = balances.find((b) => b.asset_type === 'native')?.balance ?? '0';
+  return (
+    <div>
+      <p>
+        {walletName} · {publicKey!.slice(0, 4)}…{publicKey!.slice(-4)} · {xlm} XLM
+      </p>
+      <SendForm from={publicKey!} onSent={refreshBalances} />
+    </div>
+  );
+}
+```
+
+Showing the truncated address and balance right after connect is a quiet confirmation that the app is talking to the wallet the user expects.
+
+---
+
+## Step 2 — The Send Flow
+
+`useStellarPayment` separates *building* the payment from *submitting* it, with the wallet signature in between:
+
+```tsx
+function SendForm({ from, onSent }: { from: string; onSent: () => Promise<void> }) {
+  const { buildPaymentXDR, submitSignedXDR } = useStellarPayment();
+  const [to, setTo] = useState('');
+  const [amount, setAmount] = useState('');
+  const [status, setStatus] = useState<
+    { kind: 'idle' } | { kind: 'sending' } | { kind: 'sent'; txHash: string } | { kind: 'error'; msg: string }
+  >({ kind: 'idle' });
+
+  const validate = (): string | null => {
+    if (!/^G[A-Z2-7]{55}$/.test(to.trim())) return 'Destination must be a valid G… address';
+    const n = Number(amount);
+    if (!Number.isFinite(n) || n <= 0) return 'Amount must be a positive number';
+    return null;
+  };
+
+  const send = async () => {
+    const problem = validate();
+    if (problem) return setStatus({ kind: 'error', msg: problem });
+
+    setStatus({ kind: 'sending' });
+    try {
+      // 1. Build unsigned XDR
+      const xdr = await buildPaymentXDR({
+        from,
+        to: to.trim(),
+        amount,
+        memo: 'simple-payment-app',
+      });
+
+      // 2. Wallet signs (Freighter shown)
+      const signed = await window.freighterApi.signTransaction(xdr, {
+        network: 'TESTNET',
+      });
+
+      // 3. Submit and confirm
+      const result = await submitSignedXDR(signed);
+      if (!result.success || !result.txHash) {
+        throw new Error(result.error ?? 'submission failed');
+      }
+      setStatus({ kind: 'sent', txHash: result.txHash });
+      await onSent(); // refresh balances
+    } catch (e: any) {
+      setStatus({ kind: 'error', msg: e.message ?? 'unknown error' });
+    }
+  };
+
+  return (
+    <div>
+      <input value={to} onChange={(e) => setTo(e.target.value)} placeholder="Destination G…" />
+      <input value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="Amount (XLM)" />
+      <button onClick={send} disabled={status.kind === 'sending'}>
+        {status.kind === 'sending' ? 'Sending…' : 'Send'}
+      </button>
+
+      {status.kind === 'sent' && <Confirmation txHash={status.txHash} />}
+      {status.kind === 'error' && <p role="alert">⚠ {status.msg}</p>}
+    </div>
+  );
+}
+```
+
+Disabling the button while `sending` is the minimum double-submit protection; the docs' double-submission guide covers the stronger patterns.
+
+---
+
+## Step 3 — Confirmation the User Can Verify
+
+Don't just say "Success" — hand the user the receipt:
+
+```tsx
+function Confirmation({ txHash }: { txHash: string }) {
+  return (
+    <div>
+      <p>✓ Payment sent</p>
+      <a
+        href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        View transaction {txHash.slice(0, 8)}… on stellar.expert
+      </a>
+    </div>
+  );
+}
+```
+
+The explorer link matters: it proves the confirmation reflects the ledger, not the app's optimism, and it teaches users where to look when something ever *doesn't* confirm.
+
+---
+
+## Failure Modes to Expect on Testnet
+
+| Failure | Cause | UI response |
+|---------|-------|-------------|
+| `op_no_destination` | Destination account unfunded | "This address doesn't exist yet — it needs XLM to be created" |
+| `op_underfunded` | Amount exceeds spendable balance | Show spendable (balance minus reserve), not raw balance |
+| Wallet rejects | User cancelled the signature | Return to idle silently — cancel is not an error |
+| Network timeout | Horizon slow or offline | Offer retry; check transaction status by hash before resubmitting |
+
+---
+
+## Summary
+
+Connect → validate → build XDR → wallet signs → submit → link the receipt. The app stays under 150 lines because each hook owns one seam of the flow, and every trust-sensitive step (keys, signing) lives in the wallet where it belongs. From here, the natural extensions are asset selection for non-XLM payments and the trustline flow those assets require — both covered by their own guides.

--- a/routes-d/386-order-book-useofferbook.mdx
+++ b/routes-d/386-order-book-useofferbook.mdx
@@ -1,0 +1,130 @@
+---
+title: Reading the Order Book with useOfferBook
+description: Use the useOfferBook hook to display live DEX order books — refresh and polling patterns, depth pagination, and a compact two-sided book UI.
+---
+
+# Reading the Order Book with useOfferBook
+
+Stellar's built-in DEX keeps a public order book for every asset pair. The `useOfferBook` hook fetches both sides — bids and asks — and derives the numbers a trading UI actually renders: the spread and the mid-price. This guide covers subscription and refresh patterns, what "pagination" means for an order book, and a small working book component.
+
+---
+
+## Basic Shape
+
+```tsx
+import { useOfferBook } from '@/hooks/useOfferBook';
+
+const XLM = { isNative: true } as const;
+const USDC = {
+  code: 'USDC',
+  issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+};
+
+function useXlmUsdcBook() {
+  return useOfferBook({
+    selling: XLM,   // base: what asks are selling
+    buying: USDC,   // quote: what bids pay with
+    limit: 20,      // offers per side
+  });
+}
+```
+
+The hook returns `{ bids, asks, spread, midPrice, loading, error, refresh }` — both sides in one state object so the UI can never render bids from one moment and asks from another.
+
+---
+
+## Subscription and Refresh Patterns
+
+An order book is the fastest-moving data in a trading UI, so the refresh strategy *is* the design decision:
+
+**Interval polling** — the baseline. Books change constantly, so poll on a short interval while the book is visible, and stop when it isn't:
+
+```tsx
+import { useEffect } from 'react';
+
+function usePolledBook(intervalMs = 5000) {
+  const book = useXlmUsdcBook();
+
+  useEffect(() => {
+    if (document.hidden) return; // don't poll a hidden tab from mount
+    const id = setInterval(() => {
+      if (!document.hidden) book.refresh();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs, book.refresh]);
+
+  return book;
+}
+```
+
+**Event-driven refresh** — poll slowly (30s) as a floor, but call `refresh()` immediately after anything that changes the book from *this* client: the user placing or cancelling an offer. The book then feels instant where the user is looking, without hammering Horizon.
+
+**Refresh on reveal** — always `refresh()` when the pair changes or the panel becomes visible again (`visibilitychange`); a book that is seconds stale on reveal misleads more than an empty one.
+
+Do **not** re-create the hook per render with new asset objects — keep `selling`/`buying` referentially stable (module constants or `useMemo`) or you'll re-subscribe on every keystroke elsewhere in the form.
+
+---
+
+## Pagination: Depth, Not Pages
+
+Order books don't paginate like transaction lists — there is no cursor to walk. The `limit` parameter controls **depth per side**: `limit: 20` returns the best 20 bids and best 20 asks by price. Deeper levels exist but rarely matter to UI:
+
+- A compact widget wants `limit: 10` — the top of book is where the action is.
+- A full trading view might use `limit: 50` and render a depth chart.
+- "Load more depth" is just calling the hook (or refreshing) with a larger `limit` — replace the book, don't append, because every level may have moved since the shallower fetch.
+
+Offers within each side arrive **sorted by price** (best first), so index 0 is always best bid / best ask, and `spread = asks[0].price − bids[0].price` — which the hook computes for you.
+
+---
+
+## A Compact Book Component
+
+```tsx
+function OrderBookPanel() {
+  const { bids, asks, spread, midPrice, loading, error, refresh } = usePolledBook();
+
+  if (loading && bids.length === 0) return <p>Loading book…</p>;
+  if (error) return <p>Book unavailable: {error.message} <button onClick={refresh}>Retry</button></p>;
+  if (bids.length === 0 && asks.length === 0) {
+    return <p>No offers for this pair yet — be the first to place one.</p>;
+  }
+
+  return (
+    <div>
+      <header>
+        <strong>XLM / USDC</strong>{' '}
+        <span>mid {midPrice.toFixed(7)}</span>{' '}
+        <span>spread {spread.toFixed(7)}</span>
+      </header>
+
+      <table>
+        <thead>
+          <tr><th>Bid amount</th><th>Bid</th><th>Ask</th><th>Ask amount</th></tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: Math.max(bids.length, asks.length) }).map((_, i) => (
+            <tr key={i}>
+              <td>{bids[i]?.amount ?? ''}</td>
+              <td>{bids[i]?.price ?? ''}</td>
+              <td>{asks[i]?.price ?? ''}</td>
+              <td>{asks[i]?.amount ?? ''}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+Details that keep it honest under motion:
+
+- `loading && bids.length === 0` — show the spinner only on first load; during background refreshes keep rendering the previous book (a flashing skeleton every 5s is worse than 5-second-old data).
+- The two-column ladder pairs rank-for-rank (best vs best), which is what traders expect.
+- The empty state is real: thin testnet pairs frequently have zero offers, and an empty book is information, not an error.
+
+---
+
+## Summary
+
+Treat the book as one atomic snapshot (`bids` + `asks` from the same fetch), poll while visible and refresh eagerly after the user's own actions, and think of `limit` as depth rather than pages — replaced wholesale, never appended. With `spread` and `midPrice` precomputed by the hook, the component's only real job is rendering the ladder and staying calm while the numbers move.


### PR DESCRIPTION
## Summary
Adds four documentation drafts to the `routes-d` staging folder, one per assigned issue: a CLI tutorial for creating a first Stellar account, a trustline creation flow guide built on `useTrustlines`, a simple payment app guide, and an order book guide built on `useOfferBook`. All drafts use the folder's `<issue>-<slug>.mdx` naming convention and match the frontmatter and section style of the merged drafts already in routes-d.

closes #380
closes #383
closes #384
closes #386

## Changes
- **#380 — first Stellar account via the CLI**: `routes-d/380-first-stellar-account-cli.mdx` is a testnet-only walkthrough with a working command sequence: `stellar keys generate` → explicit Friendbot funding (`stellar keys fund` and the curl equivalent) → verification against Horizon's `/accounts` endpoint with annotated JSON output (balances, sequence, and the pre-funding 404 as the teachable moment) → a proving payment between two generated accounts. Closes with base-reserve/minimum-balance implications and the exact deltas between testnet and mainnet.
- **#383 — trustline creation flow**: `routes-d/383-trustline-creation-flow.mdx` documents the full `useTrustlines` flow: `buildChangeTrustXDR` → wallet signing → `refresh()`, with a complete component including an already-trusted guard. Covers reserve implications concretely (0.5 XLM per line, `op_low_reserve`, a `canAffordTrustline` pre-check with headroom for fees), trustline removal via `limit: '0'`, and an edge-case table including issuer-authorization (`is_authorized`) states for regulated assets.
- **#384 — simple payment app**: `routes-d/384-simple-payment-app.mdx` builds a minimal app on `WalletProvider` + `useStellarWallet` + `useStellarPayment`: connect with identity confirmation, a validated send form (address regex, positive amount), build-sign-submit with `buildPaymentXDR`/`submitSignedXDR`, and a confirmation that links the tx hash to stellar.expert rather than just claiming success. Includes a testnet failure-mode table (`op_no_destination`, `op_underfunded`, user cancel, timeouts) with the right UI response for each. Testnet throughout; no secret keys in the app.
- **#386 — order book with useOfferBook**: `routes-d/386-order-book-useofferbook.mdx` covers refresh patterns (visibility-aware interval polling, event-driven refresh after the user's own offer actions, refresh-on-reveal, keeping asset params referentially stable), explains that order book "pagination" is per-side depth via `limit` (replace, never append), and provides a compact two-sided ladder component using the hook's `bids`/`asks`/`spread`/`midPrice`, with a first-load-only spinner and a genuine empty state for thin pairs.

## Test plan
- Hook parameter/return shapes cross-checked against `docs/hooks/use-trustlines.mdx`, `use-stellar-payment.mdx`, `use-stellar-wallet.mdx`, and `use-offer-book.mdx` API references.
- CLI commands in #380 follow current stellar-cli syntax (`stellar keys generate/address/fund`, `stellar tx new payment`); amounts documented in stroops with the 7-decimal convention.
- Drafts live in `routes-d/`, outside `contentlayer`'s `contentDirPath: 'docs'`, so `pnpm build:content` output is unaffected; frontmatter matches the docs schema for later promotion.

---
Note: `pnpm build:content` and `pnpm check:links` fail on a clean checkout of `main` for pre-existing reasons unrelated to this PR; these changes add files only under `routes-d/`.