### PR TITLE
docs: Soroban storage types/TTLs + account recovery pattern drafts

### DIFF
--- a/routes-d/426-soroban-storage-types-and-ttls.mdx
+++ b/routes-d/426-soroban-storage-types-and-ttls.mdx
@@ -1,0 +1,212 @@
+---
+title: Soroban Storage Types and TTLs
+description: Compare temporary, instance, and persistent storage on Soroban, and walk through TTL extension flows with a working example for each storage type.
+date: 2026-07-26
+---
+
+# Soroban Storage Types and TTLs
+
+Every ledger entry a Soroban contract writes carries a **TTL (time to live)**, expressed as `live_until_ledger_seq`. When an entry's TTL runs out, what happens next depends on which of the three storage types it lives in. Picking the wrong one either costs more than it should, or silently loses data you needed to keep.
+
+---
+
+## The Three Storage Types
+
+|                          | Temporary                        | Instance                           | Persistent             |
+| ------------------------ | -------------------------------- | ---------------------------------- | ---------------------- |
+| Survives TTL expiry?     | No — deleted permanently         | Archived, restorable               | Archived, restorable   |
+| Keyed per entry?         | Yes                              | No — shared with contract instance | Yes                    |
+| Loaded every invocation? | No                               | Yes (part of instance footprint)   | No                     |
+| Typical use              | Nonces, rate limits, order books | Admin config, small maps           | Balances, user records |
+| Relative rent cost       | Lowest                           | Low if kept small                  | Highest (long-lived)   |
+
+**Temporary storage** is cheapest because expired entries are simply gone — there is no archive to pay rent on. Never use it for anything you cannot afford to lose.
+
+**Instance storage** lives on the contract instance itself and shares the instance's own TTL. It is read into every invocation's footprint automatically, so it is fast to access but expensive to bloat — every call pays for reading the whole thing.
+
+**Persistent storage** is the only type with per-key durability. When its TTL expires the entry is **archived**, not deleted: it must be restored with a `RestoreFootprintOp` (and rent paid) before it can be read or written again.
+
+---
+
+## TTL Mechanics
+
+Every entry that supports a TTL has a `live_until_ledger_seq`. The remaining TTL is:
+
+```
+ttl = live_until_ledger_seq - current_ledger_sequence
+```
+
+Extending TTL is done with `extend_ttl(threshold, extend_to)`:
+
+- If the entry's current TTL is **greater than** `threshold`, the call is a no-op (cheap).
+- If the current TTL is **at or below** `threshold`, the TTL is bumped so `live_until_ledger_seq = current_ledger + extend_to`.
+
+This threshold/extend_to split lets you call `extend_ttl` unconditionally on every write without paying rent on every single call — only when the entry is actually getting close to expiry.
+
+```rust
+// contracts/storage-demo/src/lib.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol, Address};
+
+const BUMP_THRESHOLD: u32 = 100_000; // ~ a few days of ledgers
+const BUMP_AMOUNT: u32 = 500_000;
+
+#[contract]
+pub struct StorageDemo;
+
+#[contractimpl]
+impl StorageDemo {
+    pub fn touch_persistent(env: Env, key: Symbol) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    }
+}
+```
+
+If TTL hits zero:
+
+- **Temporary** → entry is gone. Reading it returns `None`, same as if it never existed.
+- **Instance / Persistent** → entry is archived. Any transaction touching it must include a `RestoreFootprintOp` first, which pays rent to bring it back before the contract call executes.
+
+---
+
+## Example: Temporary Storage — Replay Protection Nonce
+
+Temporary storage is a good fit for data that only needs to matter for a short window, like a nonce used to reject replayed signatures.
+
+```rust
+use soroban_sdk::{contract, contractimpl, Env, Address, BytesN};
+
+#[contract]
+pub struct NonceGuard;
+
+#[contractimpl]
+impl NonceGuard {
+    pub fn consume_nonce(env: Env, user: Address, nonce: BytesN<32>) {
+        let key = (user.clone(), nonce.clone());
+
+        if env.storage().temporary().has(&key) {
+            panic!("nonce already used");
+        }
+
+        // Only needs to survive the replay window — a few minutes of ledgers.
+        env.storage().temporary().set(&key, &true);
+        env.storage().temporary().extend_ttl(&key, 100, 1_000);
+    }
+}
+```
+
+No cleanup needed: once the TTL lapses, the entry vanishes and never costs rent again.
+
+---
+
+## Example: Instance Storage — Admin Config
+
+Instance storage suits small, frequently-read config that every invocation needs, like an admin address or a fee rate.
+
+```rust
+use soroban_sdk::{contract, contractimpl, Env, Address, Symbol, symbol_short};
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const FEE_BPS: Symbol = symbol_short!("FEE_BPS");
+
+#[contract]
+pub struct ConfigDemo;
+
+#[contractimpl]
+impl ConfigDemo {
+    pub fn init(env: Env, admin: Address, fee_bps: u32) {
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&FEE_BPS, &fee_bps);
+        env.storage().instance().extend_ttl(500_000, 1_000_000);
+    }
+
+    pub fn admin(env: Env) -> Address {
+        env.storage().instance().get(&ADMIN).unwrap()
+    }
+
+    pub fn set_fee(env: Env, admin: Address, fee_bps: u32) {
+        admin.require_auth();
+        assert_eq!(admin, env.storage().instance().get(&ADMIN).unwrap());
+        env.storage().instance().set(&FEE_BPS, &fee_bps);
+        // Every write is a good place to re-check the instance's own TTL too.
+        env.storage().instance().extend_ttl(500_000, 1_000_000);
+    }
+}
+```
+
+Note `instance().extend_ttl` takes no key — it extends the TTL of the instance entry as a whole, which is why instance storage should stay small: bumping it always touches everything in it.
+
+---
+
+## Example: Persistent Storage — User Balances
+
+Persistent storage is the right choice for per-user data that must survive indefinitely and cannot silently disappear.
+
+```rust
+use soroban_sdk::{contract, contractimpl, Env, Address};
+
+const BALANCE_BUMP_THRESHOLD: u32 = 200_000;
+const BALANCE_BUMP_AMOUNT: u32 = 1_000_000;
+
+#[contract]
+pub struct BalanceDemo;
+
+#[contractimpl]
+impl BalanceDemo {
+    pub fn credit(env: Env, user: Address, amount: i128) {
+        let key = user.clone();
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(0);
+
+        env.storage().persistent().set(&key, &(balance + amount));
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BALANCE_BUMP_THRESHOLD, BALANCE_BUMP_AMOUNT);
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        env.storage().persistent().get(&user).unwrap_or(0)
+    }
+}
+```
+
+If a user's balance entry is ever allowed to expire and gets archived, the client submitting the next transaction against it must attach a `RestoreFootprintOp` — the Stellar SDK's transaction builder surfaces this as a simulation error telling you which footprint entries need restoring.
+
+```ts
+// client-side: restoring an archived entry before calling the contract
+import { rpc, TransactionBuilder, Operation } from '@stellar/stellar-sdk';
+
+const sim = await server.simulateTransaction(tx);
+if (rpc.Api.isSimulationRestore(sim)) {
+  const restoreTx = new TransactionBuilder(account, { fee, networkPassphrase })
+    .setSorobanData(sim.restorePreamble.transactionData)
+    .addOperation(Operation.restoreFootprint({}))
+    .setTimeout(30)
+    .build();
+  // sign and submit restoreTx before retrying the original call
+}
+```
+
+---
+
+## Choosing Between Them
+
+- Data that is fine to lose and only matters briefly → **temporary**.
+- Small, hot config read on nearly every call → **instance**, and keep it small.
+- Anything per-user or per-record that must never silently vanish → **persistent**, and extend its TTL on every write that touches it.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Temporary, instance, and persistent storage are compared directly
+- [ ] TTL extension flow (`threshold` / `extend_to`) is explained
+- [ ] A working example is given for each of the three storage types
+- [ ] Archival + `RestoreFootprintOp` behavior is covered for instance/persistent

--- a/routes-d/431-account-recovery-design-pattern.mdx
+++ b/routes-d/431-account-recovery-design-pattern.mdx
@@ -1,0 +1,217 @@
+---
+title: Account Recovery Design Pattern
+description: A complete account recovery pattern for Stellar accounts using weighted signers and pre-authorized transactions — trust model, signer setup, and recovery flow with a reference example.
+date: 2026-07-26
+---
+
+# Account Recovery Design Pattern
+
+Losing the sole signing key to a Stellar account is unrecoverable by default — there is no password reset. This guide covers a recovery pattern built entirely from primitives already in the Stellar protocol: weighted multisig signers and pre-authorized transactions. No custodian holds your funds at any point.
+
+---
+
+## Trust Model
+
+Three keys participate, each trusted for a different purpose:
+
+- **Device key** — the key a user signs with day to day. Full trust for normal spending, but assumed losable (lost phone, wiped device).
+- **Guardian key(s)** — one or more keys held by a recovery service, a friend, or a second device. Individually trusted for _nothing_ — a guardian key alone must never be able to move funds or replace the device key.
+- **Pre-authorized recovery transaction** — a specific, fully-formed transaction (replacing the lost device key) that the user pre-signs while they still have the device key, then discards the signing key's involvement. It becomes valid on its own once a time precondition passes, without needing anyone's signature at redemption time.
+
+The trust boundary is enforced by **weights and thresholds**, not by asking any party to behave — the protocol itself refuses to execute an operation until enough weight signs it.
+
+| Party                                 | Trusted alone to spend?          | Trusted alone to change signers?                                         |
+| ------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| Device key                            | Yes (meets low/medium threshold) | No                                                                       |
+| Single guardian                       | No                               | No                                                                       |
+| Guardian quorum (M-of-N) + device key | —                                | Yes, for recovery-class ops                                              |
+| Pre-auth recovery tx                  | —                                | Yes, but only after it, alone, was pre-signed by the original device key |
+
+---
+
+## Signer Setup
+
+Stellar's `SetOptions` operation manages signers and per-operation-class thresholds (`low`, `medium`, `high`). The pattern:
+
+1. Keep the device key as the account's master key, but lower its effective control by setting thresholds above its own weight for the operation classes you want to protect.
+2. Add guardian keys with small individual weights, so no single guardian can act alone.
+3. Add a pre-authorized transaction hash as a special signer — a signer entry whose "key" is `hash(recovery_tx)` rather than a public key. It counts as already signed by definition.
+
+```ts
+// scripts/setup-recovery.ts
+import {
+  Account,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  Networks,
+  hash,
+} from '@stellar/stellar-sdk';
+
+const deviceKey = Keypair.fromSecret(process.env.DEVICE_SECRET!);
+const guardianA = 'GADR...A'; // recovery service signer
+const guardianB = 'GADR...B'; // second device / trusted contact
+
+async function setupRecovery(
+  server: import('@stellar/stellar-sdk').Horizon.Server
+) {
+  const account = await server.loadAccount(deviceKey.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee: '10000',
+    networkPassphrase: Networks.PUBLIC,
+  })
+    // Device key keeps weight 10 — enough alone for low/medium threshold ops.
+    .addOperation(Operation.setOptions({ masterWeight: 10 }))
+    // Guardians get weight 5 each — neither alone meets any threshold.
+    .addOperation(
+      Operation.setOptions({
+        signer: { ed25519PublicKey: guardianA, weight: 5 },
+      })
+    )
+    .addOperation(
+      Operation.setOptions({
+        signer: { ed25519PublicKey: guardianB, weight: 5 },
+      })
+    )
+    // High threshold (signer changes, master key changes) requires 10 —
+    // device key alone still cannot re-key the account; needs a guardian too.
+    .addOperation(
+      Operation.setOptions({
+        lowThreshold: 5,
+        medThreshold: 10,
+        highThreshold: 15,
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(deviceKey);
+  return server.submitTransaction(tx);
+}
+```
+
+With `highThreshold: 15`, the device key (weight 10) needs at least one guardian (weight 5) to co-sign any `SetOptions` that changes signers again — this is what stops a stolen device key alone from locking out the real owner's recovery path.
+
+---
+
+## The Pre-Authorized Recovery Transaction
+
+Separately, while the device key is still available, pre-sign a recovery transaction that replaces the device key entirely, and set it to only become valid after a time delay (so a would-be attacker who steals it cannot use it immediately — the real owner has a window to notice and react):
+
+```ts
+// scripts/build-preauth-recovery.ts
+import {
+  Account,
+  Operation,
+  TransactionBuilder,
+  Networks,
+  hash,
+} from '@stellar/stellar-sdk';
+
+async function buildPreauthRecovery(
+  server: import('@stellar/stellar-sdk').Horizon.Server,
+  accountId: string,
+  newDeviceKey: string
+) {
+  const account = await server.loadAccount(accountId);
+  const minTime = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7; // 7-day delay
+
+  const recoveryTx = new TransactionBuilder(account, {
+    fee: '10000',
+    networkPassphrase: Networks.PUBLIC,
+    timebounds: { minTime, maxTime: 0 },
+  })
+    .addOperation(
+      Operation.setOptions({
+        masterWeight: 10,
+        signer: { ed25519PublicKey: newDeviceKey, weight: 10 },
+      })
+    )
+    // Old device key is fully revoked in the same transaction.
+    .build();
+
+  const preauthHash = hash(recoveryTx.signatureBase());
+
+  // Register the pre-auth hash as a signer on the LIVE account, weight = highThreshold.
+  const registerTx = new TransactionBuilder(account, {
+    fee: '10000',
+    networkPassphrase: Networks.PUBLIC,
+  })
+    .addOperation(
+      Operation.setOptions({
+        signer: { preAuthTx: preauthHash, weight: 15 },
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  return { recoveryTx, registerTx };
+}
+```
+
+`recoveryTx` itself is stored offline (with the guardian service, or split via Shamir among trusted contacts) — it needs no further signature once its `minTime` precondition passes, because the network already trusts `hash(recoveryTx)` as a signer with weight 15.
+
+---
+
+## Recovery Flow
+
+**Normal operation:** device key alone signs payments — weight 10 clears `lowThreshold`/`medThreshold`.
+
+**Device key lost, guardians available:** user proves identity to guardians out of band; user's new key + one guardian co-sign a `SetOptions` swapping the signer — combined weight 15 clears `highThreshold`.
+
+```ts
+async function guardianAssistedRecovery(
+  server: import('@stellar/stellar-sdk').Horizon.Server,
+  accountId: string,
+  newDeviceKeypair: import('@stellar/stellar-sdk').Keypair,
+  guardianKeypair: import('@stellar/stellar-sdk').Keypair
+) {
+  const account = await server.loadAccount(accountId);
+  const tx = new TransactionBuilder(account, {
+    fee: '10000',
+    networkPassphrase: Networks.PUBLIC,
+  })
+    .addOperation(
+      Operation.setOptions({
+        signer: { ed25519PublicKey: newDeviceKeypair.publicKey(), weight: 10 },
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(guardianKeypair); // guardian's weight-5 signature
+  // A second guardian or another available signer must also sign to reach weight 15.
+  return server.submitTransaction(tx);
+}
+```
+
+**Guardians unavailable (worst case):** the pre-authorized `recoveryTx` becomes submittable on its own once `minTime` passes — no signature required, since the network already counts it as pre-signed:
+
+```ts
+async function submitPreauthRecovery(
+  server: import('@stellar/stellar-sdk').Horizon.Server,
+  recoveryTx: import('@stellar/stellar-sdk').Transaction
+) {
+  return server.submitTransaction(recoveryTx); // no .sign() call — the tx IS the signature
+}
+```
+
+---
+
+## Failure Modes to Design Around
+
+- **Guardian collusion**: never give guardians combined weight to reach `highThreshold` without the device key — require the device key's replacement to always route through a fresh device key + guardian quorum, not guardians alone.
+- **Lost recovery tx**: if the offline `recoveryTx` copy is lost, the time-locked fallback disappears; guardian-assisted recovery is the only remaining path, so guardians should still be independently reachable.
+- **Stale pre-auth tx**: a pre-authorized transaction sets a fixed new key at creation time. If that intended replacement key is later itself compromised, the pre-auth tx as recorded is now unsafe to redeem — rotate it (revoke the old `preAuthTx` signer, register a new one) whenever the target key changes.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Trust model is stated explicitly, including what no single party can do alone
+- [ ] Signer setup covers weights and per-class thresholds
+- [ ] Both guardian-assisted and pre-authorized-transaction recovery flows are shown
+- [ ] A reference example is given for setup, guardian recovery, and pre-auth redemption


### PR DESCRIPTION
## Summary
- Adds a thorough guide comparing Soroban temporary, instance, and persistent storage, including TTL extension flow (`threshold`/`extend_to`) and a working example for each storage type.
- Adds a complete account recovery design pattern doc: trust model, weighted-signer setup, and both guardian-assisted and pre-authorized-transaction recovery flows, with a reference example for each step.

Both are scoped to documentation only, placed in `routes-d/` per repo convention, matching existing MDX frontmatter/style.

Closes #426
Closes #431

## Test plan
- [x] `pnpm build:content` runs clean (pre-existing unrelated warning on `guides/custom-hook-authoring-playbook.mdx`, not touched by this PR)
- [x] Files added under `routes-d/` only, matching existing frontmatter (`title`, `description`, `date`) and section style of other routes-d drafts
- [ ] Maintainer review/approval