### PR TITLE
docs: add trustline listing, history pagination, network switching and multisig CLI drafts (routes-d)

### DIFF
--- a/routes-d/387-listing-trustline-assets.mdx
+++ b/routes-d/387-listing-trustline-assets.mdx
@@ -1,0 +1,139 @@
+---
+title: Listing Trustline Assets
+description: List the assets an account holds trustlines for — the trustline data shape, a rendering component with sensible grouping, and honest empty-state handling.
+---
+
+# Listing Trustline Assets
+
+"What assets does this account hold?" sounds like a balance question, but on Stellar it is a **trustline** question: every non-XLM asset an account can hold corresponds to a trustline entry, present whether the balance is `1000` or `0`. This guide documents the data shape `useTrustlines` returns, a small component that renders it well, and the empty states that a surprising number of UIs get wrong.
+
+---
+
+## The Data Shape
+
+```tsx
+import { useTrustlines } from '@/hooks/useTrustlines';
+
+const { trustlines, loading, error, refresh } = useTrustlines(publicKey);
+```
+
+Each entry describes one trusted asset:
+
+```typescript
+interface Trustline {
+  asset_code: string;      // e.g. 'USDC'
+  asset_issuer: string;    // issuer account (G...)
+  asset_type: string;      // 'credit_alphanum4' | 'credit_alphanum12'
+  balance: string;         // current holding, may be '0.0000000'
+  limit?: string;          // max the account will hold
+  is_authorized?: boolean; // for issuer-controlled (regulated) assets
+}
+```
+
+Three properties routinely trip up first implementations:
+
+- **`balance` is a string.** Horizon returns fixed-point strings; convert with `Number()` only for display/compare, never for arithmetic you'll send back to the network.
+- **XLM is not in the list.** Native lumens need no trustline, so a "your assets" view that should include XLM must merge it in from a balances source.
+- **Identity is `code` + `issuer`.** Two entries can share `asset_code`; key React lists and lookups on the pair.
+
+---
+
+## A Rendering Example
+
+Zero-balance trustlines are still information ("you can receive this asset"), so render them — just visually subordinate:
+
+```tsx
+export function AssetList({ publicKey }: { publicKey: string }) {
+  const { trustlines, loading, error, refresh } = useTrustlines(publicKey);
+
+  if (loading) return <AssetListSkeleton rows={3} />;
+  if (error) {
+    return (
+      <p role="alert">
+        Couldn't load assets: {error.message}{' '}
+        <button onClick={refresh}>Retry</button>
+      </p>
+    );
+  }
+  if (trustlines.length === 0) return <EmptyAssets />;
+
+  const held = trustlines.filter((t) => Number(t.balance) > 0);
+  const empty = trustlines.filter((t) => Number(t.balance) === 0);
+
+  return (
+    <div>
+      <ul>
+        {held.map((t) => (
+          <li key={`${t.asset_code}:${t.asset_issuer}`}>
+            <strong>{t.asset_code}</strong>
+            <span> {t.balance}</span>
+            <IssuerTag issuer={t.asset_issuer} />
+            {t.is_authorized === false && <em> · awaiting issuer approval</em>}
+          </li>
+        ))}
+      </ul>
+
+      {empty.length > 0 && (
+        <details>
+          <summary>{empty.length} asset(s) with zero balance</summary>
+          <ul>
+            {empty.map((t) => (
+              <li key={`${t.asset_code}:${t.asset_issuer}`}>
+                {t.asset_code} <IssuerTag issuer={t.asset_issuer} />
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function IssuerTag({ issuer }: { issuer: string }) {
+  return (
+    <code title={issuer}>
+      {issuer.slice(0, 4)}…{issuer.slice(-4)}
+    </code>
+  );
+}
+```
+
+The `IssuerTag` is non-negotiable: asset codes are not unique, and showing `USDC` without its issuer is how users get phished by look-alike assets. The full issuer lives in the `title` attribute for verification on hover.
+
+---
+
+## Empty States Are Three Different States
+
+A single "No assets" message conflates situations that call for different responses:
+
+| State | Detection | Message |
+|-------|-----------|---------|
+| No trustlines at all | `trustlines.length === 0` | "This account holds only XLM. Add a trustline to receive other assets." + CTA |
+| Trustlines exist, all zero | `held.length === 0 && empty.length > 0` | "Ready to receive USDC, EURC" — list what *can* arrive |
+| Account not found | error with 404 from Horizon | "This account isn't funded yet" — not an error tone |
+
+```tsx
+function EmptyAssets() {
+  return (
+    <div>
+      <p>This account holds only XLM.</p>
+      <p>Add a trustline to hold other assets like USDC.</p>
+      <a href="/docs/hooks/use-trustlines">Add an asset →</a>
+    </div>
+  );
+}
+```
+
+The 404 case matters most: an unfunded account is a *brand-new user*, and greeting them with an error-styled message is the worst possible first impression.
+
+---
+
+## Refresh Semantics
+
+`refresh()` re-queries Horizon. Call it after any operation that changes trustlines or balances — adding/removing a trustline, receiving a payment you initiated elsewhere in the app. For passive updates (payments arriving from outside), poll gently or refresh on window focus; trustline sets change rarely compared to balances.
+
+---
+
+## Summary
+
+Treat the trustline list as the account's asset capability list: key by code+issuer, always show the issuer, render zero-balance lines as receivable assets rather than hiding them, and split the empty state into its three honest cases (XLM-only, all-zero, unfunded). Do that and the same component serves wallets, dashboards, and send-form asset pickers unchanged.

--- a/routes-d/390-transaction-history-pagination.mdx
+++ b/routes-d/390-transaction-history-pagination.mdx
@@ -1,0 +1,115 @@
+---
+title: Paginating Transaction History with useTransactionHistory
+description: Cursor-based pagination with useTransactionHistory — loadMore/hasMore semantics, ordering options, infinite scroll, and the cases that break naive page math.
+---
+
+# Paginating Transaction History with useTransactionHistory
+
+Accounts accumulate transactions forever, so history is the one dataset you must never fetch whole. Horizon paginates with **cursors** — opaque tokens marking a position in the stream — and `useTransactionHistory` wraps that machinery into three fields: `transactions`, `loadMore`, and `hasMore`. This guide covers how the cursor model behaves, ordering, and the patterns for rendering unbounded history well.
+
+---
+
+## Cursor-Based Usage
+
+```tsx
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
+
+export function History({ publicKey }: { publicKey: string }) {
+  const { transactions, loading, error, loadMore, hasMore, refresh } =
+    useTransactionHistory(publicKey, {
+      limit: 10,      // page size
+      order: 'desc',  // newest first
+    });
+
+  if (loading && transactions.length === 0) return <p>Loading history…</p>;
+  if (error) return <p role="alert">Failed to load: {error.message}</p>;
+  if (transactions.length === 0) return <p>No transactions yet.</p>;
+
+  return (
+    <>
+      <ul>
+        {transactions.map((tx) => (
+          <li key={tx.id}>
+            <time>{new Date(tx.created_at).toLocaleString()}</time>{' '}
+            <code>{tx.id.slice(0, 8)}…</code>
+            {tx.successful === false && <em> (failed)</em>}
+          </li>
+        ))}
+      </ul>
+
+      {hasMore ? (
+        <button onClick={loadMore} disabled={loading}>
+          {loading ? 'Loading…' : 'Load older transactions'}
+        </button>
+      ) : (
+        <p>— end of history —</p>
+      )}
+    </>
+  );
+}
+```
+
+The mental model: the hook holds a cursor pointing just past the last transaction it returned. `loadMore()` fetches the next `limit` records from that cursor and **appends** them to `transactions` — the array only ever grows. `hasMore` turns false when a fetch comes back short, which is Horizon's way of saying you've reached the end.
+
+Why cursors instead of page numbers: new transactions arrive constantly, so "page 3" is a moving target — records would slide between pages as you browse. A cursor pins your position to a fixed record, making pagination stable no matter what arrives at the head of the stream.
+
+---
+
+## Ordering Options
+
+| `order` | Sequence | Use for |
+|---------|----------|---------|
+| `'desc'` (default) | Newest → oldest | Activity feeds, dashboards — virtually all UIs |
+| `'asc'` | Oldest → newest | Audits, accounting exports, replaying account history |
+
+Two consequences of ordering interact with pagination:
+
+- With `'desc'`, `loadMore` walks **backwards in time** — perfect for "Load older".
+- With `'asc'`, `loadMore` walks forward from the account's creation; `hasMore: false` here means you've caught up to *now*, and a later `refresh()` may find more.
+
+Switching `order` (or `publicKey`) resets the accumulated list and cursor — don't cache the array across a switch expecting it to merge.
+
+---
+
+## Infinite Scroll
+
+`loadMore` composes directly with an intersection observer for scroll-triggered loading:
+
+```tsx
+import { useEffect, useRef } from 'react';
+
+function useInfiniteScroll(loadMore: () => Promise<void>, hasMore: boolean, loading: boolean) {
+  const sentinel = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el || !hasMore) return;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting && !loading) loadMore();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore, hasMore, loading]);
+
+  return sentinel;
+}
+// render: <div ref={sentinel} /> after the list
+```
+
+The `!loading` guard is essential — the observer fires repeatedly while the sentinel is visible, and without the guard you'll issue overlapping `loadMore` calls that append duplicate pages on slow networks.
+
+---
+
+## Details That Bite
+
+- **New transactions don't prepend.** The hook paginates *older*; a payment arriving after mount won't appear until `refresh()`. Refresh after the user's own sends, and consider refresh-on-focus for everything else. `refresh()` resets to the first page.
+- **Failed transactions are included.** Horizon returns them (`successful: false`); render them marked, don't filter silently — users look for their failed attempt to understand what happened.
+- **Key by `tx.id`**, never array index — appends shift nothing, but refreshes replace the array.
+- **Page size is a latency/robustness tradeoff.** `10` renders fast and works everywhere; jump to `50`+ only for data-dense views. Horizon caps `limit` at 200.
+- **Empty history is a state, not an error** — a funded account that hasn't transacted returns an empty first page with `hasMore: false`.
+
+---
+
+## Summary
+
+Let the hook own the cursor: render `transactions`, gate "older" on `hasMore`, guard `loadMore` against overlap, and use `refresh()` — not pagination — to pick up new activity. Choose `'desc'` unless you're auditing, key rows by id, and show failed transactions honestly. Cursor pagination's one rule is that position is pinned to records, not page numbers — everything else follows from it.

--- a/routes-d/392-network-switching-mid-session.mdx
+++ b/routes-d/392-network-switching-mid-session.mdx
@@ -1,0 +1,140 @@
+---
+title: Switching Networks Mid-Session
+description: Safely switch a running dApp between testnet and mainnet — the switch flow, exactly which state to invalidate, wallet coordination, and a working NetworkSwitcher.
+---
+
+# Switching Networks Mid-Session
+
+Letting users flip between testnet and mainnet without a page reload is table stakes for a developer-facing dApp — and quietly dangerous, because *every piece of chain-derived state in memory belongs to the old network* the instant the switch happens. A balance from testnet rendered on mainnet is a lie with a currency symbol. This guide covers the switch flow, an explicit inventory of what to invalidate, and how to keep the connected wallet in agreement.
+
+---
+
+## What "the Network" Actually Is
+
+A network is three coordinates that must change **together**:
+
+```ts
+interface NetworkConfig {
+  name: 'TESTNET' | 'PUBLIC';
+  horizonUrl: string;          // e.g. https://horizon-testnet.stellar.org
+  networkPassphrase: string;   // baked into every signed transaction
+}
+```
+
+The passphrase is the safety net: it is hashed into every transaction signature, so a transaction built for one network is *invalid* on the other. Mixed state can mislead users, but it cannot make a testnet-built payment execute on mainnet.
+
+---
+
+## The Switch Flow
+
+Ordering matters — tear down before pointing anywhere new:
+
+```
+1. Block new actions        (disable send buttons, close signing modals)
+2. Abort in-flight requests (stale responses must not land after the switch)
+3. Swap NetworkConfig       (context update — horizon URL + passphrase together)
+4. Invalidate chain state   (balances, history, trustlines, book, contract reads)
+5. Re-verify the wallet     (does it agree about the network?)
+6. Refetch for the new network
+```
+
+A minimal context implementation:
+
+```tsx
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
+
+const NETWORKS: Record<'TESTNET' | 'PUBLIC', NetworkConfig> = {
+  TESTNET: {
+    name: 'TESTNET',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  },
+  PUBLIC: {
+    name: 'PUBLIC',
+    horizonUrl: 'https://horizon.stellar.org',
+    networkPassphrase: 'Public Global Stellar Network ; September 2015',
+  },
+};
+
+const NetworkContext = createContext<{
+  config: NetworkConfig;
+  epoch: number;                       // increments on every switch
+  switchNetwork: (n: 'TESTNET' | 'PUBLIC') => void;
+} | null>(null);
+
+export function NetworkProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState(NETWORKS.TESTNET);
+  const [epoch, setEpoch] = useState(0);
+  const abortRef = useRef(new AbortController());
+
+  const switchNetwork = useCallback((name: 'TESTNET' | 'PUBLIC') => {
+    if (NETWORKS[name] === config) return;
+    abortRef.current.abort();               // 2. kill in-flight fetches
+    abortRef.current = new AbortController();
+    setConfig(NETWORKS[name]);              // 3. swap config atomically
+    setEpoch((e) => e + 1);                 // 4. signal: everything stale
+  }, [config]);
+
+  return (
+    <NetworkContext.Provider value={{ config, epoch, switchNetwork }}>
+      {children}
+    </NetworkContext.Provider>
+  );
+}
+```
+
+The `epoch` counter is the invalidation mechanism: any hook that caches chain data includes `epoch` in its effect dependencies, so a switch automatically clears and refetches it. With a data library like React Query, put `config.name` in every query key and the same property falls out for free.
+
+---
+
+## State to Invalidate — the Inventory
+
+| State | Why it's wrong after a switch | Action |
+|-------|------------------------------|--------|
+| Balances / trustlines | Different ledger entirely | Clear + refetch |
+| Transaction history & cursors | Cursors are per-Horizon-stream | Clear list **and** cursor |
+| Order book | Different offers exist | Clear + refetch |
+| Pending unsigned XDR | Carries old passphrase — will fail | **Discard**, never resubmit |
+| Contract IDs in config | Same contract has different IDs per network | Resolve per-network from config |
+| Sequence numbers / fee estimates | Account state differs | Refetch lazily |
+| User's *draft form inputs* | Still valid — user intent, not chain state | **Keep** |
+
+The last row is the UX half of correctness: wiping the user's half-typed recipient and amount on switch punishes them for exploring. Invalidate what came *from* the chain; preserve what came from the user.
+
+---
+
+## Keeping the Wallet in Agreement
+
+The dApp switching doesn't switch the user's wallet. If the wallet signs with testnet selected while the dApp submits to mainnet Horizon, the submission fails with a cryptic signature error. Verify at the seam:
+
+```tsx
+function useWalletNetworkGuard() {
+  const { config } = useContext(NetworkContext)!;
+  const [mismatch, setMismatch] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const walletNet = await window.freighterApi.getNetwork(); // 'TESTNET' | 'PUBLIC'
+      setMismatch(walletNet !== config.name);
+    })();
+  }, [config]);
+
+  return mismatch; // render a blocking banner when true
+}
+```
+
+Block signing actions — not browsing — while mismatched, with a banner: "Your wallet is on TESTNET but this app is on MAINNET. Switch your wallet to continue."
+
+---
+
+## Small Safeguards Worth Copying
+
+- **Persist the selection** (`localStorage`) so a reload doesn't silently revert to a default network — surprise-mainnet is the worst surprise.
+- **Make the current network loudly visible** whenever it's PUBLIC (colored badge in the header). Ambiguity should only ever cost play money.
+- **Confirm switches *to* mainnet** ("You're switching to real funds") but not to testnet — friction should point toward safety.
+
+---
+
+## Summary
+
+Model the network as one atomic config (URL + passphrase), drive every cached read through an epoch or query-key that includes it, and walk the six-step flow: block, abort, swap, invalidate, re-verify wallet, refetch. Invalidate chain-derived state ruthlessly, preserve user intent, and treat a wallet/dApp network mismatch as a signing blocker rather than a footnote. Users should experience the switch as one clean beat — everything chain-flavored blinks once and returns true.

--- a/routes-d/394-multisig-setup-cli.mdx
+++ b/routes-d/394-multisig-setup-cli.mdx
@@ -1,0 +1,139 @@
+---
+title: Multi-Sig Setup via the CLI
+description: Configure Stellar multi-signature accounts with the CLI — adding signers with set-options, understanding thresholds, safe removal, and a worked 2-of-3 example on testnet.
+---
+
+# Multi-Sig Setup via the CLI
+
+Any Stellar account can require multiple signatures. There is no special "multisig account" type — you add **signers** with weights and raise the account's **thresholds** until no single key clears the bar. Both are done with the `set_options` operation, which the Stellar CLI exposes as `stellar tx new set-options`. This guide walks a complete 2-of-3 setup on testnet, then the threshold rules and the removal flow, including the mistakes that permanently lock accounts.
+
+---
+
+## The Model in 60 Seconds
+
+- Every account's master key starts with **weight 1**; additional signers get their own weights.
+- Operations are classed **low / medium / high**, each with a threshold (default 0):
+  - *low*: e.g. allow-trust style operations
+  - *medium*: payments, offers, most everything
+  - *high*: changing signers or thresholds themselves
+- A transaction succeeds when the **sum of signing weights ≥ the threshold** of its highest-class operation.
+
+With defaults of 0, any signer weight ≥ 1 clears everything — which is why adding a signer *without* raising thresholds changes nothing about security.
+
+---
+
+## Worked Example: 2-of-3 on Testnet
+
+Three keys — `ceo`, `cfo`, `ops` — where any two together can move funds, and changing the signer set itself also needs two.
+
+```bash
+# Identities (ceo's account will become the shared treasury)
+stellar keys generate ceo --network testnet
+stellar keys generate cfo --network testnet
+stellar keys generate ops --network testnet
+stellar keys fund ceo --network testnet
+
+TREASURY=$(stellar keys address ceo)
+```
+
+**Add the two co-signers** (each `set_options` call can add one signer):
+
+```bash
+stellar tx new set-options \
+  --source ceo --network testnet \
+  --signer "$(stellar keys address cfo)" --signer-weight 1
+
+stellar tx new set-options \
+  --source ceo --network testnet \
+  --signer "$(stellar keys address ops)" --signer-weight 1
+```
+
+**Then raise the thresholds** — deliberately as the *last* step, after confirming the signers landed:
+
+```bash
+stellar tx new set-options \
+  --source ceo --network testnet \
+  --med-threshold 2 --high-threshold 2
+```
+
+From this moment, the master key alone (weight 1) can no longer pay or change signers: any two of the three keys must co-sign.
+
+> Order matters. Raising thresholds *before* the co-signers exist locks the account instantly — the master key can't reach the new threshold, and nobody else is a signer yet. Signers first, thresholds second, always.
+
+---
+
+## Verify the Configuration
+
+```bash
+curl -s "https://horizon-testnet.stellar.org/accounts/$TREASURY" \
+  | jq '{ thresholds, signers }'
+```
+
+```json
+{
+  "thresholds": {
+    "low_threshold": 0,
+    "med_threshold": 2,
+    "high_threshold": 2
+  },
+  "signers": [
+    { "key": "GCEO...", "weight": 1, "type": "ed25519_public_key" },
+    { "key": "GCFO...", "weight": 1, "type": "ed25519_public_key" },
+    { "key": "GOPS...", "weight": 1, "type": "ed25519_public_key" }
+  ]
+}
+```
+
+---
+
+## Signing with Multiple Keys
+
+A multisig payment is built once, then accumulates signatures before submission:
+
+```bash
+# Build unsigned, sign with the first key
+stellar tx new payment \
+  --source ceo --network testnet \
+  --destination <DEST_G...> --amount 100_0000000 \
+  --build-only \
+  | stellar tx sign --sign-with-key ceo --network testnet > partially-signed.xdr
+
+# Second signer adds theirs and submits
+cat partially-signed.xdr \
+  | stellar tx sign --sign-with-key cfo --network testnet \
+  | stellar tx send --network testnet
+```
+
+The XDR travels between signers as text — over any channel you trust — with each `stellar tx sign` appending one signature. Submission succeeds once accumulated weight (1 + 1) meets the medium threshold (2).
+
+---
+
+## Threshold Changes and Signer Removal
+
+Both are **high-threshold** operations, so under 2-of-3 they themselves need two signatures — build with `--build-only` and run the same sign-and-pass flow above.
+
+Remove a signer by setting their weight to zero:
+
+```bash
+stellar tx new set-options \
+  --source ceo --network testnet \
+  --signer "$(stellar keys address ops)" --signer-weight 0 \
+  --build-only | stellar tx sign --sign-with-key ceo --network testnet \
+  | stellar tx sign --sign-with-key cfo --network testnet \
+  | stellar tx send --network testnet
+```
+
+To retire the master key itself, set `--master-weight 0` — after which the account is controlled purely by its other signers.
+
+**Before every change, run the lockout check:** after this transaction, does some reachable combination of remaining signer weights still meet the *high* threshold? If not, the account becomes permanently unmodifiable — there is no recovery, no support ticket, no reset. The two classic self-locks:
+
+- Removing a signer (3 signers → 2) while leaving `high_threshold` at a level the survivors can't reach.
+- Setting `--master-weight 0` while the master key was the only signer.
+
+Each removed signer also releases its 0.5 XLM base-reserve, a small bonus for pruning departed members.
+
+---
+
+## Summary
+
+Multisig on Stellar is two knobs on `set_options`: signer weights and the three thresholds. Add signers first, raise thresholds second, verify via Horizon, and pass partially-signed XDR between keys with `stellar tx sign`. Before any high-threshold change, prove on paper that the surviving signer set can still clear `high_threshold` — it is the one mistake this system will not forgive.


### PR DESCRIPTION
## Summary
Adds four documentation drafts to the `routes-d` staging folder, one per assigned issue: listing trustline assets, paginating transaction history with `useTransactionHistory`, switching networks mid-session, and multi-sig setup via the Stellar CLI. All drafts use the folder's `<issue>-<slug>.mdx` naming convention and match the frontmatter and section style of the merged drafts already in routes-d.

closes #387
closes #390
closes #392
closes #394

## Changes
- **#387 — listing trustline assets**: `routes-d/387-listing-trustline-assets.mdx` documents the trustline entry shape returned by `useTrustlines` (string balances, code+issuer identity, `is_authorized` for regulated assets, XLM's absence from the list), a rendering component that groups held vs zero-balance lines with a mandatory issuer tag, and splits the empty state into its three real cases (XLM-only account, all-zero trustlines, unfunded/404 account) with distinct copy for each.
- **#390 — transaction history pagination**: `routes-d/390-transaction-history-pagination.mdx` explains the cursor model behind `loadMore`/`hasMore` (append-only accumulation, why cursors beat page numbers on a live stream), `asc` vs `desc` ordering and how each interacts with pagination, an intersection-observer infinite-scroll helper with an overlap guard, and the practical gotchas: new transactions require `refresh()` not pagination, failed transactions are included, key by `tx.id`, Horizon's limit cap.
- **#392 — network switching mid-session**: `routes-d/392-network-switching-mid-session.mdx` models the network as one atomic config (name, Horizon URL, passphrase), gives a six-step switch flow (block, abort in-flight, swap, invalidate, re-verify wallet, refetch) with a working `NetworkProvider` using an epoch counter for invalidation, a state-inventory table distinguishing chain-derived state (clear) from user intent (keep), a wallet/dApp network mismatch guard that blocks signing, and safeguards (persist selection, loud mainnet badge, confirm switches toward mainnet only).
- **#394 — multi-sig setup via the CLI**: `routes-d/394-multisig-setup-cli.mdx` walks a complete 2-of-3 testnet setup with `stellar tx new set-options` (signers first, thresholds second — with an explicit warning that the reverse order locks the account), Horizon verification of `thresholds`/`signers`, passing partially-signed XDR between keys with `stellar tx sign`/`stellar tx send`, signer removal via zero weight and master-key retirement, and the pre-change lockout check for high-threshold operations.

## Test plan
- Hook shapes cross-checked against the API references in `docs/hooks/use-trustlines.mdx` and `docs/hooks/use-transaction-history.mdx` (parameters, return fields, defaults).
- Network passphrases and Horizon URLs in #392 match the canonical testnet/public values; CLI flows in #394 follow current stellar-cli syntax (`set-options`, `--build-only`, `tx sign`, `tx send`).
- Drafts live in `routes-d/`, outside `contentlayer`'s `contentDirPath: 'docs'`, so `pnpm build:content` output is unaffected; frontmatter matches the docs schema for later promotion.

---
Note: `pnpm build:content` and `pnpm check:links` fail on a clean checkout of `main` for pre-existing reasons unrelated to this PR; these changes add files only under `routes-d/`.