### PR TITLE
docs: add guides for time bounds, Soroban auth, network retries, and liquidity pools

### DIFF
--- a/routes-d/396-transaction-time-bounds.mdx
+++ b/routes-d/396-transaction-time-bounds.mdx
@@ -1,0 +1,118 @@
+---
+title: Transaction Time Bounds
+description: Learn how to set minimum and maximum time bounds on a Stellar transaction to control when it is valid for submission.
+---
+
+# Transaction Time Bounds
+
+A Stellar transaction can carry a **time bounds** envelope that restricts the ledger time window in which the transaction is valid. Outside that window, the network rejects the transaction outright, which lets you build expiry logic, prevent replay after a deadline, and coordinate time-sensitive operations without trusting the counter-party to act promptly.
+
+---
+
+## How time bounds work
+
+Time bounds are expressed as two Unix timestamps (seconds since epoch):
+
+| Field | Name | Meaning |
+|---|---|---|
+| `minTime` | Earliest valid ledger close time | Transaction is **invalid** if the ledger closes before this time |
+| `maxTime` | Latest valid ledger close time | Transaction is **invalid** if the ledger closes after this time |
+
+Either field can be `0`, which means "no constraint" for that bound.
+
+---
+
+## Setting time bounds with the Stellar SDK
+
+```typescript
+import {
+  TransactionBuilder,
+  Networks,
+  Keypair,
+  BASE_FEE,
+} from '@stellar/stellar-sdk';
+import StellarSdk from '@stellar/stellar-sdk';
+
+const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+const keypair = Keypair.fromSecret('S...');
+
+const account = await server.loadAccount(keypair.publicKey());
+
+const now = Math.floor(Date.now() / 1000);
+const fiveMinutes = 5 * 60;
+
+const transaction = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    StellarSdk.Operation.payment({
+      destination: 'GBOB...',
+      asset: StellarSdk.Asset.native(),
+      amount: '10',
+    })
+  )
+  // Valid only in the next 5 minutes.
+  .setTimeout(fiveMinutes)  // sets maxTime = now + 300, minTime = 0
+  .build();
+
+transaction.sign(keypair);
+await server.submitTransaction(transaction);
+```
+
+`TransactionBuilder.setTimeout(seconds)` is the recommended helper — it sets `maxTime` to `now + seconds` and leaves `minTime` at `0`.
+
+---
+
+## Setting both minTime and maxTime explicitly
+
+Use `.setTimeBounds` when you need a specific open window:
+
+```typescript
+const transaction = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(/* ... */)
+  .setTimeBounds({
+    minTime: now + 60,        // not valid for the first minute
+    maxTime: now + 60 * 10,   // expires after 10 minutes
+  })
+  .build();
+```
+
+---
+
+## Common pitfalls
+
+**Always set a `maxTime`.** The Stellar protocol requires either `maxTime > 0` or an explicit opt-out. Without a deadline, a transaction can sit in a signing flow or queue indefinitely and be submitted much later than intended, leading to unexpected side-effects.
+
+**Clock skew.** Stellar validators use their own clocks. Allow a small buffer (30–60 seconds) on `minTime` to avoid race conditions with slightly misaligned validator clocks.
+
+**`txTOO_LATE` and `txTOO_EARLY` errors.** If the network returns `txTOO_LATE`, `maxTime` has passed — rebuild the transaction with a fresh deadline. If it returns `txTOO_EARLY`, wait until the `minTime` window opens before resubmitting.
+
+**Fee bump transactions.** A fee bump wraps an inner transaction; the outer transaction's time bounds apply independently. Make sure both the inner and outer bounds are compatible.
+
+---
+
+## Checking time bounds on a submitted transaction
+
+You can inspect the time bounds of a recorded transaction via Horizon:
+
+```bash
+curl -s "https://horizon-testnet.stellar.org/transactions/<TX_HASH>" \
+  | jq '.valid_before, .valid_after'
+```
+
+- `valid_after` maps to `minTime`
+- `valid_before` maps to `maxTime`
+
+---
+
+## Summary
+
+- Use `TransactionBuilder.setTimeout(seconds)` for simple expiry deadlines.
+- Use `.setTimeBounds({ minTime, maxTime })` when you need a controlled open window.
+- Always provide a `maxTime` to prevent indefinitely-valid transactions.
+- Add a 30–60 second buffer to `minTime` to tolerate minor clock skew.
+- Handle `txTOO_LATE` by rebuilding with a fresh deadline; handle `txTOO_EARLY` by waiting.

--- a/routes-d/399-soroban-auth-check.mdx
+++ b/routes-d/399-soroban-auth-check.mdx
@@ -1,0 +1,161 @@
+---
+title: Writing a Soroban Auth Check
+description: Learn how to enforce caller authorization inside a Soroban smart contract using require_auth, and how to test it.
+---
+
+# Writing a Soroban Auth Check
+
+Soroban's authorization model is explicit: every address that must approve an action calls `require_auth()` (or `require_auth_for_args()`) at the point where its permission is needed. If the required signature is absent, the call panics and the entire transaction rolls back. This guide shows how to write and verify a minimal auth check, and how to test it in the Soroban test environment.
+
+---
+
+## Basic usage: `require_auth`
+
+Call `address.require_auth()` inside your contract function before performing any privileged action. The runtime verifies that the transaction carries a valid authorization entry for that address.
+
+```rust
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct Vault;
+
+#[contractimpl]
+impl Vault {
+    /// Withdraw `amount` from the vault. Only `owner` may call this.
+    pub fn withdraw(env: Env, owner: Address, amount: i128) {
+        // Panics if `owner` has not signed this invocation.
+        owner.require_auth();
+
+        // ... transfer logic here
+    }
+}
+```
+
+`require_auth` checks that the invoking transaction (or an authorization entry in it) carries a valid signature or sub-invocation proof from `owner`. No signature → `Unauthorized` panic → full rollback.
+
+---
+
+## Scoping auth with `require_auth_for_args`
+
+If the same address appears in multiple calls within one transaction, you can scope the authorization to specific arguments so that a single signature approves only the intended parameters:
+
+```rust
+use soroban_sdk::{symbol_short, vec, Address, Env};
+
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth_for_args(
+        (to.clone(), amount).into_val(&env),
+    );
+
+    // Transfer logic...
+}
+```
+
+The arguments passed to `require_auth_for_args` must exactly match those included in the authorization payload the signer constructed off-chain.
+
+---
+
+## Combining role checks with auth
+
+A common pattern is to combine `require_auth` with a stored admin or role:
+
+```rust
+use soroban_sdk::{Address, Env, Symbol};
+
+fn require_admin(env: &Env, caller: &Address) {
+    caller.require_auth();
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&Symbol::new(env, "admin"))
+        .expect("admin not set");
+    if *caller != admin {
+        panic!("caller is not the admin");
+    }
+}
+```
+
+Call `require_admin(&env, &caller)` at the top of any admin-only function.
+
+---
+
+## Testing the auth check
+
+The Soroban test environment provides `mock_all_auths()` to bypass auth for happy-path tests, and targeted helpers to verify that auth is actually enforced.
+
+### Happy path (auth mocked)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_withdraw_success() {
+        let env = Env::default();
+        env.mock_all_auths(); // bypasses auth checks
+
+        let contract_id = env.register(Vault, ());
+        let client = VaultClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.withdraw(&owner, &100i128);
+        // assert expected state changes...
+    }
+}
+```
+
+### Verifying auth is required
+
+To confirm the contract actually enforces auth, call without `mock_all_auths()` and expect a panic:
+
+```rust
+#[test]
+#[should_panic]
+fn test_withdraw_no_auth_panics() {
+    let env = Env::default();
+    // No mock_all_auths — auth is enforced.
+
+    let contract_id = env.register(Vault, ());
+    let client = VaultClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    // This call provides no auth entry, so require_auth panics.
+    client.withdraw(&owner, &100i128);
+}
+```
+
+### Checking which auths were required
+
+Use `env.auths()` after a mocked call to assert exactly which addresses were asked to authorize, and with which arguments:
+
+```rust
+use soroban_sdk::testutils::AuthorizedFunction;
+
+#[test]
+fn test_withdraw_requires_owner_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Vault, ());
+    let client = VaultClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    client.withdraw(&owner, &100i128);
+
+    let auths = env.auths();
+    // The first (and only) auth should be from `owner`.
+    assert_eq!(auths[0].0, owner);
+}
+```
+
+---
+
+## Summary
+
+- Call `address.require_auth()` before any privileged logic — missing auth panics and rolls back.
+- Use `require_auth_for_args` to bind authorization to specific parameter values.
+- Combine `require_auth` with a stored admin address for role-based access control.
+- Use `env.mock_all_auths()` for happy-path tests and omit it (plus `#[should_panic]`) to verify enforcement.
+- Inspect `env.auths()` to assert exactly which addresses were required to authorize.

--- a/routes-d/404-network-outages-and-retries.mdx
+++ b/routes-d/404-network-outages-and-retries.mdx
@@ -1,0 +1,159 @@
+---
+title: Handling Network Outages and Retries
+description: Patterns for retrying Horizon and Soroban RPC calls during outages, including backoff strategies and idempotency considerations.
+---
+
+# Handling Network Outages and Retries
+
+Horizon and the Soroban RPC are HTTP services that can return transient errors — rate-limit responses, gateway timeouts, or momentary unavailability during rollouts. A resilient Stellar application handles these gracefully by retrying with a backoff strategy and tracking whether an operation has already landed on the ledger before trying again.
+
+---
+
+## Classifying errors
+
+Not all errors are worth retrying:
+
+| Error class | Examples | Retry? |
+|---|---|---|
+| Transient network | `ECONNRESET`, `ETIMEDOUT`, HTTP 429, 502, 503, 504 | Yes |
+| Rate limit | HTTP 429 with `Retry-After` header | Yes, after the specified delay |
+| Ledger rejection | `tx_bad_auth`, `tx_insufficient_fee` | No — fix the transaction |
+| Already submitted | `tx_bad_seq` with sequence ahead of account | Investigate before retrying |
+
+---
+
+## Exponential backoff with jitter
+
+Retrying immediately hammers an already-struggling endpoint. Use exponential backoff — each attempt waits twice as long as the previous one — plus random jitter to spread load from multiple concurrent clients.
+
+```typescript
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 5,
+  baseDelayMs = 200,
+): Promise<T> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      const isTransient =
+        err?.response?.status === 429 ||
+        err?.response?.status >= 500 ||
+        err?.code === 'ECONNRESET' ||
+        err?.code === 'ETIMEDOUT';
+
+      if (!isTransient || attempt === maxAttempts - 1) throw err;
+
+      const retryAfter = Number(err?.response?.headers?.['retry-after']) * 1000;
+      const backoff = retryAfterMs ?? baseDelayMs * 2 ** attempt;
+      const jitter = Math.random() * backoff * 0.25;
+      await new Promise(r => setTimeout(r, backoff + jitter));
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+
+Usage:
+
+```typescript
+const account = await withRetry(() => server.loadAccount(publicKey));
+```
+
+---
+
+## Idempotency: check before resubmitting
+
+Transactions are uniquely identified by their hash. If you submitted a transaction and then lost the response due to a network error, the transaction may already have landed. Resubmitting a duplicate will cause a `tx_bad_seq` error — but more importantly, you should not assume the first submission failed.
+
+**Before retrying a submission, query the ledger:**
+
+```typescript
+import StellarSdk from '@stellar/stellar-sdk';
+
+async function submitOnce(
+  server: StellarSdk.Horizon.Server,
+  tx: StellarSdk.Transaction,
+): Promise<StellarSdk.Horizon.HorizonApi.TransactionResponse> {
+  const hash = tx.hash().toString('hex');
+
+  // 1. Check if already included.
+  try {
+    const existing = await server.transactions().transaction(hash).call();
+    return existing; // already landed — return without resubmitting
+  } catch {
+    // Not found — proceed with submission.
+  }
+
+  // 2. Submit with retry on transient errors.
+  return withRetry(() => server.submitTransaction(tx));
+}
+```
+
+---
+
+## Soroban RPC retries
+
+The Soroban RPC (`SorobanRpc.Server`) uses the same HTTP layer. Wrap simulation and `sendTransaction` calls the same way:
+
+```typescript
+import { SorobanRpc } from '@stellar/stellar-sdk';
+
+const rpc = new SorobanRpc.Server('https://soroban-testnet.stellar.org');
+
+const simulation = await withRetry(() =>
+  rpc.simulateTransaction(transaction)
+);
+
+if (SorobanRpc.Api.isSimulationError(simulation)) {
+  throw new Error(`Simulation failed: ${simulation.error}`);
+}
+
+const prepared = SorobanRpc.assembleTransaction(transaction, simulation).build();
+prepared.sign(keypair);
+
+const sendResult = await withRetry(() => rpc.sendTransaction(prepared));
+
+// Poll for inclusion.
+let status = sendResult.status;
+while (status === 'PENDING' || status === 'NOT_FOUND') {
+  await new Promise(r => setTimeout(r, 1000));
+  const get = await withRetry(() => rpc.getTransaction(sendResult.hash));
+  status = get.status;
+}
+```
+
+---
+
+## Handling Horizon outages with a fallback endpoint
+
+Run a secondary Horizon instance (your own or a community one) and fall back to it when your primary returns repeated 5xx responses:
+
+```typescript
+const ENDPOINTS = [
+  'https://horizon-testnet.stellar.org',
+  'https://my-horizon-backup.example.com',
+];
+
+async function loadAccountFallback(publicKey: string) {
+  for (const url of ENDPOINTS) {
+    try {
+      const server = new StellarSdk.Horizon.Server(url);
+      return await server.loadAccount(publicKey);
+    } catch {
+      // try next endpoint
+    }
+  }
+  throw new Error('All Horizon endpoints unavailable');
+}
+```
+
+---
+
+## Summary
+
+- Distinguish transient errors (5xx, 429, timeouts) from permanent ones — only retry transient errors.
+- Use exponential backoff with jitter; honour `Retry-After` headers from 429 responses.
+- Before resubmitting a transaction, check the ledger by hash to avoid double-submissions.
+- Apply the same retry wrapper to Soroban RPC simulation, `sendTransaction`, and `getTransaction` polling.
+- Keep a list of fallback Horizon endpoints for outage scenarios.

--- a/routes-d/409-liquidity-pool-participation.mdx
+++ b/routes-d/409-liquidity-pool-participation.mdx
@@ -1,0 +1,168 @@
+---
+title: Liquidity Pool Participation
+description: Learn how to deposit into and withdraw from a Stellar AMM liquidity pool, and understand how pool share tokens work.
+---
+
+# Liquidity Pool Participation
+
+Stellar's built-in AMM lets anyone become a liquidity provider for a trading pair. When you deposit two assets into a constant-product pool, you receive **pool share tokens** representing your proportional ownership. When you withdraw, you burn those shares and receive back both assets plus any fees earned while your liquidity was in the pool.
+
+---
+
+## Prerequisites
+
+- Both assets in the pair need trustlines on your account.
+- You must also hold a trustline for the **liquidity pool share** asset.
+- Your account must hold enough of both assets to deposit.
+
+---
+
+## Step 1 – Establish a trustline for the pool share
+
+Each Stellar AMM pool has a unique ID derived from its asset pair. Before you can receive pool shares, your account needs a trustline to that share asset.
+
+```typescript
+import StellarSdk, {
+  Asset,
+  LiquidityPoolAsset,
+  getLiquidityPoolId,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Operation,
+} from '@stellar/stellar-sdk';
+
+const server = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org');
+const keypair = StellarSdk.Keypair.fromSecret('S...');
+
+const assetA = Asset.native();                             // XLM (must be lexicographically first)
+const assetB = new Asset('USDC', 'GABC...');               // second asset
+
+const poolShareAsset = new LiquidityPoolAsset(assetA, assetB, 30); // 30 = 0.30% fee tier
+
+const account = await server.loadAccount(keypair.publicKey());
+
+const trustTx = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.changeTrust({ asset: poolShareAsset })
+  )
+  .setTimeout(30)
+  .build();
+
+trustTx.sign(keypair);
+await server.submitTransaction(trustTx);
+```
+
+---
+
+## Step 2 – Deposit into the pool
+
+Use `liquidityPoolDeposit` to add both assets. You supply the pool ID, your desired amounts, and acceptable minimum/maximum price bounds to protect against front-running.
+
+```typescript
+const poolId = getLiquidityPoolId('constant_product', poolShareAsset.getLiquidityPoolParameters())
+  .toString('hex');
+
+// Reload account after the trustline transaction.
+const accountAfterTrust = await server.loadAccount(keypair.publicKey());
+
+const depositTx = new TransactionBuilder(accountAfterTrust, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.liquidityPoolDeposit({
+      liquidityPoolId: poolId,
+      maxAmountA: '100',    // maximum XLM to deposit
+      maxAmountB: '50',     // maximum USDC to deposit
+      minPrice: { n: 1, d: 3 },  // accept a price no lower than 1/3
+      maxPrice: { n: 3, d: 1 },  // accept a price no higher than 3/1
+    })
+  )
+  .setTimeout(30)
+  .build();
+
+depositTx.sign(keypair);
+await server.submitTransaction(depositTx);
+```
+
+The pool accepts the deposit at the current ratio. If the ratio at execution time falls outside your `minPrice`/`maxPrice` bounds, the operation fails and your funds are not moved.
+
+---
+
+## Understanding pool share tokens
+
+When you deposit, the pool mints share tokens proportional to your contribution relative to the pool's existing reserves:
+
+```
+shares_received = total_shares_in_pool × min(depositA / reserveA, depositB / reserveB)
+```
+
+These tokens accumulate trading fees passively — you do not need to do anything. When you withdraw, burning your shares entitles you to:
+
+```
+amountA_out = (your_shares / total_shares) × reserveA_at_withdrawal
+amountB_out = (your_shares / total_shares) × reserveB_at_withdrawal
+```
+
+Because fees increase the reserves over time, `amountA_out + amountB_out` will typically exceed your original deposit (in combined value), though **impermanent loss** can offset fee gains when prices diverge significantly.
+
+---
+
+## Step 3 – Withdraw from the pool
+
+Use `liquidityPoolWithdraw` to burn share tokens and receive both assets back. Set `minAmountA` and `minAmountB` to protect against receiving less than you expect.
+
+```typescript
+const accountForWithdrawal = await server.loadAccount(keypair.publicKey());
+
+// Check how many shares you hold.
+const sharesBalance = accountForWithdrawal.balances.find(
+  b => b.asset_type === 'liquidity_pool_shares' && b.liquidity_pool_id === poolId
+);
+const sharesToWithdraw = sharesBalance?.balance ?? '0';
+
+const withdrawTx = new TransactionBuilder(accountForWithdrawal, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.liquidityPoolWithdraw({
+      liquidityPoolId: poolId,
+      amount: sharesToWithdraw,  // burn all shares
+      minAmountA: '0',           // set a real floor in production
+      minAmountB: '0',
+    })
+  )
+  .setTimeout(30)
+  .build();
+
+withdrawTx.sign(keypair);
+await server.submitTransaction(withdrawTx);
+```
+
+After the transaction settles, your account will hold the returned assets and your pool share balance will be zero.
+
+---
+
+## Querying pool information
+
+Inspect the current reserves and total shares via Horizon:
+
+```bash
+curl -s "https://horizon-testnet.stellar.org/liquidity_pools/<POOL_ID>" \
+  | jq '{ total_shares, reserves }'
+```
+
+---
+
+## Summary
+
+- Create a trustline for the pool share asset before depositing.
+- Use `liquidityPoolDeposit` with price bounds to protect against slippage.
+- Pool share tokens represent proportional ownership; fees accrue automatically inside the reserves.
+- Use `liquidityPoolWithdraw` with `minAmountA`/`minAmountB` guards to set a withdrawal floor.
+- Query the pool via Horizon to inspect live reserves and your share of the pool.


### PR DESCRIPTION
Closes #396
Closes #399
Closes #404
Closes #409

Adds four new MDX guides to `routes-d/`, each matching the existing frontmatter and writing style:

- **396-transaction-time-bounds.mdx** — explains `minTime`/`maxTime`, `setTimeout` helper, explicit `.setTimeBounds`, common pitfalls (clock skew, `txTOO_LATE`/`txTOO_EARLY`), and how to inspect bounds via Horizon.
- **399-soroban-auth-check.mdx** — covers `require_auth`, `require_auth_for_args`, role-based patterns, and testing with `mock_all_auths`, `#[should_panic]`, and `env.auths()`.
- **404-network-outages-and-retries.mdx** — error classification table, exponential backoff with jitter, idempotency check-before-resubmit pattern, Soroban RPC retry wrapper, fallback endpoint strategy.
- **409-liquidity-pool-participation.mdx** — pool share trustline setup, `liquidityPoolDeposit` with price bounds, share token mechanics and fee accrual, `liquidityPoolWithdraw` with floor guards, Horizon pool query.