### PR TITLE
docs: add asset auth flags, offer management, and testnet testing guides

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -106,10 +106,17 @@ export const sidebarNav: SidebarSection[] = [
         href: '/docs/guides/testing-horizon-soroban',
       },
       {
+        title: 'Testing Transactions on Testnet',
+        href: '/docs/guides/testing-transactions-testnet',
+      },
+      {
         title: 'Cross-Contract Calls',
         href: '/docs/guides/cross-contract-calls',
       },
-      { title: 'Hook Error Handling', href: '/docs/guides/hook-error-handling' },
+      {
+        title: 'Hook Error Handling',
+        href: '/docs/guides/hook-error-handling',
+      },
       {
         title: 'Wallet UX Patterns',
         href: '/docs/guides/wallet-ux-patterns',
@@ -142,6 +149,14 @@ export const sidebarNav: SidebarSection[] = [
       {
         title: 'Horizon vs Soroban RPC',
         href: '/docs/guides/horizon-vs-soroban-rpc',
+      },
+      {
+        title: 'Asset Authorization Flags',
+        href: '/docs/guides/asset-auth-flags',
+      },
+      {
+        title: 'Creating and Managing DEX Offers',
+        href: '/docs/guides/offer-creation-management',
       },
       {
         title: 'Documentation Roadmap',

--- a/docs/guides/asset-auth-flags.mdx
+++ b/docs/guides/asset-auth-flags.mdx
@@ -1,0 +1,110 @@
+---
+title: Asset Authorization Flags
+description: The Stellar asset authorization flags, what each one controls, how to set them from an issuing account, and common combinations for permissioned or regulated assets.
+date: 2026-07-28
+---
+
+# Asset Authorization Flags
+
+Every Stellar asset is controlled by flags set on its **issuing account**, not on the asset itself. These flags decide whether holders need approval before they can hold the asset, whether the issuer can later freeze or claw back funds, and whether the rules can ever change. This guide lists each flag, shows how to set them, and covers the combinations you'll see in practice.
+
+---
+
+## The flags
+
+| Flag                         | Value | Effect                                                                                 |
+| ---------------------------- | ----- | -------------------------------------------------------------------------------------- |
+| `AUTH_REQUIRED_FLAG`         | `1`   | Holders must be explicitly authorized by the issuer before they can hold the asset.    |
+| `AUTH_REVOCABLE_FLAG`        | `2`   | The issuer can revoke (freeze) a holder's authorization after it has been granted.     |
+| `AUTH_IMMUTABLE_FLAG`        | `4`   | Locks the account's flags permanently — no flag, including this one, can change again. |
+| `AUTH_CLAWBACK_ENABLED_FLAG` | `8`   | The issuer can claw back previously issued balances from a holder's trustline.         |
+
+Flags are combined with bitwise OR when setting more than one at a time (for example `AUTH_REQUIRED_FLAG \| AUTH_REVOCABLE_FLAG` = `3`).
+
+### `AUTH_REQUIRED_FLAG`
+
+Without this flag, any account can create a trustline and hold the asset immediately. With it set, a new trustline starts **unauthorized** — the holder can't receive the asset until the issuer approves that specific trustline with `Operation.setTrustLineFlags` (`authorized: true`). Use this for whitelisted or KYC-gated assets.
+
+### `AUTH_REVOCABLE_FLAG`
+
+Lets the issuer flip an already-authorized trustline back to unauthorized (or partially authorized, via `authorizedToMaintainLiabilities`) at any time, effectively freezing that holder. Without `AUTH_REVOCABLE_FLAG`, authorization granted once can never be taken back. This flag is also a prerequisite for enabling clawback on the account.
+
+### `AUTH_IMMUTABLE_FLAG`
+
+A one-way switch. Once set, no future `setOptions` can change flags on the account — not even to clear `AUTH_IMMUTABLE_FLAG` itself. Set it in the **same** operation as any other flags you want, since it's the last change you'll ever be able to make. Used to prove an asset's authorization model can never be tightened (or loosened) later.
+
+### `AUTH_CLAWBACK_ENABLED_FLAG`
+
+Enables the issuer to use `Operation.clawback` to reclaim asset balances directly from a holder's trustline (or a claimable balance) without their cooperation. Trustlines created after this flag is set on the issuer default to clawback-enabled. Requires `AUTH_REVOCABLE_FLAG` to also be set.
+
+---
+
+## Setting flags
+
+Flags are set with `Operation.setOptions` from the **issuing account**:
+
+```typescript
+import {
+  TransactionBuilder,
+  Operation,
+  Networks,
+  AuthRequiredFlag,
+  AuthRevocableFlag,
+} from '@stellar/stellar-sdk';
+
+const issuerAccount = await horizon.loadAccount(issuerPublicKey);
+
+const transaction = new TransactionBuilder(issuerAccount, {
+  fee: '100',
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.setOptions({
+      setFlags: AuthRequiredFlag | AuthRevocableFlag,
+    })
+  )
+  .setTimeout(30)
+  .build();
+```
+
+Clear a flag the same way with `clearFlags`:
+
+```typescript
+Operation.setOptions({
+  clearFlags: AuthRevocableFlag,
+});
+```
+
+Once `AUTH_REQUIRED_FLAG` is set, authorize a specific holder's trustline before they can receive the asset:
+
+```typescript
+Operation.setTrustLineFlags({
+  trustor: holderPublicKey,
+  asset: new Asset('USDC', issuerPublicKey),
+  flags: { authorized: true },
+});
+```
+
+Check an issuer's current flags via Horizon's account endpoint — `account.flags` returns `auth_required`, `auth_revocable`, `auth_immutable`, and `auth_clawback_enabled` as booleans.
+
+---
+
+## Common combinations
+
+| Combination                                                               | Value | Use case                                                                         |
+| ------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------------------- |
+| None set                                                                  | `0`   | Fully open asset — anyone can hold it; issuer has no freeze or clawback power.   |
+| `AUTH_REQUIRED_FLAG`                                                      | `1`   | Whitelist-only asset. Issuer approves each holder once, with no way to revoke.   |
+| `AUTH_REQUIRED_FLAG \| AUTH_REVOCABLE_FLAG`                               | `3`   | Standard regulated-asset pattern — approve holders, freeze bad actors later.     |
+| `AUTH_REVOCABLE_FLAG`                                                     | `2`   | Open enrollment with issuer retaining the ability to freeze after the fact.      |
+| `AUTH_REQUIRED_FLAG \| AUTH_REVOCABLE_FLAG \| AUTH_CLAWBACK_ENABLED_FLAG` | `11`  | Full compliance stack — approve, freeze, and claw back for legal orders.         |
+| Any combination `\| AUTH_IMMUTABLE_FLAG`                                  | `+4`  | Locks whatever rules are chosen permanently — no future tightening or loosening. |
+
+---
+
+## Related docs
+
+- [useTrustlines](/docs/hooks/use-trustlines) — creating and managing trustlines for permissioned assets
+- [Claimable Balances](/docs/guides/claimable-balances) — clawback also applies to claimable balances created from a clawback-enabled trustline
+- [Stellar Horizon](/docs/integrations/horizon) — reading account flags and trustline state
+- [Glossary](/docs/guides/glossary) — authorization, trustline, and issuer terminology

--- a/docs/guides/horizon-vs-soroban-rpc.mdx
+++ b/docs/guides/horizon-vs-soroban-rpc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Horizon vs Soroban RPC — Choosing the Right API
 description: A comprehensive comparison of Horizon and Soroban RPC to help you decide which API a given workload should talk to, including hybrid usage patterns.
-date: 2026-07-26
+date: 2026-07-28
 ---
 
 # Horizon vs Soroban RPC — Choosing the Right API
@@ -30,6 +30,12 @@ Stellar apps typically talk to two different servers: **Horizon**, the classic h
 | Order book / DEX queries                          | ✅ First-class                                                                                            | ❌ Not supported                                                                             |
 | Fee model                                         | Flat base fee per operation                                                                               | Resource-based fees computed via simulation (CPU, memory, ledger I/O, plus classic base fee) |
 | Rate limits                                       | Per-IP request limits (see [Rate Limiting Horizon Requests](/docs/guides/rate-limiting-horizon-requests)) | Also rate-limited; typically lower quotas on public endpoints than Horizon                   |
+
+## Latency and pagination differences
+
+**Pagination:** Horizon's list endpoints (`payments()`, `transactions()`, `offers()`, etc.) use cursor-based pagination — each response includes `_links.next`/`_links.prev`, and the SDK exposes it as `.cursor()`, `.limit()`, and `.order()`. This makes infinite-scroll history and "load more" UIs straightforward. Soroban RPC has no equivalent list/cursor API: `getEvents` takes a starting ledger and returns a `cursor` you pass to the next call, but it's bounded by a short retention window (recent ledgers only), and reads like `getLedgerEntries` and `simulateTransaction` are single-shot lookups against the latest state with nothing to paginate.
+
+**Latency:** Horizon supports server-sent event streams (`.stream()`) for near-real-time updates as new ledgers close (Stellar ledgers close roughly every 5 seconds). Soroban RPC has no streaming — consumers must poll `getEvents` or `getTransaction`, so effective latency is bounded by your polling interval, not by network push. A typical pattern is polling `getTransaction` every 1–2 seconds until the status leaves `PENDING`, versus subscribing once to a Horizon stream and reacting as events arrive.
 
 ## Suggested patterns for common needs
 

--- a/docs/guides/offer-creation-management.mdx
+++ b/docs/guides/offer-creation-management.mdx
@@ -1,0 +1,178 @@
+---
+title: Creating and Managing DEX Offers
+description: Create, update, and cancel offers on Stellar's built-in decentralized exchange, including how offer pricing works and a small end-to-end example.
+date: 2026-07-28
+---
+
+# Creating and Managing DEX Offers
+
+Stellar's ledger includes a built-in decentralized exchange (DEX): any account can post a limit offer to buy or sell one asset for another, and the network matches it against the order book automatically. Offers are created, updated, and cancelled with the same operation — `manageSellOffer` (or `manageBuyOffer`) — by changing the `offerId` and `amount` you pass in. This guide covers all three, plus how offer pricing works.
+
+For reading order book state (bids, asks, spread), see [useOfferBook](/docs/hooks/use-offer-book).
+
+---
+
+## Creating an offer
+
+Pass `offerId: '0'` to create a new offer. `selling`/`buying` set the trading pair, `amount` is how much of `selling` you're offering, and `price` is the exchange rate.
+
+```typescript
+import {
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Networks,
+} from '@stellar/stellar-sdk';
+
+const sourceAccount = await horizon.loadAccount(publicKey);
+
+const transaction = new TransactionBuilder(sourceAccount, {
+  fee: '100',
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.manageSellOffer({
+      selling: Asset.native(),
+      buying: new Asset(
+        'USDC',
+        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+      ),
+      amount: '100', // sell up to 100 XLM
+      price: '0.10', // 0.10 USDC per XLM
+      offerId: '0', // 0 = create a new offer
+    })
+  )
+  .setTimeout(30)
+  .build();
+```
+
+If the offer's price immediately crosses an existing offer on the other side of the book, it fills (fully or partially) instead of resting on the ledger — creating an offer is also how you take an existing one.
+
+An open offer holds part of the account's [minimum balance reserve](/docs/guides/glossary), same as a trustline, until it's filled or cancelled.
+
+## Updating an offer
+
+Reuse the same operation with the existing `offerId` and a new `amount` and/or `price`. Stellar has no separate "update" operation — changing an offer is replacing it in place.
+
+```typescript
+Operation.manageSellOffer({
+  selling: Asset.native(),
+  buying: new Asset(
+    'USDC',
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  ),
+  amount: '150', // revised amount
+  price: '0.12', // revised price
+  offerId: existingOfferId, // must match a live offer you own
+});
+```
+
+## Cancelling an offer
+
+Set `amount: '0'` on the existing `offerId`. The offer is removed from the book and its reserve is released.
+
+```typescript
+Operation.manageSellOffer({
+  selling: Asset.native(),
+  buying: new Asset(
+    'USDC',
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  ),
+  amount: '0',
+  price: '0.12', // price is ignored when amount is 0, but still required by the SDK
+  offerId: existingOfferId,
+});
+```
+
+## Pricing semantics
+
+- For `manageSellOffer`, `price` is the price of **1 unit of `selling` in terms of `buying`** — how much `buying` you receive per unit of `selling`.
+- For `manageBuyOffer`, `price` is the price of **1 unit of `buying` in terms of `selling`** — how much `selling` you pay per unit of `buying`.
+- `price` accepts a decimal string (`'0.10'`) or an explicit rational `{ n, d }` (`{ n: 1, d: 10 }`). Use the rational form when a repeating decimal would otherwise round (e.g. a `1/3` price).
+- Offers rest at their given price and are matched against better-or-equal offers on the opposite side first, so a newly created offer can fill immediately rather than resting.
+
+## Finding an offer's ID
+
+`manageSellOffer` doesn't return the created `offerId` directly in the built transaction — look it up from Horizon after submission:
+
+```typescript
+const { records } = await horizon
+  .offers()
+  .forAccount(publicKey)
+  .order('desc')
+  .limit(1)
+  .call();
+
+const offerId = records[0]?.id;
+```
+
+## Small example: full lifecycle
+
+```typescript
+async function manageOffer(
+  horizon: Server,
+  sourceAccount: Account,
+  offerId: string
+) {
+  const usdc = new Asset(
+    'USDC',
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  );
+
+  const buildAndSubmit = (op: ReturnType<typeof Operation.manageSellOffer>) =>
+    horizon.submitTransaction(
+      new TransactionBuilder(sourceAccount, {
+        fee: '100',
+        networkPassphrase: Networks.TESTNET,
+      })
+        .addOperation(op)
+        .setTimeout(30)
+        .build()
+    );
+
+  // 1. Create
+  await buildAndSubmit(
+    Operation.manageSellOffer({
+      selling: Asset.native(),
+      buying: usdc,
+      amount: '100',
+      price: '0.10',
+      offerId: '0',
+    })
+  );
+
+  // 2. Update price
+  await buildAndSubmit(
+    Operation.manageSellOffer({
+      selling: Asset.native(),
+      buying: usdc,
+      amount: '100',
+      price: '0.12',
+      offerId,
+    })
+  );
+
+  // 3. Cancel
+  await buildAndSubmit(
+    Operation.manageSellOffer({
+      selling: Asset.native(),
+      buying: usdc,
+      amount: '0',
+      price: '0.12',
+      offerId,
+    })
+  );
+}
+```
+
+Each step must be signed and submitted as its own transaction; the account's sequence number must be reloaded between submissions.
+
+---
+
+## Related docs
+
+- [useOfferBook](/docs/hooks/use-offer-book) — query order books and trading pairs
+- [useTrustlines](/docs/hooks/use-trustlines) — a trustline is required before offering or receiving a non-native asset
+- [Horizon vs Soroban RPC](/docs/guides/horizon-vs-soroban-rpc) — the DEX and order book are Horizon-only; Soroban RPC has no order book API
+- [Transaction Lifecycle](/docs/guides/transaction-lifecycle) — build, sign, submit, and confirm walkthrough
+- [Glossary](/docs/guides/glossary) — reserve, trustline, and DEX terminology

--- a/docs/guides/testing-transactions-testnet.mdx
+++ b/docs/guides/testing-transactions-testnet.mdx
@@ -1,0 +1,102 @@
+---
+title: Testing Transactions on Testnet
+description: A practical flow for funding testnet accounts, verifying transactions, and running a pre-mainnet smoke test before switching a Nextellar app to production.
+date: 2026-07-28
+---
+
+# Testing Transactions on Testnet
+
+Testnet runs the same protocol and SDK as mainnet, so it's the best place to exercise a full transaction flow — funding, building, signing, submitting, confirming — before pointing a Nextellar app at real funds. This guide covers funding and verifying testnet transactions, a smoke test checklist to run before switching, and the environment variables involved.
+
+This guide is about exercising real testnet transactions end to end. For mocking Horizon/Soroban and unit-testing hooks locally, see [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban) instead.
+
+---
+
+## 1. Point your app at testnet
+
+Nextellar apps read network configuration from environment variables — see the [Environment Options Reference](/docs/cli/environment-options) for the full list and [Network Switching](/docs/cli/configuration#network-switching) for the switch procedure. The testnet defaults:
+
+```bash
+# .env.local
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_SOROBAN_RPC=https://soroban-testnet.stellar.org
+NEXT_PUBLIC_NETWORK=TESTNET
+```
+
+Horizon, Soroban RPC, and `NEXT_PUBLIC_NETWORK` must all agree — a testnet Horizon URL paired with a `PUBLIC` network passphrase produces `tx_bad_auth` on every submission, since the signed transaction's network passphrase won't match what the server expects.
+
+## 2. Fund a testnet account with Friendbot
+
+Testnet accounts don't exist on the ledger until they're funded. Friendbot creates the account and sends it test XLM in one call:
+
+```bash
+curl "https://friendbot.stellar.org/?addr=<PUBLIC_KEY>"
+```
+
+Or from a script:
+
+```typescript
+async function fundTestnetAccount(publicKey: string) {
+  const res = await fetch(`https://friendbot.stellar.org/?addr=${publicKey}`);
+  if (!res.ok) throw new Error('Friendbot funding failed');
+}
+```
+
+## 3. Verify the account before transacting
+
+Confirm the account funded successfully and read its current sequence number before building a transaction — a stale sequence number is the most common cause of `tx_bad_seq` in testnet runs.
+
+```typescript
+const { balances } = useStellarBalances(publicKey);
+// or directly:
+const account = await horizon.loadAccount(publicKey);
+console.log(account.balances, account.sequenceNumber());
+```
+
+## 4. Build, sign, submit, and confirm
+
+Use [`useStellarPayment`](/docs/hooks/use-stellar-payment) (or the raw SDK, per [Transaction Lifecycle](/docs/guides/transaction-lifecycle)) to run a payment through the full flow, then verify it lands in history:
+
+```typescript
+const { buildPaymentXDR, submitSignedXDR } = useStellarPayment();
+
+const xdr = await buildPaymentXDR({ from, to, amount: '10', asset: 'XLM' });
+const signedXdr = await wallet.signTransaction(xdr);
+const result = await submitSignedXDR(signedXdr);
+
+if (result.success) {
+  console.log('Confirmed:', result.txHash);
+}
+```
+
+Cross-check the hash against Horizon directly, or with [`useTransactionHistory`](/docs/hooks/use-transaction-history), to confirm it's visible outside your own app state.
+
+---
+
+## Smoke test checklist
+
+Run through this before switching an app from testnet to mainnet:
+
+- [ ] Account funds successfully via Friendbot and the new balance is visible from Horizon within one ledger close (~5s)
+- [ ] A native XLM payment builds, signs, and submits successfully, and appears in transaction history
+- [ ] Trustline creation succeeds for every custom asset the app uses
+- [ ] A custom-asset payment succeeds once trusted, and fails with a readable error if the trustline is missing
+- [ ] Any Soroban contract calls simulate successfully before signing, and the invocation confirms via `getTransaction`
+- [ ] A wallet-rejected (declined) signature is handled without leaving the UI stuck in a loading state
+- [ ] An intentionally bad transaction (stale sequence number, insufficient balance) surfaces a readable error instead of crashing
+- [ ] The app's network indicator matches reality — correct passphrase, correct Horizon/Soroban URLs, no requests leaking to the other network
+
+## Switching to mainnet
+
+Once the checklist passes, flip the environment variables per [Network Switching](/docs/cli/configuration#network-switching). Testnet's fee market and ledger load don't mirror mainnet, so re-run at least the payment smoke test on mainnet with a small real-value transaction before considering the switch complete.
+
+---
+
+## Related docs
+
+- [Environment Options Reference](/docs/cli/environment-options) — full variable list, defaults, and valid values
+- [CLI Configuration — Network Switching](/docs/cli/configuration#network-switching) — switching between testnet and mainnet
+- [Transaction Lifecycle](/docs/guides/transaction-lifecycle) — build → sign → submit → confirm walkthrough
+- [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban) — mocking and unit-testing hooks locally
+- [Hook Error Handling](/docs/guides/hook-error-handling) — recovery patterns for submission failures
+- [Glossary](/docs/guides/glossary) — Friendbot, sequence number, and other key terms

--- a/routes-d/412-asset-auth-flags.mdx
+++ b/routes-d/412-asset-auth-flags.mdx
@@ -1,0 +1,33 @@
+# Working Draft — Issue #412
+
+## Document the asset auth flags
+
+**Status:** Complete
+**Target file:** `docs/guides/asset-auth-flags.mdx`
+**Sidebar entry:** Product Guides → "Asset Authorization Flags"
+
+### Scope
+
+Documentation-only. No code changes. The guide covers:
+
+1. Each Stellar issuer-account authorization flag: `AUTH_REQUIRED_FLAG`, `AUTH_REVOCABLE_FLAG`, `AUTH_IMMUTABLE_FLAG`, `AUTH_CLAWBACK_ENABLED_FLAG`
+2. How to set/clear flags with `Operation.setOptions`, and authorize a trustline with `Operation.setTrustLineFlags`
+3. Common flag combinations and their real-world use cases
+
+### Internal links used
+
+| Link text          | Href                            | Exists? |
+| ------------------ | ------------------------------- | ------- |
+| useTrustlines      | /docs/hooks/use-trustlines      | ✅      |
+| Claimable Balances | /docs/guides/claimable-balances | ✅      |
+| Stellar Horizon    | /docs/integrations/horizon      | ✅      |
+| Glossary           | /docs/guides/glossary           | ✅      |
+
+### Acceptance criteria checklist
+
+- [x] Lists each auth flag
+- [x] Shows how to set them
+- [x] Notes common combinations
+- [x] Frontmatter matches existing style (title, description, date)
+- [x] Sidebar entry added to Product Guides section in `config/sidebar.tsx`
+- [x] All internal links verified against existing MDX files

--- a/routes-d/414-offer-creation-management.mdx
+++ b/routes-d/414-offer-creation-management.mdx
@@ -1,0 +1,36 @@
+# Working Draft — Issue #414
+
+## Document offer creation and management
+
+**Status:** Complete
+**Target file:** `docs/guides/offer-creation-management.mdx`
+**Sidebar entry:** Product Guides → "Creating and Managing DEX Offers"
+
+### Scope
+
+Documentation-only. No code changes. The guide covers:
+
+1. Creating an offer with `Operation.manageSellOffer` (`offerId: '0'`)
+2. Updating an offer (same op, existing `offerId`, new amount/price)
+3. Cancelling an offer (`amount: '0'`)
+4. Pricing semantics for `manageSellOffer` vs `manageBuyOffer`
+5. Looking up an offer's ID from Horizon after creation
+6. A small end-to-end lifecycle example
+
+### Internal links used
+
+| Link text              | Href                                | Exists? |
+| ---------------------- | ----------------------------------- | ------- |
+| useOfferBook           | /docs/hooks/use-offer-book          | ✅      |
+| useTrustlines          | /docs/hooks/use-trustlines          | ✅      |
+| Horizon vs Soroban RPC | /docs/guides/horizon-vs-soroban-rpc | ✅      |
+| Transaction Lifecycle  | /docs/guides/transaction-lifecycle  | ✅      |
+| Glossary               | /docs/guides/glossary               | ✅      |
+
+### Acceptance criteria checklist
+
+- [x] Shows creating, updating, and cancelling offers
+- [x] Notes pricing semantics
+- [x] Provides a small example
+- [x] Sidebar entry added to Product Guides section in `config/sidebar.tsx`
+- [x] All internal links verified against existing MDX files

--- a/routes-d/416-horizon-vs-soroban-rpc-latency-pagination.mdx
+++ b/routes-d/416-horizon-vs-soroban-rpc-latency-pagination.mdx
@@ -1,0 +1,27 @@
+# Working Draft — Issue #416
+
+## Document the difference between Horizon and Soroban RPC
+
+**Status:** Complete
+**Target file:** `docs/guides/horizon-vs-soroban-rpc.mdx` (existing page, extended)
+
+### Scope
+
+Documentation-only. No code changes. `docs/guides/horizon-vs-soroban-rpc.mdx` already covers feature scope
+and suggested usage per API, but was missing an explicit callout of latency and pagination differences
+required by this issue. Added a new "Latency and pagination differences" section between the feature
+comparison table and the suggested-patterns table, and bumped the frontmatter `date`. No other section
+was restructured.
+
+### What was added
+
+- Pagination: Horizon's cursor-based list pagination vs Soroban RPC's bounded, cursor-less `getEvents`
+  and single-shot reads (`getLedgerEntries`, `simulateTransaction`)
+- Latency: Horizon's SSE streaming vs Soroban RPC's poll-only model, with a concrete polling cadence
+
+### Acceptance criteria checklist
+
+- [x] Notes feature scope of each (already present)
+- [x] Highlights latency and pagination differences (added)
+- [x] Suggests which to use when (already present)
+- [x] No existing content removed or restructured

--- a/routes-d/417-testing-transactions-testnet.mdx
+++ b/routes-d/417-testing-transactions-testnet.mdx
@@ -1,0 +1,42 @@
+# Working Draft — Issue #417
+
+## Add a guide on testing transactions on testnet
+
+**Status:** Complete
+**Target file:** `docs/guides/testing-transactions-testnet.mdx`
+**Sidebar entry:** Product Guides → "Testing Transactions on Testnet"
+
+### Scope
+
+Documentation-only. No code changes. Distinct from `docs/guides/testing-horizon-soroban.mdx`, which covers
+mocking Horizon/Soroban for unit tests — this guide covers exercising real transactions against live testnet
+before switching an app to mainnet. The guide covers:
+
+1. Environment switches needed to target testnet (linking to the existing env-vars reference instead of duplicating it)
+2. Funding a testnet account with Friendbot
+3. Verifying the funded account and sequence number before transacting
+4. Building, signing, submitting, and confirming a test transaction
+5. A smoke test checklist to run before switching to mainnet
+6. Notes on switching to mainnet after a clean run
+
+### Internal links used
+
+| Link text                                | Href                                      | Exists? |
+| ---------------------------------------- | ----------------------------------------- | ------- |
+| Environment Options Reference            | /docs/cli/environment-options             | ✅      |
+| CLI Configuration (network switching)    | /docs/cli/configuration#network-switching | ✅      |
+| useStellarBalances                       | /docs/hooks/use-stellar-balances          | ✅      |
+| useStellarPayment                        | /docs/hooks/use-stellar-payment           | ✅      |
+| useTransactionHistory                    | /docs/hooks/use-transaction-history       | ✅      |
+| Transaction Lifecycle                    | /docs/guides/transaction-lifecycle        | ✅      |
+| Testing Horizon and Soroban Interactions | /docs/guides/testing-horizon-soroban      | ✅      |
+| Hook Error Handling                      | /docs/guides/hook-error-handling          | ✅      |
+| Glossary                                 | /docs/guides/glossary                     | ✅      |
+
+### Acceptance criteria checklist
+
+- [x] Shows funding and verification steps
+- [x] Suggests a smoke test checklist
+- [x] Notes required env switches
+- [x] Sidebar entry added to Product Guides section in `config/sidebar.tsx`
+- [x] All internal links verified against existing MDX files


### PR DESCRIPTION
 Summary

  Adds four documentation guides to the Product Guides section, closing four open documentation issues.

  - Asset Authorization Flags — lists AUTH_REQUIRED_FLAG, AUTH_REVOCABLE_FLAG, AUTH_IMMUTABLE_FLAG, and
  AUTH_CLAWBACK_ENABLED_FLAG, how to set/clear them, and common real-world combinations.
  - Creating and Managing DEX Offers — creating, updating, and cancelling offers via manageSellOffer, pricing
  semantics, and a full lifecycle example.
  - Testing Transactions on Testnet — Friendbot funding, account/sequence verification, required env switches, and a
  pre-mainnet smoke test checklist. Cross-linked with (and scoped separately from) the existing mocked-testing guide.
  - Horizon vs Soroban RPC — extended the existing guide with a new "Latency and pagination differences" section
  (cursor pagination + SSE streaming vs. bounded getEvents/poll-only); no other content restructured.

  All four pages are registered in config/sidebar.tsx under Product Guides, and working drafts are included under
  routes-d/ named per issue number.

  Closes

  Closes #412
  Closes #414
  Closes #416
  Closes #417