### PR TITLE
Docs/issues 609 612 630 429

### DIFF
--- a/docs/cli/cheat-sheet.mdx
+++ b/docs/cli/cheat-sheet.mdx
@@ -40,6 +40,36 @@ nextellar my-app \
 nextellar my-app --defaults
 ```
 
+### Template Selection
+
+```bash
+# Scaffold with the minimal template
+nextellar my-app --template minimal
+
+# Scaffold with the DeFi template
+nextellar my-app --template defi
+
+# Scaffold a JavaScript project instead of TypeScript
+nextellar my-app --javascript
+```
+
+### Contracts
+
+```bash
+# Scaffold with Soroban smart contracts included
+nextellar my-app --with-contracts
+
+# Build the scaffolded Soroban contracts
+npm run contracts:build
+```
+
+### CI-Friendly Scaffold
+
+```bash
+# Non-interactive scaffold suitable for CI pipelines
+nextellar my-app --defaults --skip-install --no-telemetry
+```
+
 ## Development Commands
 
 ### Content & Build
@@ -116,6 +146,38 @@ nextellar add components
 
 # Add testing setup
 nextellar add testing
+```
+
+## Lifecycle Commands
+
+### Add & Diagnose
+
+```bash
+# Add the wallet connection feature
+nextellar add wallet
+
+# List all available features
+nextellar add --list
+
+# Run environment diagnostics as JSON (for CI)
+nextellar doctor --json
+```
+
+### Upgrade & Deploy
+
+```bash
+# Preview what an upgrade would change
+nextellar upgrade --dry-run
+
+# Validate a deployment without producing a bundle
+nextellar deploy --dry-run
+```
+
+### Telemetry
+
+```bash
+# Check telemetry status and config file path
+nextellar telemetry status
 ```
 
 ## Deployment

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -268,6 +268,73 @@ nextellar deploy
 nextellar deploy --dry-run
 ```
 
+### nextellar telemetry
+
+Manage anonymous CLI telemetry preferences.
+
+```bash
+nextellar telemetry <action>
+```
+
+**Arguments:**
+
+| Argument | Type   | Required | Description                          |
+| -------- | ------ | -------- | ------------------------------------- |
+| `action` | string | Yes      | One of `status`, `enable`, `disable` |
+
+**Examples:**
+
+```bash
+# Check current telemetry status and config file location
+nextellar telemetry status
+
+# Opt in to anonymous telemetry
+nextellar telemetry enable
+
+# Opt out of telemetry
+nextellar telemetry disable
+```
+
+**Output:**
+
+```bash
+nextellar telemetry status
+```
+
+```bash
+Telemetry is disabled.
+Config: /Users/you/.nextellar/config.json
+```
+
+`status`, `enable`, and `disable` all read from and write to the config file path printed above (`~/.nextellar/config.json`).
+
+**Disabling telemetry for a single invocation:**
+
+Pass `--no-telemetry` to the main scaffold command:
+
+```bash
+npx nextellar my-app --no-telemetry
+```
+
+**Disabling telemetry for an environment:**
+
+Set `NEXTELLAR_TELEMETRY_DISABLED` to force telemetry off, overriding both the stored config and any missing `--no-telemetry` flag:
+
+```bash
+export NEXTELLAR_TELEMETRY_DISABLED=1
+npx nextellar my-app
+```
+
+Accepted values are `1`, `true`, `yes`, or `on` (case-insensitive).
+
+**First-run notice:**
+
+The first time you scaffold a project without `--no-telemetry` or `NEXTELLAR_TELEMETRY_DISABLED` set, the CLI prints a one-time notice explaining that anonymous usage data is collected and how to opt out. The notice is shown once and then recorded in the config file so it isn't repeated on later runs.
+
+**What is sent:**
+
+Telemetry is opt-in — no events are sent until you run `nextellar telemetry enable`. Once enabled, a single anonymous `scaffold` event is sent to the `nextellar.dev` telemetry endpoint after each scaffold, containing the template, language, network, wallets, package manager, `--with-contracts` flag, success flag, CLI version, Node version, and OS. It never includes your project name, file paths, or secrets. See the CLI repository's [`docs/telemetry.md`](https://github.com/nextellarlabs/nextellar/blob/main/docs/telemetry.md) for the full payload shape and reliability guarantees.
+
 ## Project Creation Workflow
 
 When you run `nextellar my-app`, here's what happens:

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -56,6 +56,8 @@ Telemetry can be disabled for a single scaffold command:
 npx nextellar my-app --no-telemetry
 ```
 
+Telemetry can also be forced off for an environment with the `NEXTELLAR_TELEMETRY_DISABLED` env var, or managed persistently with `nextellar telemetry status|enable|disable`. See [Telemetry](/docs/cli/commands#nextellar-telemetry) in the CLI Commands reference for the full picture, including what data is sent.
+
 ## Notes
 
 - The `Alias` column shows shorthand forms where supported.

--- a/docs/customization/font.mdx
+++ b/docs/customization/font.mdx
@@ -12,14 +12,14 @@ The font used in this template is defined in `src/layout.tsx` using the `next/fo
 
 The font is imported and configured in `project-root/src/layout.tsx`:
 
-````tsx
+```tsx
 import { Geist } from 'next/font/google';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
 });
-```typescript
+```
 
 ## Applying the Font Globally
 
@@ -33,7 +33,7 @@ To apply the font globally, it is used in the `<body>` tag inside `project-root/
       text-sm
       font-regular tracking-wide antialiased`}
   >
-````
+```
 
 - `text-sm` is a Tailwind CSS utility class that controls the base font size.
 - You can change this to `xs`,`md`,`lg`, `xs`, `2xl`, or any other Tailwind font size to modify the default text size.
@@ -42,7 +42,7 @@ To apply the font globally, it is used in the `<body>` tag inside `project-root/
 
 If you need more control over typography settings, you can modify `tailwind.config.js` in the project root:
 
-````js
+```js
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -65,7 +65,7 @@ module.exports = {
   },
   plugins: [],
 };
-```typescript
+```
 
 - The `screens` object defines responsive breakpoints. You can modify them based on your requirements.
 - The default values provided are industry standards, but you can adjust them as needed.
@@ -80,7 +80,7 @@ const geistSans = Geist({
   weight: ['400', '700'],
   subsets: ['latin'],
 });
-```typescript
+```
 
 - `"400"` represents regular weight, while `"700"` is bold.
 - You can add more values like `"300"` (light) or `"900"` (extra bold) if required.
@@ -94,4 +94,3 @@ const geistSans = Geist({
 - You can modify font weight by adding an array of values in the font configuration.
 
 This guide helps you easily modify fonts and typography settings according to your design requirements.
-````

--- a/docs/customization/sidebar.mdx
+++ b/docs/customization/sidebar.mdx
@@ -84,14 +84,14 @@ If you want to add a new section, append an object to the `sidebarNav` array:
 
 To add a single page (without dropdown sub-pages):
 
-````tsx
+```tsx
 {
     title: "Standalone Page",
     icon: <Search className="h-5 w-5" />,
     href: "/docs/standalone-page",
     pages: [] // Keep empty
 }
-```json
+```
 
 ### Removing an Existing Section
 
@@ -114,4 +114,3 @@ The sidebar is typically used inside a `Sidebar.tsx` component inside the `compo
 - This is a simple modification that can be done quickly.
 
 This guide should help developers easily navigate and modify the sidebar for their documentation.
-````

--- a/docs/customization/toc.mdx
+++ b/docs/customization/toc.mdx
@@ -104,14 +104,14 @@ export const TocData = {
 
 To add a new TOC entry, insert a new key-value pair in `TocData`:
 
-````tsx
+```tsx
 'new-section/page-slug': [
     {
         title: "New Section",
         href: "/docs/new-section#new-section",
     }
 ]
-```json
+```
 
 ### Removing a TOC Entry
 
@@ -144,4 +144,3 @@ The TOC is used in the `toc.tsx` component, which dynamically retrieves TOC data
 - Changes are simple and allow for easy customization.
 
 This guide ensures developers can efficiently modify and maintain the TOC structure for their documentation.
-````

--- a/docs/getting-started/faq.mdx
+++ b/docs/getting-started/faq.mdx
@@ -69,6 +69,10 @@ Every Nextellar project ships with 8 production-ready hooks:
 | `useSorobanContract`    | Invoke Soroban smart contracts      |
 | `useSorobanEvents`      | Subscribe to contract events        |
 
+## Does Nextellar collect any data?
+
+Nextellar collects anonymous, opt-in telemetry to understand tool usage — no events are sent until you explicitly run `nextellar telemetry enable`. You can check your current setting, opt in or out, disable it for a single command with `--no-telemetry`, or force it off for an environment with `NEXTELLAR_TELEMETRY_DISABLED`. See [Telemetry](/docs/cli/commands#nextellar-telemetry) for the full command reference and what data is sent.
+
 ## Why does the content build step fail?
 
 The most common cause is a missing or malformed frontmatter field. Every MDX file requires `title` and `description`:

--- a/docs/sdk/api-reference.mdx
+++ b/docs/sdk/api-reference.mdx
@@ -59,9 +59,9 @@ const { signedTxXdr } = await kit.signTransaction(unsignedXdr, {
 
 Disconnects the current wallet session.
 
-````typescript
-await kit.disconnect();
 ```typescript
+await kit.disconnect();
+```
 
 ### `signTransaction(props)`
 
@@ -74,7 +74,7 @@ const signedXdr = await signTransaction({
   unsignedTransaction: xdr,
   address: publicKey,
 });
-```css
+```
 
 ---
 
@@ -97,7 +97,7 @@ const sourceAccount = await server.loadAccount(publicKey);
 
 // Submit transaction
 const result = await server.submitTransaction(transaction);
-````
+```
 
 ### Soroban RPC
 
@@ -157,12 +157,12 @@ const usdc = new Asset(
 
 ### Networks
 
-````typescript
+```typescript
 import { Networks } from '@stellar/stellar-sdk';
 
 Networks.TESTNET; // 'Test SDF Network ; September 2015'
 Networks.PUBLIC; // 'Public Global Stellar Network ; September 2015'
-```css
+```
 
 ---
 
@@ -178,7 +178,7 @@ interface Balance {
   balance: string;
   limit?: string;
 }
-````
+```
 
 ### Trustline
 
@@ -243,12 +243,12 @@ interface WalletContextState {
 
 ### WalletConfigContextState
 
-````typescript
+```typescript
 interface WalletConfigContextState {
   horizonUrl: string;
   network: string;
 }
-```css
+```
 
 ---
 
@@ -261,7 +261,7 @@ The hooks include built-in validation:
 ```typescript
 // Public keys are 56 characters starting with 'G'
 const isValid = key.length === 56 && key.startsWith('G');
-````
+```
 
 ### Secret Key Validation
 
@@ -279,10 +279,10 @@ const isValid = amount > 0 && amount <= 922337203685.4775807;
 
 ### Memo Validation
 
-````typescript
+```typescript
 // Text memos cannot exceed 28 characters
 const isValid = memo.length <= 28;
-```css
+```
 
 ---
 
@@ -294,7 +294,7 @@ Recommended environment variables for production:
 NEXT_PUBLIC_HORIZON_URL=https://horizon.stellar.org
 NEXT_PUBLIC_NETWORK=PUBLIC
 NEXT_PUBLIC_SOROBAN_RPC=https://soroban-rpc.stellar.org
-```bash
+```
 
 ---
 
@@ -303,4 +303,3 @@ NEXT_PUBLIC_SOROBAN_RPC=https://soroban-rpc.stellar.org
 - [Hooks Overview](/docs/hooks) - React hooks reference
 - [Wallet Integration](/docs/sdk/wallet-integration) - Multi-wallet setup guide
 - [CLI Reference](/docs/cli/commands) - Scaffolding options
-````

--- a/docs/sdk/wallet-integration.mdx
+++ b/docs/sdk/wallet-integration.mdx
@@ -105,7 +105,7 @@ const kit = new StellarWalletsKit({
 
 When a transaction needs to be signed, the wallet kit handles the communication with the user's wallet:
 
-````tsx
+```tsx
 import { kit, signTransaction } from '@/lib/stellar-wallet-kit';
 
 // Option 1: Use the kit directly
@@ -118,7 +118,7 @@ const signedXdr = await signTransaction({
   unsignedTransaction: unsignedXdr,
   address: publicKey,
 });
-```typescript
+```
 
 Most hooks handle this automatically. For example, `useStellarWallet` includes a `sendPayment` function that builds, signs, and submits transactions.
 
@@ -131,7 +131,7 @@ const kit = new StellarWalletsKit({
   network: WalletNetwork.TESTNET,
   // ...
 });
-````
+```
 
 ### Mainnet
 
@@ -206,7 +206,7 @@ For development, you can use the `signAndSubmitWithSecret` methods available on 
 > [!CAUTION]
 > This is for development/testing only. Never use secret keys in production.
 
-````tsx
+```tsx
 const { signAndSubmitWithSecret } = useStellarPayment();
 
 // DEV ONLY
@@ -216,7 +216,7 @@ const result = await signAndSubmitWithSecret({
   amount: '10',
   secret: 'SABC...', // Never do this in production!
 });
-```typescript
+```
 
 ## Common Issues
 
@@ -249,4 +249,3 @@ If the connection is lost unexpectedly:
 - [WalletProvider](/docs/hooks/wallet-provider) - Global wallet context
 - [useStellarWallet](/docs/hooks/use-stellar-wallet) - Wallet connection hook
 - [WalletConnectButton](/docs/hooks/wallet-connect-button) - Pre-built UI component
-````

--- a/routes-d/429-fee-bump-transaction-tutorial.mdx
+++ b/routes-d/429-fee-bump-transaction-tutorial.mdx
@@ -1,0 +1,174 @@
+---
+title: Fee Bump Transactions
+description: A complete tutorial on wrapping a signed Stellar transaction in a fee-bump transaction, covering the inner/outer transaction split, signer separation, and a working end-to-end sample.
+date: 2026-07-28
+---
+
+# Fee Bump Transactions
+
+A **fee-bump transaction** lets a separate account pay the network fee for a transaction that has already been built and signed, without touching the original signatures. This is the mechanism behind "gasless" UX, sponsor-paid transactions, and rescuing a transaction that was submitted with too low a fee during network congestion — a third party wraps the existing signed transaction in a new envelope and pays for it themselves.
+
+This guide covers the two-envelope structure that makes this possible, how signing responsibility is split between the two accounts involved, and a working sample you can run end to end.
+
+---
+
+## Inner and outer transactions
+
+A fee-bump transaction is not a modification of the original transaction — it is a second, outer envelope that wraps the first one unchanged:
+
+- **Inner transaction** — the original `Transaction`, built and signed normally by its source account. Its fee, sequence number, operations, and signatures are fixed the moment it's signed and are never altered by fee bumping.
+- **Outer transaction** — a `FeeBumpTransaction` that references the inner transaction's XDR and names a `feeSource` account that pays the actual network fee. This is what gets submitted to Horizon.
+
+```
+Inner tx:  built + signed by the source account (fee can be as low as BASE_FEE)
+              ↓ wrapped, unchanged
+Outer tx:  FeeBumpTransaction { feeSource, fee, innerTx }
+              ↓ signed by the fee source account
+Submitted: the outer envelope (Horizon applies the inner tx's operations)
+```
+
+Only the outer envelope is broadcast. Horizon and the network verify both envelopes: the outer signature authorizes payment of the fee, and the inner signatures authorize the operations that run against the inner transaction's source account.
+
+## Signer separation
+
+The two envelopes have independent signing domains, so the accounts involved never need to coordinate:
+
+- The inner transaction's source account signs **only** the inner transaction hash. It has no say in — and does not need to know about — how or by whom the fee eventually gets paid.
+- The fee source account signs **only** the outer `FeeBumpTransaction` hash, which is a distinct hash computed over the fee-bump envelope (network ID + `ENVELOPE_TYPE_TX_FEE_BUMP`), not the inner transaction's hash. A fee-bump signature cannot be substituted for an inner-transaction signature, or vice versa.
+- Wrapping a transaction in a fee bump **never requires re-signing the inner transaction** — that's what makes it possible to bump the fee on a transaction signed by a hardware wallet, a multisig quorum, or a user who is no longer available.
+- The fee source and the inner transaction's source can be the same account or two entirely different accounts. A paymaster service, a sponsor, or the original submitter with a fresh fee are all valid — the protocol only cares that the outer envelope carries a valid signature for the named `feeSource`.
+- The inner transaction must be an ordinary transaction — you cannot wrap a fee-bump transaction in another fee-bump transaction.
+
+## Building a fee-bump transaction
+
+`TransactionBuilder.buildFeeBumpTransaction` takes the fee source, a per-operation base fee, the inner transaction, and the network passphrase:
+
+```typescript
+import { TransactionBuilder, Networks, Keypair } from '@stellar/stellar-sdk';
+
+// The inner transaction, already built and signed by its own source account
+const innerTx = TransactionBuilder.fromXDR(innerTxXdr, Networks.TESTNET);
+
+const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+  feeSourceKeypair.publicKey(), // or an Account/MuxedAccount instance
+  '200', // baseFee: stroops per operation, inner tx + 1
+  innerTx,
+  Networks.TESTNET
+);
+
+// Only the fee source signs the outer envelope — the inner signatures are untouched
+feeBumpTx.sign(feeSourceKeypair);
+```
+
+`baseFee` is a per-operation rate, the same convention as `TransactionBuilder`'s `fee` option. The SDK computes the total fee charged as `baseFee * (innerOperationCount + 1)` — the `+1` accounts for the fee-bump wrapper itself. `buildFeeBumpTransaction` throws if `baseFee` is lower than either the network's minimum base fee or the inner transaction's own per-operation fee rate, so a fee bump can only raise the effective fee, never lower it.
+
+## Submitting and handling results
+
+The outer `FeeBumpTransaction` is what you submit — Horizon unpacks it and applies the inner transaction's operations if the fee is accepted:
+
+```typescript
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+try {
+  const result = await server.submitTransaction(feeBumpTx);
+  console.log('Fee-bumped transaction succeeded:', result.hash);
+} catch (err: any) {
+  const codes = err?.response?.data?.extras?.result_codes;
+
+  if (codes?.transaction === 'tx_fee_bump_inner_failed') {
+    // The fee bump itself was accepted, but the inner transaction failed —
+    // check codes.inner_transaction and codes.operations for the real cause.
+    console.error('Inner transaction failed:', codes.inner_transaction);
+  } else if (codes?.transaction === 'tx_insufficient_fee') {
+    // baseFee was too low for current network conditions; rebuild with a higher baseFee
+    console.error('Fee bump rejected: insufficient fee');
+  } else {
+    throw err;
+  }
+}
+```
+
+A rejected fee bump (`tx_insufficient_fee`) does not consume the inner transaction's sequence number, so it's safe to rebuild the fee bump with a higher `baseFee` and resubmit using the same inner transaction.
+
+## Working sample
+
+A complete example: account `A` signs a payment with the network minimum fee, then account `B` — a separate fee-paying account — wraps and pays for it.
+
+```typescript
+import {
+  TransactionBuilder,
+  Networks,
+  Operation,
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+} from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+async function buildAndSubmitFeeBump(
+  sourceKeypair: Keypair, // account A: builds and signs the inner transaction
+  feeSourceKeypair: Keypair, // account B: pays the actual network fee
+  destination: string,
+  amount: string
+) {
+  // 1. Account A builds and signs the inner transaction at the network minimum fee
+  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+
+  const innerTx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination,
+        asset: Asset.native(),
+        amount,
+      })
+    )
+    .setTimeout(180)
+    .build();
+
+  innerTx.sign(sourceKeypair);
+
+  // 2. Account B wraps the signed inner transaction in a fee-bump transaction.
+  //    innerTx's signature above is never touched.
+  const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+    feeSourceKeypair.publicKey(),
+    (Number(BASE_FEE) * 10).toString(), // bid well above the minimum
+    innerTx,
+    Networks.TESTNET
+  );
+
+  // 3. Account B signs only the outer envelope
+  feeBumpTx.sign(feeSourceKeypair);
+
+  // 4. Submit the outer envelope — account A never has to re-sign anything
+  const result = await server.submitTransaction(feeBumpTx);
+  return result.hash;
+}
+```
+
+Account A's wallet never needs to be online for step 2 or 3 — it can hand off the signed inner transaction XDR (`innerTx.toXDR()`) to account B ahead of time, and B builds and pays for the fee bump whenever it's convenient.
+
+## Pitfalls
+
+**Rebuilding the inner transaction invalidates the fee bump.** The outer envelope's hash is derived in part from the inner transaction's XDR. If you change anything about the inner transaction — even just rebuilding it with a different sequence number or timeout — you must build a fresh fee-bump transaction around it.
+
+**The fee source account still needs a funded, existing account.** `feeSource` is not exempt from needing to exist on the ledger with enough XLM to cover the fee; fee bumping shifts _who_ pays, not whether an account needs a balance.
+
+**You cannot fee-bump a transaction that's already a fee bump.** If you receive a signed envelope and aren't sure which kind it is, use `TransactionBuilder.fromXDR` and check whether the result is a `Transaction` or a `FeeBumpTransaction` before attempting to wrap it again.
+
+**A successful fee bump does not guarantee the inner transaction succeeded.** Always check for `tx_fee_bump_inner_failed` — the fee was accepted and charged, but the wrapped operations may still have failed (e.g. a bad sequence number or an operation-level error on the inner transaction).
+
+---
+
+## Related docs
+
+- [Fee Market Awareness](/docs/guides/fee-market-awareness) — dynamic fee pricing and recovering a stuck transaction with a fee bump
+- [Building a Paymaster on Stellar](/docs/guides/building-a-paymaster) — using fee-bump transactions to sponsor fees for other users
+- [Transaction Lifecycle](/docs/guides/transaction-lifecycle) — how a submitted envelope is validated and applied
+- [Glossary](/docs/guides/glossary) — fee-bump transaction, inner transaction, and other key terms


### PR DESCRIPTION
  - Document `nextellar telemetry status|enable|disable`, `NEXTELLAR_TELEMETRY_DISABLED`, and
  `--no-telemetry`, verified against the CLI source, with cross-links from the flags reference
  and FAQ.
  files were fixed rather than skipped.
  - Add a fee bump transaction tutorial draft in routes-d covering the inner/outer transaction
  split, signer separation, and a full working sample.

  ## Test plan

  - [x] `pnpm build:content` — no errors in any touched file
  - [x] `pnpm validate:sidebar` — 100% valid, no broken references
  - [x] Fence pairing verified programmatically for all 5 fixed files (even counts, no headings
  trapped inside code blocks)
  - [x] Telemetry commands and flags cross-checked against `bin/nextellar.ts` and
  `src/lib/telemetry.ts` in the CLI repo
  - [x] Cheat sheet commands cross-checked against CLI source (feature ids, scaffold options,
  generated npm scripts)
  - [x] Fee bump sample cross-checked against `TransactionBuilder.buildFeeBumpTransaction` in
  js-stellar-base

  Closes #609
  Closes #612
  Closes #630
  Closes #429