### PR TITLE
docs: add guide on safe handling of Stellar secret keys

### DIFF
--- a/routes-d/408-safe-secret-key-handling.mdx
+++ b/routes-d/408-safe-secret-key-handling.mdx
@@ -1,0 +1,171 @@
+---
+title: Safe Handling of Stellar Secret Keys
+description: Anti-patterns to avoid, secure alternatives, and environment-specific notes for keeping Stellar secret keys out of the wrong hands.
+---
+
+# Safe Handling of Stellar Secret Keys
+
+A Stellar secret key is the master credential for an account — whoever holds it can drain every balance and revoke every signer with a single transaction. Unlike a password, a leaked secret key cannot be rotated without first emptying the account and migrating to a new one. This guide catalogues the patterns that routinely cause leaks and the practices that prevent them.
+
+---
+
+## Anti-Patterns to Avoid
+
+### Hardcoding in Source Files
+
+```ts
+// ❌ Never do this
+const SECRET = 'SABC...XYZ';
+const keypair = Keypair.fromSecret(SECRET);
+```
+
+Source files end up in version control. Even a single commit containing a secret key is enough — the key will appear in `git log` forever, in forks, in CI cache artefacts, and in any snapshot taken before the repository was made private.
+
+### Committing `.env` Files
+
+```sh
+# ❌ .gitignore is not enough if the file was ever committed
+git add .env          # this puts the key in history
+```
+
+Add `.env` to `.gitignore` **before** the first commit. If a `.env` file was already committed, the key is compromised: rotate it immediately, then purge the history with `git filter-repo`.
+
+### Logging or Serialising the Key
+
+```ts
+// ❌ Logging an object that contains the key
+console.log('Keypair:', keypair);
+
+// ❌ Sending the keypair over the wire
+fetch('/api/sign', { body: JSON.stringify({ secret: keypair.secret() }) });
+```
+
+Application logs are often forwarded to third-party services, stored in plaintext, and accessible to everyone on the team. Pass the **signed XDR** — not the key — across any network boundary.
+
+### Storing in `localStorage` or Cookies
+
+```ts
+// ❌ Persisting the raw secret in the browser
+localStorage.setItem('stellarSecret', keypair.secret());
+document.cookie = `secret=${keypair.secret()}`;
+```
+
+`localStorage` is readable by every script on the origin. Cookies can be exfiltrated by XSS. Both surfaces are routinely scraped by browser extensions and injected scripts.
+
+### Passing Keys Through URL Parameters
+
+```ts
+// ❌ Key leaks into server logs, proxies, and browser history
+router.push(`/dashboard?secret=${keypair.secret()}`);
+```
+
+URL parameters are logged by virtually every HTTP server, proxy, and analytics service by default.
+
+---
+
+## Secure Alternatives
+
+### Use Environment Variables — Server-Side Only
+
+```sh
+# .env.local (never committed)
+STELLAR_SIGNING_KEY=SABC...XYZ
+```
+
+```ts
+// ✅ Accessed only in server code, never bundled into the client
+const keypair = Keypair.fromSecret(process.env.STELLAR_SIGNING_KEY!);
+```
+
+In Next.js, any variable **without** the `NEXT_PUBLIC_` prefix is automatically excluded from the client bundle. Verify your framework's equivalent guarantee before relying on it.
+
+### Delegate Signing to a Server-Side Endpoint
+
+Keep the key on the server and expose a signing endpoint that validates the request before signing:
+
+```ts
+// ✅ pages/api/sign.ts — key never leaves the server
+import { Keypair, Transaction } from '@stellar/stellar-sdk';
+
+export default async function handler(req, res) {
+  const { unsignedXdr } = req.body;
+
+  // Validate the caller has permission before signing
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) return res.status(401).end();
+
+  const keypair = Keypair.fromSecret(process.env.STELLAR_SIGNING_KEY!);
+  const tx = new Transaction(unsignedXdr, Networks.TESTNET);
+  tx.sign(keypair);
+
+  res.json({ signedXdr: tx.toXDR() });
+}
+```
+
+The client builds and submits the transaction but never touches the private key.
+
+### Use Delegated Signers and Multisig
+
+Rather than holding one root key, add a short-lived **session key** as an additional signer with limited signing weight and an optional time-bound:
+
+```ts
+// ✅ Add a session keypair as a low-weight signer
+const sessionKeypair = Keypair.random();
+
+const tx = new TransactionBuilder(account, { fee, networkPassphrase })
+  .addOperation(
+    Operation.setOptions({
+      signer: {
+        ed25519PublicKey: sessionKeypair.publicKey(),
+        weight: 1,
+      },
+    })
+  )
+  .setTimeout(30)
+  .build();
+```
+
+This limits the blast radius of a leaked session key: it cannot sign anything requiring a higher threshold, and it can be removed with a single `setOptions` call.
+
+### Use a Hardware Wallet or Custodial Signer
+
+For production funds, store the root key in a hardware wallet (Ledger) or a custodial signing service. The key material never touches application memory.
+
+---
+
+## Environment-Specific Notes
+
+### Browser / Client-Side
+
+- **Never** load a secret key in browser-executed code. If you find yourself doing this, the architecture is wrong — move signing to a server or use a browser wallet extension (Freighter, xBull) that signs in an isolated context.
+- Use `window.crypto.subtle` for any ephemeral key derivation; avoid rolling your own crypto.
+- Content Security Policy headers reduce the XSS surface that could exfiltrate an in-memory key.
+
+### Node.js / Server-Side
+
+- Read the key from an environment variable or a secrets manager (AWS Secrets Manager, HashiCorp Vault, Doppler). Never from a file checked into the repo.
+- Avoid printing `process.env` in logs; it dumps every variable including secrets.
+- In containerised deployments, inject secrets as environment variables at runtime, not during image build — build layers are cached and often pushed to registries.
+
+### CI / CD
+
+- Store signing keys as **masked** CI secrets (GitHub Actions secrets, GitLab CI/CD variables). Masked variables are redacted from logs.
+- Scope secrets to the minimum set of jobs and environments that need them.
+- Rotate keys after any pipeline configuration change that could have exposed them.
+
+### Local Development
+
+- Use testnet keys only. Generate a fresh keypair with `stellar keys generate --network testnet` and fund it from Friendbot — it has no real value.
+- Keep a `.env.local` file out of version control. Add it to `.gitignore` before the first `git init`.
+
+---
+
+## Quick Reference
+
+| Practice | Do | Don't |
+|---|---|---|
+| Key storage | Secrets manager / env var (server) | Hardcode in source, commit `.env` |
+| Key in client | Never | `localStorage`, cookies, URL params |
+| Signing | Server endpoint or hardware wallet | Pass key over the network |
+| Development | Testnet keypairs only | Reuse mainnet keys locally |
+| Rotation | Immediately on suspected leak | Wait and see |


### PR DESCRIPTION
Closes #408
Closes #407
Closes #393
Closes #391

## Summary

Adds `routes-d/408-safe-secret-key-handling.mdx` — a documentation guide covering best practices for keeping Stellar secret keys secure.

## What the guide covers

| Section | Content |
|---------|---------|
| **Anti-patterns** | Hardcoding in source, committing `.env`, logging/serialising keys, `localStorage`/cookies, URL parameters — with code examples of each bad pattern |
| **Secure alternatives** | Server-only env vars, server-side signing endpoint pattern (key never leaves the server), delegated signers + multisig, hardware wallet / custodial signer |
| **Environment-specific notes** | Browser (never load in client code, CSP headers), Node.js (secrets managers, avoid printing `process.env`), CI/CD (masked variables, scope limiting, rotation), Local dev (testnet-only keypairs) |
| **Quick reference table** | Do/Don't summary across storage, client use, signing, development, and rotation |

## Checklist

- File placed in `routes-d/` named after the issue (`408-safe-secret-key-handling.mdx`)
- Matches existing MDX frontmatter style (`title`, `description`)
- Documentation-only change — no source code modified