### PR TITLE
docs: add hook availability callouts

### DIFF
--- a/docs/hooks/use-offer-book.mdx
+++ b/docs/hooks/use-offer-book.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `useOfferBook` hook queries Stellar's decentralized exchange (DEX) order books, enabling trading interfaces and price discovery.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add defi`
+</Note>
+
 ## Features
 
 - **Order Book Data**: Fetch bids and asks for trading pairs

--- a/docs/hooks/use-soroban-contract.mdx
+++ b/docs/hooks/use-soroban-contract.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `useSorobanContract` hook provides a complete interface for interacting with Soroban smart contracts. It handles XDR value conversion, transaction simulation, and contract invocation.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add contracts`
+</Note>
+
 ## Features
 
 - **Read-Only Calls**: Simulate contract functions without submitting transactions

--- a/docs/hooks/use-soroban-events.mdx
+++ b/docs/hooks/use-soroban-events.mdx
@@ -8,9 +8,10 @@ date: 2026-07-28
 
 The `useSorobanEvents` hook polls a Soroban contract for events, retrying transient RPC failures with exponential backoff and continuing at a reduced rate instead of giving up.
 
-## Availability
-
-Ships with the `default` template (TypeScript and `--javascript`). Not included in `minimal` or `defi` — see [Scaffolding Templates](/docs/cli/templates).
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add contracts`
+</Note>
 
 ## Features
 

--- a/docs/hooks/use-stellar-balances.mdx
+++ b/docs/hooks/use-stellar-balances.mdx
@@ -10,6 +10,11 @@ The `useStellarBalances` hook provides real-time balance tracking for Stellar ac
 
 **Available in templates:** `default`, `minimal`, `defi`, `js`
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add balances`
+</Note>
+
 ## Features
 
 - **Real-Time Balances**: Automatic balance fetching with race condition safety

--- a/docs/hooks/use-stellar-payment.mdx
+++ b/docs/hooks/use-stellar-payment.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `useStellarPayment` hook provides advanced utilities for building, signing, and submitting Stellar payment transactions. It offers more control than `useStellarWallet.sendPayment()` with separate methods for each step of the payment flow.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add payments`
+</Note>
+
 ## Features
 
 - **Build Unsigned XDR**: Create transaction XDR for external wallet signing

--- a/docs/hooks/use-stellar-wallet.mdx
+++ b/docs/hooks/use-stellar-wallet.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `useStellarWallet` hook provides a complete solution for connecting to Stellar wallets, managing account state, and executing payments. It's the foundation of wallet integration in Nextellar apps.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add wallet`
+</Note>
+
 ## Features
 
 - **Multi-Wallet Support**: Freighter, Albedo, Lobstr, xBull, Hana

--- a/docs/hooks/use-transaction-history.mdx
+++ b/docs/hooks/use-transaction-history.mdx
@@ -13,6 +13,11 @@ The `useTransactionHistory` hook fetches and paginates a Stellar account's opera
   `minimal` or `defi` templates.
 </Note>
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add history`
+</Note>
+
 ## Features
 
 - **Cursor-Based Pagination**: Load additional pages using Horizon's `paging_token` cursor

--- a/docs/hooks/use-trustlines.mdx
+++ b/docs/hooks/use-trustlines.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `useTrustlines` hook manages asset trustlines, allowing accounts to hold custom Stellar assets. It provides methods to query existing trustlines, build change-trust transactions, and submit them to the network.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add trustlines`
+</Note>
+
 ## Features
 
 - **Query Trustlines**: Fetch and list all active trustlines for an account

--- a/docs/hooks/wallet-connect-button.mdx
+++ b/docs/hooks/wallet-connect-button.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 A production-ready React component for wallet connection with a polished dropdown interface. Handles the complete connection flow, displays wallet info, and provides quick actions.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add wallet`
+</Note>
+
 ## Features
 
 - **One-Click Connect**: Opens wallet selection modal

--- a/docs/hooks/wallet-provider.mdx
+++ b/docs/hooks/wallet-provider.mdx
@@ -8,6 +8,11 @@ date: 2026-06-02
 
 The `WalletProvider` component wraps your application to provide global wallet functionality throughout the component tree. It handles wallet connection, state persistence, and exposes its configuration to all Nextellar hooks.
 
+<Note>
+  **Ships in:** default, js<br/>
+  Not in your scaffold? Run `nextellar add wallet`
+</Note>
+
 ## Features
 
 - **Global Wallet State**: Share connection status across all components


### PR DESCRIPTION
#651 Add per-template availability + nextellar add callouts to every hook page
Closes  #651
**Title:** `docs: add hook availability and CLI callouts`

**Description:**
Adds a standard `<Note>` callout to all 10 hook/provider pages to clarify which templates ship each hook and how to add them to a scaffold using the `nextellar add <feature_id>` command. This connects the hook usage directly with the CLI commands, as requested in issue #651.

**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

**Changes made:**
- Added `nextellar add defi` callout to `use-offer-book.mdx`
- Added `nextellar add contracts` callout to `use-soroban-contract.mdx`
- Replaced older Availability section with `nextellar add contracts` callout in `use-soroban-events.mdx`
- Added `nextellar add balances` callout to `use-stellar-balances.mdx`
- Added `nextellar add payments` callout to `use-stellar-payment.mdx`
- Added `nextellar add wallet` callout to `use-stellar-wallet.mdx`, `wallet-connect-button.mdx`, and `wallet-provider.mdx`
- Added `nextellar add history` callout to `use-transaction-history.mdx`
- Added `nextellar add trustlines` callout to `use-trustlines.mdx`

**Checklist:**
- [x] `pnpm build:content` passes with no errors
- [x] `pnpm check:links` passes with no broken internal links
- [x] `pnpm lint` passes with no new warnings
- [x] New MDX files have valid frontmatter (`title` and `description`)
- [x] Internal links use absolute paths like `/docs/...`
