### PR TITLE
fix(#633): replace API Explorer with hosted API roadmap stub

### DIFF
--- a/config/sidebar.tsx
+++ b/config/sidebar.tsx
@@ -182,7 +182,7 @@ export const sidebarNav: SidebarSection[] = [
     icon: <Database className="h-5 w-5" />,
     defaultOpen: true,
     pages: [
-      { title: 'API Explorer', href: '/docs/api/explorer' },
+      { title: 'Hosted API (Roadmap)', href: '/docs/api' },
       { title: 'Overview', href: '/docs/sdk/overview' },
       { title: 'API Reference', href: '/docs/sdk/api-reference' },
       { title: 'Wallet Integration', href: '/docs/sdk/wallet-integration' },

--- a/docs/api/explorer.mdx
+++ b/docs/api/explorer.mdx
@@ -1,145 +1,19 @@
 ---
 title: API Explorer
-description: Explore Nextellar hooks, providers, and integration endpoints from one interactive reference page.
-date: 2026-06-02
+description: The API Explorer has been removed. See the Hosted API roadmap page.
+date: 2026-08-03
 ---
+
+import { Note } from '@/components/note';
 
 # API Explorer
 
-Use this explorer to scan the Nextellar API surface by workflow. Each section expands into the hooks, providers, endpoints, and documentation links that usually belong together.
-
-<Note type="info">
-  This page is documentation-first. It uses native browser controls so the
-  content remains readable when JavaScript, custom styling, or client-side
-  hydration is unavailable.
+<Note type="warning">
+  **This page has been removed.** There is no live hosted API or interactive
+  explorer to document at this time.
 </Note>
 
-## How to Use This Explorer
-
-1. Start with the workflow that matches your task.
-2. Expand the cards to compare the API surface.
-3. Open the linked reference pages for full options, return values, and examples.
-4. Copy the starter snippet into a local component and replace placeholder values.
-
-## Explore by Workflow
-
-<div className="grid gap-4 my-6">
-  <details className="rounded-lg border p-4">
-    <summary className="cursor-pointer font-semibold">Connect a wallet</summary>
-    <p className="text-sm text-muted-foreground">
-      Use the provider and wallet hook when a page needs connection state,
-      account identity, and signing access.
-    </p>
-
-    | API | Type | Use it for |
-    | --- | --- | --- |
-    | `WalletProvider` | Provider | Configure network, Horizon, and wallet state for the app |
-    | `useStellarWallet` | Hook | Connect, disconnect, and read the active public key |
-    | `ConnectWalletButton` | Component | Render the default wallet connection control |
-
-    ```tsx
-    <WalletProvider horizonUrl="https://horizon-testnet.stellar.org">
-      <ConnectWalletButton />
-    </WalletProvider>
-    ```
-
-    Related docs: [WalletProvider](/docs/hooks/wallet-provider), [useStellarWallet](/docs/hooks/use-stellar-wallet), [ConnectWalletButton](/docs/components/connect-wallet-button).
-
-  </details>
-
-  <details className="rounded-lg border p-4">
-    <summary className="cursor-pointer font-semibold">Read account data</summary>
-    <p className="text-sm text-muted-foreground">
-      Use Horizon-backed hooks when you need balances, trustlines, offers, or
-      recent activity for an account.
-    </p>
-
-    | API | Source | Use it for |
-    | --- | --- | --- |
-    | `useStellarBalances` | Horizon | Fetch native and issued-asset balances |
-    | `useTransactionHistory` | Horizon | List account operations and payments |
-    | `useTrustlines` | Horizon | Inspect and update asset trustlines |
-    | `useOfferBook` | Horizon | Read DEX order book entries |
-
-    ```tsx
-    const { balances, loading, error } = useStellarBalances(publicKey, {
-      horizonUrl: 'https://horizon-testnet.stellar.org',
-    });
-    ```
-
-    Related docs: [Stellar Horizon](/docs/integrations/horizon), [useStellarBalances](/docs/hooks/use-stellar-balances), [useTransactionHistory](/docs/hooks/use-transaction-history), [useOfferBook](/docs/hooks/use-offer-book).
-
-  </details>
-
-  <details className="rounded-lg border p-4">
-    <summary className="cursor-pointer font-semibold">Send payments</summary>
-    <p className="text-sm text-muted-foreground">
-      Use payment APIs when a connected wallet needs to build, sign, and submit
-      Stellar payment transactions.
-    </p>
-
-    | API | Network dependency | Use it for |
-    | --- | --- | --- |
-    | `useStellarPayment` | Horizon | Build and submit payment transactions |
-    | `useStellarWallet` | Wallet Kit | Request wallet signatures |
-    | `WalletProvider` | Horizon and Wallet Kit | Share account and network configuration |
-
-    ```tsx
-    const { sendPayment } = useStellarPayment();
-
-    await sendPayment({
-      destination: 'G...',
-      amount: '10',
-      assetCode: 'XLM',
-    });
-    ```
-
-    Related docs: [useStellarPayment](/docs/hooks/use-stellar-payment), [Wallet Integration](/docs/sdk/wallet-integration), [Wallets](/docs/integrations/wallets).
-
-  </details>
-
-  <details className="rounded-lg border p-4">
-    <summary className="cursor-pointer font-semibold">Work with Soroban contracts</summary>
-    <p className="text-sm text-muted-foreground">
-      Use Soroban APIs when a page needs to simulate contract calls, build
-      invocation XDR, submit signed transactions, or poll contract events.
-    </p>
-
-    | API | Source | Use it for |
-    | --- | --- | --- |
-    | `useSorobanContract` | Soroban RPC | Call functions and build invocation XDR |
-    | `useSorobanEvents` | Soroban RPC | Read recent contract events |
-    | `WalletProvider` | Soroban RPC | Provide shared RPC and network values |
-
-    ```tsx
-    const contract = useSorobanContract({
-      contractId: 'C...',
-      network: 'TESTNET',
-    });
-
-    const result = await contract.callFunction('balance', [publicKey]);
-    ```
-
-    Related docs: [Soroban Integration](/docs/integrations/soroban), [useSorobanContract](/docs/hooks/use-soroban-contract), [useSorobanEvents](/docs/hooks/use-soroban-events).
-
-  </details>
-</div>
-
-## Endpoint Map
-
-| Area              | Default testnet endpoint              | Production endpoint               |
-| ----------------- | ------------------------------------- | --------------------------------- |
-| Horizon           | `https://horizon-testnet.stellar.org` | `https://horizon.stellar.org`     |
-| Soroban RPC       | `https://soroban-testnet.stellar.org` | `https://soroban-rpc.stellar.org` |
-| Wallet connection | Browser wallet or wallet modal        | Browser wallet or wallet modal    |
-
-## Graceful Degradation
-
-The explorer uses semantic headings, tables, links, and native `<details>` controls. If custom components do not load, the page still presents a complete outline of the API surface. If a browser does not support disclosure controls, each section still contains the full text, tables, and linked references in document order.
-
-## Related
-
-- [SDK Overview](/docs/sdk/overview) - Architecture and package-level concepts
-- [API Reference](/docs/sdk/api-reference) - Types and utilities
-- [Hooks Reference](/docs/hooks) - Hook-by-hook documentation
-- [Integrations](/docs/integrations) - Stellar ecosystem integrations
+The API Explorer described a workflow-based reference for a hosted API surface
+that does not exist yet. It has been replaced by the
+[Hosted API roadmap page](/docs/api), which explains what is planned and
+links to the available local SDK documentation in the meantime.

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -1,38 +1,41 @@
 ---
-title: API
-description: API documentation and reference
-date: 2026-06-01
+title: Hosted API
+description: A hosted REST/GraphQL API for Nextellar is planned but not yet available.
+date: 2026-08-03
 ---
 
-# API Documentation
+import { Note } from '@/components/note';
 
-For complete API documentation, please refer to the following resources:
+# Hosted API
 
-## SDK Reference
+<Note type="warning">
+  **Roadmap — not yet available.** Nextellar currently has no hosted API
+  endpoint. The CLI bootstraps your project locally; the only outbound network
+  call it makes is an opt-in telemetry ping. A hosted API is on the roadmap but
+  has not shipped.
+</Note>
 
-- [API Explorer](/docs/api/explorer) - Interactive workflow-based API surface
-- [SDK Overview](/docs/sdk/overview) - Architecture and key features
-- [API Reference](/docs/sdk/api-reference) - Type definitions and utilities
-- [Wallet Integration](/docs/sdk/wallet-integration) - Multi-wallet configuration
+## What is planned
 
-## Hooks API
+- A REST / GraphQL surface that mirrors the React-hook API, usable from
+  server-side or non-React environments.
+- Authentication via API keys tied to a Nextellar account.
+- Rate-limited access to Stellar Horizon and Soroban RPC through a managed
+  proxy, so you do not need to expose third-party endpoints directly.
 
-Complete documentation for all React hooks:
+## Until it ships
 
-- [useStellarWallet](/docs/hooks/use-stellar-wallet) - Wallet connection.
-- [useStellarBalances](/docs/hooks/use-stellar-balances) - Balance tracking.
-- [useStellarPayment](/docs/hooks/use-stellar-payment) - Payments.
-- [useTrustlines](/docs/hooks/use-trustlines) - Trustline management.
-- [useTransactionHistory](/docs/hooks/use-transaction-history) - Transaction history.
-- [useSorobanContract](/docs/hooks/use-soroban-contract) - Smart contracts.
-- [useSorobanEvents](/docs/hooks/use-soroban-events) - Contract events.
-- [useOfferBook](/docs/hooks/use-offer-book) - DEX orderbook.
+Everything you need today lives in the local SDK:
 
-## Context API
+| Resource | Link |
+| --- | --- |
+| React hooks reference | [Hooks](/docs/hooks/use-stellar-wallet) |
+| SDK overview | [SDK Overview](/docs/sdk/overview) |
+| Type definitions & utilities | [API Reference](/docs/sdk/api-reference) |
+| Wallet integration | [Wallet Integration](/docs/sdk/wallet-integration) |
+| CLI commands | [CLI Commands](/docs/cli/commands) |
 
-- [WalletProvider](/docs/hooks/wallet-provider) - Global wallet context.
+## Follow the roadmap
 
-## CLI Reference
-
-- [CLI Commands](/docs/cli/commands) - Full command reference.
-- [CLI Options](/docs/cli/options) - Configuration options.
+Track progress and leave feedback on the
+[Nextellar GitHub repository](https://github.com/nextellarlabs/nextellar/issues).


### PR DESCRIPTION
## Summary

Closes #633.

The `docs/api/` pages described a hosted API and interactive explorer that do not exist. This PR replaces them with an honest roadmap stub and updates the sidebar accordingly.

## Changes

- **`docs/api/index.mdx`** — rewritten as a clearly-marked roadmap page. Opens with a warning callout, explains what is planned (REST/GraphQL proxy), and redirects readers to the live SDK/hooks docs.
- **`docs/api/explorer.mdx`** — replaced with a short removal notice explaining why the page is gone and linking to the roadmap stub. Keeps the URL alive to avoid 404s.
- **`config/sidebar.tsx`** — entry renamed from `API Explorer` → `Hosted API (Roadmap)` and href changed from `/docs/api/explorer` → `/docs/api`.

## Acceptance criteria

- [x] No page implies a live API exists
- [x] Sidebar validation passes (`node scripts/validate-sidebar.cjs` exits 0, 0 broken links)