### PR TITLE
docs(routes-d): add guide drafts for #901, #903, #904, #905

### DIFF
--- a/routes-d/901-freighter-offline-detection.mdx
+++ b/routes-d/901-freighter-offline-detection.mdx
@@ -1,0 +1,200 @@
+---
+title: Freighter Offline Detection
+description: Detect when the Freighter wallet is offline or unresponsive — covering connection probes, request timeouts, browser connectivity events, and clear user messaging.
+date: 2026-08-25
+---
+
+# Freighter Offline Detection
+
+Freighter is a browser extension wallet, so "offline" can mean three different things: the user's device lost network access, the extension was disabled or removed, or the extension is installed but not responding to requests. A production dApp should detect all three states and tell the user what to do about each one, instead of letting a `getPublicKey()` or `signTransaction()` call hang forever.
+
+---
+
+## The Three Failure States
+
+| State | Cause | Typical symptom |
+|---|---|---|
+| Device offline | No internet connection | Horizon fetches fail alongside wallet calls |
+| Wallet unavailable | Extension disabled, removed, or not injected | `window.freighter` is undefined / API throws |
+| Wallet unresponsive | Extension loaded but stalled (background update, suspended tab) | Promise from the API never settles |
+
+Each state needs its own detection strategy and its own message.
+
+---
+
+## Detection Patterns
+
+### 1. Check that the extension is reachable
+
+The Freighter API exposes `isConnected()`, which resolves to `true` only when the extension is installed and able to respond:
+
+```typescript
+import { isConnected } from '@stellar/freighter-api';
+
+const available = await isConnected();
+if (!available) {
+  // Extension missing or disabled — prompt an install/enable flow
+}
+```
+
+### 2. Watch browser connectivity events
+
+Device-level offline state is free to observe via the browser:
+
+```typescript
+useEffect(() => {
+  const goOffline = () => setDeviceOnline(false);
+  const goOnline = () => setDeviceOnline(true);
+
+  window.addEventListener('offline', goOffline);
+  window.addEventListener('online', goOnline);
+  return () => {
+    window.removeEventListener('offline', goOffline);
+    window.removeEventListener('online', goOnline);
+  };
+}, []);
+```
+
+Also seed the initial value with `navigator.onLine` on mount.
+
+### 3. Time out wallet requests
+
+An unresponsive extension never throws — it just never resolves. Wrap every wallet call in a timeout so the UI can recover:
+
+```typescript
+function withTimeout<T>(promise: Promise<T>, ms = 10_000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('WALLET_TIMEOUT')), ms)
+    ),
+  ]);
+}
+
+// Usage
+const publicKey = await withTimeout(getPublicKey(), 10_000);
+```
+
+### 4. Poll a lightweight health check
+
+While a session is active, poll `isConnected()` every ~30 seconds. Two consecutive failures mark the wallet as unavailable and let you downgrade the UI (disable sign buttons, show a reconnect banner).
+
+---
+
+## Minimal Example
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { isConnected, getPublicKey } from '@stellar/freighter-api';
+
+type WalletStatus =
+  | 'checking'
+  | 'ready'
+  | 'device-offline'
+  | 'unavailable'
+  | 'unresponsive';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export function useWalletStatus() {
+  const [status, setStatus] = useState<WalletStatus>('checking');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function probe() {
+      if (!navigator.onLine) {
+        setStatus('device-offline');
+        return;
+      }
+
+      try {
+        // Race the health check against a timeout so a stalled
+        // extension cannot leave us in "checking" forever.
+        const available = await Promise.race([
+          isConnected(),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error('timeout')),
+              REQUEST_TIMEOUT_MS
+            )
+          ),
+        ]);
+
+        if (!available) throw new Error('not-installed');
+        await getPublicKey(); // confirms permission is granted
+        setStatus('ready');
+      } catch (err) {
+        if (!cancelled) {
+          setStatus(
+            err.message === 'timeout' ? 'unresponsive' : 'unavailable'
+          );
+        }
+      }
+    }
+
+    probe();
+
+    const onOffline = () => setStatus('device-offline');
+    const onOnline = () => probe();
+    window.addEventListener('offline', onOffline);
+    window.addEventListener('online', onOnline);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('offline', onOffline);
+      window.removeEventListener('online', onOnline);
+    };
+  }, []);
+
+  return status;
+}
+```
+
+---
+
+## User Messaging
+
+Map every detected state to a short, actionable message. Name the fix, don't just describe the failure:
+
+| State | Suggested copy |
+|---|---|
+| `device-offline` | "You're offline. Check your internet connection — your wallet will reconnect automatically." |
+| `unavailable` | "We can't reach Freighter. Make sure the extension is installed and enabled, then refresh this page." |
+| `unresponsive` | "Freighter isn't responding. Try reopening the extension — your transaction wasn't submitted." |
+| Recovered (`online`) | "Connection restored. You can continue." |
+
+Guidelines:
+
+- **Never blame the user** — say "we can't reach Freighter", not "you disconnected".
+- **Preserve form state.** An offline error during signing must not clear amounts or destinations; let the user retry the same transaction.
+- **One status at a time.** If both device and wallet are unreachable, show the device message first — it's usually the root cause.
+- **Announce changes accessibly.** Render the banner in a `role="status"` region so screen readers hear transitions.
+
+```tsx
+{status !== 'ready' && status !== 'checking' && (
+  <div role="status" className="rounded-md bg-amber-50 p-3 text-sm text-amber-900">
+    {MESSAGES[status]}
+  </div>
+)}
+```
+
+---
+
+## Summary
+
+- Distinguish device offline, wallet unavailable, and wallet unresponsive — each has a different fix.
+- Use `isConnected()` as the health probe and `navigator.onLine` plus browser events for device state.
+- Always race wallet calls with a timeout (~10s); an unresponsive extension throws nothing.
+- Poll the health check while a session is active to catch mid-session failures.
+- Show one actionable message per state, keep form state intact, and announce changes via `role="status"`.
+
+---
+
+## Related
+
+- [Wallets (Freighter, Albedo, Lobstr, xBull, Hana)](/docs/integrations/wallets) - Multi-wallet integration overview
+- [useStellarWallet](/docs/hooks/use-stellar-wallet) - Standalone hook docs
+- [Common Error Messages](/docs/troubleshooting/common-error-messages) - Troubleshooting reference

--- a/routes-d/903-skeleton-loading-account-data.mdx
+++ b/routes-d/903-skeleton-loading-account-data.mdx
@@ -1,0 +1,152 @@
+---
+title: Skeleton Loading for Account Data
+description: Show skeleton placeholders while account balances and transaction history load — covering placeholder shapes, fallback timing, and a small reusable example.
+date: 2026-08-25
+---
+
+# Skeleton Loading for Account Data
+
+Fetching account data (public key, XLM balance, asset list) over Horizon takes a moment on every page load. Showing a spinner is fine, but skeletons that mirror the final layout feel faster and prevent layout shift when real data arrives. This guide covers the placeholder shapes worth building, how long to show them before falling back to an error state, and a small reusable example.
+
+---
+
+## Placeholder Shapes
+
+Match each skeleton to the shape of the data it stands in for:
+
+| Data | Placeholder shape |
+|---|---|
+| Public key | Short pill (~`w-40 h-4`) — truncated G-address line |
+| Native XLM balance | Large block (`w-32 h-8`) next to a small label bar |
+| Asset row | Horizontal row: circle icon (`h-9 w-9 rounded-full`) + two stacked bars |
+| Transaction row | Two-line row: wide bar on top, narrow muted bar below |
+
+Rules of thumb:
+
+- Keep the skeleton's outer dimensions identical to the loaded content so nothing jumps when data lands.
+- Group skeletons into the same containers (cards, rows, dividers) as the real UI.
+- Animate with a single `animate-pulse` shimmer; don't animate borders or layout.
+
+```tsx
+function SkeletonRow() {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <div className="h-9 w-9 animate-pulse rounded-full bg-muted" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Fallback Timing
+
+Skeletons are a promise that content is coming — enforce both ends of it:
+
+1. **Delay before showing (200–300 ms).** If data arrives instantly, skip the skeleton entirely. A skeleton that flashes for 50 ms feels slower than no skeleton at all.
+2. **Timeout to error state (~10 s).** Horizon may be slow or unreachable. After the timeout, swap the skeleton for an error message with a retry button instead of pulsing forever.
+
+```tsx
+const [state, setState] = useState<'loading' | 'ready' | 'error'>('loading');
+
+useEffect(() => {
+  const startedAt = Date.now();
+
+  async function load() {
+    try {
+      const [account, elapsed] = await Promise.all([
+        fetchAccount(publicKey),
+        delay(250), // minimum display window
+      ]);
+      setAccount(account);
+      setState('ready');
+    } catch {
+      setState('error');
+    }
+  }
+
+  load();
+}, [publicKey]);
+```
+
+The `Promise.all` with `delay(250)` guarantees the skeleton shows for at least 250 ms even on fast responses, avoiding a flash of empty content.
+
+---
+
+## Minimal Example
+
+A balance card with skeleton, error, and loaded states:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useStellarBalances } from '@/hooks/useStellarBalances';
+
+function BalanceCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      aria-busy="true"
+      className="rounded-xl border p-4"
+    >
+      <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+      <div className="mt-2 h-8 w-32 animate-pulse rounded bg-muted" />
+      <div className="mt-4 space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BalanceCard({ publicKey }: { publicKey: string }) {
+  const { balances, loading, error, refresh } = useStellarBalances(publicKey);
+
+  if (loading) return <BalanceCardSkeleton />;
+
+  if (error) {
+    return (
+      <div role="alert" className="rounded-xl border border-destructive/30 p-4 text-sm">
+        <p>We couldn't load your balances. Your funds are safe.</p>
+        <button onClick={refresh} className="mt-2 font-medium underline">
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border p-4">
+      {/* Render real balances */}
+    </div>
+  );
+}
+```
+
+Accessibility notes:
+
+- Put `aria-busy="true"` on the skeleton container and `aria-hidden="true"` on the decorative bars so screen readers hear "loading" rather than silence.
+- The error branch uses `role="alert"` so failures are announced immediately.
+
+---
+
+## Summary
+
+- Mirror the final layout: pills for addresses, blocks for balances, rows for assets and history.
+- Delay skeletons by ~250 ms to avoid flashes, but always cap them with a ~10 s timeout to an error + retry state.
+- Use `aria-busy` and `aria-hidden` on skeletons, `role="alert"` on the fallback.
+- Keep placeholder dimensions identical to loaded content to prevent layout shift.
+
+---
+
+## Related
+
+- [Wallets (Freighter, Albedo, Lobstr, xBull, Hana)](/docs/integrations/wallets) - Connection and balance fetching overview
+- [useStellarBalances](/docs/hooks/use-stellar-balances) - Hook used in this guide
+- [Input](/docs/components/input) - Component states including loading

--- a/routes-d/904-staggered-animations-lists.mdx
+++ b/routes-d/904-staggered-animations-lists.mdx
@@ -1,0 +1,149 @@
+---
+title: Staggered Animations for Lists
+description: Animate lists of items (balances, transactions, search results) with a stagger using framer-motion — covering a small implementation, motion accessibility, and sensible limits on stagger.
+date: 2026-08-25
+---
+
+# Staggered Animations for Lists
+
+A stagger reveals list items one after another instead of all at once, which draws the eye down the list and makes long renders feel intentional rather than jarring. This guide shows a small framer-motion implementation for wallet UIs like balance or transaction lists, how to keep it accessible with `prefers-reduced-motion`, and the limits that keep staggers from feeling slow.
+
+---
+
+## Implementation
+
+framer-motion supports staggering through a parent's `staggerChildren` variant — each child animates automatically in order:
+
+```tsx
+'use client';
+
+import { motion } from 'framer-motion';
+
+const container = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.06 }, // seconds between items
+  },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 8 },
+  show: { opacity: 1, y: 0 },
+};
+
+export function AnimatedAssetList({ assets }: { assets: Asset[] }) {
+  return (
+    <motion.ul
+      variants={container}
+      initial="hidden"
+      animate="show"
+      className="divide-y"
+    >
+      {assets.map((asset) => (
+        <motion.li
+          key={asset.code}
+          variants={item}
+          transition={{ duration: 0.25 }}
+          className="flex items-center justify-between py-2"
+        >
+          <span>{asset.code}</span>
+          <span>{asset.balance}</span>
+        </motion.li>
+      ))}
+    </motion.ul>
+  );
+}
+```
+
+Only opacity and transform (`y`) are animated — these run on the compositor and don't trigger layout recalculations mid-stagger.
+
+---
+
+## Motion Accessibility
+
+Animations can cause discomfort for users with vestibular disorders. Respect the OS-level "reduce motion" setting:
+
+```tsx
+import { useReducedMotion } from 'framer-motion';
+
+export function AnimatedAssetList({ assets }: { assets: Asset[] }) {
+  const reduceMotion = useReducedMotion();
+
+  const container = {
+    hidden: {},
+    show: {
+      transition: { staggerChildren: reduceMotion ? 0 : 0.06 },
+    },
+  };
+
+  // ...
+}
+```
+
+When `useReducedMotion()` returns `true`:
+
+- Set `staggerChildren` to `0` so items appear together.
+- Or swap to a pure fade (`opacity` only, no `y` movement) if you still want a gentle transition.
+- Never remove content from the DOM based on this setting — only the motion changes.
+
+You can also handle it purely in CSS with a media query if you're not using framer-motion:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .stagger-item {
+    animation: none;
+  }
+}
+```
+
+---
+
+## Limits on Stagger
+
+Staggers degrade quickly as lists grow. Follow these caps:
+
+| Constraint | Recommended limit | Why |
+|---|---|---|
+| Per-item delay | ≤ 60–80 ms | Above this, users wait on items they can already see |
+| Total sequence | ≤ 400–500 ms end-to-end | Longer feels sluggish, not polished |
+| Max staggered items | ~8–10 | Cap the effect; render the rest immediately |
+| Re-triggers | Once per mount | Don't re-run on filter/sort changes |
+
+For lists longer than the cap, apply the stagger to the first N items only:
+
+```tsx
+const MAX_STAGGERED = 10;
+
+const item = {
+  hidden: { opacity: 0, y: 8 },
+  show: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: i < MAX_STAGGERED ? i * 0.06 : 0,
+      duration: 0.25,
+    },
+  }),
+};
+
+// <motion.li custom={index} variants={item} ...>
+```
+
+Items past the cap appear instantly with no delay, so a 100-row transaction history never takes 6 seconds to reveal.
+
+---
+
+## Summary
+
+- Stagger via a parent variant with `staggerChildren`; animate only `opacity` and transforms.
+- Always honor `prefers-reduced-motion` — collapse the stagger to zero or a plain fade.
+- Keep per-item delay ≤ 60–80 ms, total duration ≤ 500 ms, and stagger at most ~10 items.
+- Run the animation once per mount; don't replay it when list contents change.
+
+---
+
+## Related
+
+- [Wallets (Freighter, Albedo, Lobstr, xBull, Hana)](/docs/integrations/wallets) - Where asset lists come from
+- [useStellarBalances](/docs/hooks/use-stellar-balances) - Data source for balance lists
+- [useStellarWallet](/docs/hooks/use-stellar-wallet) - Session state around animated lists

--- a/routes-d/905-accessible-form-errors-wallets.mdx
+++ b/routes-d/905-accessible-form-errors-wallets.mdx
@@ -1,0 +1,127 @@
+---
+title: Accessible Form Errors for Wallet Inputs
+description: Make wallet form errors perceivable to everyone — the ARIA attributes to set, a small worked example, and error copy that tells users exactly what to fix.
+date: 2026-08-25
+---
+
+# Accessible Form Errors for Wallet Inputs
+
+Wallet forms (send amount, destination address, memo) fail in specific ways: invalid G-addresses, insufficient balances, amounts below the minimum, or a rejected signature. Sighted users see red borders; screen reader users get nothing unless you wire up ARIA correctly. This guide covers the attributes to set, a small example built on the `Input` component, and copy suggestions for the most common failures.
+
+---
+
+## ARIA Attributes to Set
+
+Set these on every validated wallet input:
+
+| Attribute | Where | Value |
+|---|---|---|
+| `aria-invalid` | The input | `"true"` when validation fails, removed/`"false"` otherwise |
+| `aria-describedby` | The input | ID of the error message element (only while erroring) |
+| `role="alert"` | The error message | Announces the error immediately when it appears |
+| `aria-live="assertive"` | The error container | Alternative to `role="alert"` for regions that update repeatedly |
+| `aria-required` | The input | `"true"` on mandatory fields |
+
+Key behaviors:
+
+- **Toggle `aria-describedby`, don't leave it dangling.** Pointing at an empty or hidden element makes screen readers announce nothing.
+- **Use one live region per form.** Multiple `role="alert"` elements firing together read over each other.
+- **Keep focus where it is.** Announcing the error is enough; yanking focus to the message disorients keyboard users.
+- **Pair visual and programmatic state.** If the border turns red (`isError`), `aria-invalid` must be set too.
+
+---
+
+## Minimal Example
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/input';
+
+const ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+export function SendForm() {
+  const [destination, setDestination] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const hasError = error !== null;
+  const errorId = 'destination-error';
+
+  function validate(value: string) {
+    if (!value) setError('Enter the destination address.');
+    else if (!ADDRESS_RE.test(value))
+      setError('That doesn\u2019t look like a Stellar address. Addresses start with G and are 56 characters long.');
+    else setError(null);
+  }
+
+  return (
+    <div>
+      <label htmlFor="destination" className="mb-1 block text-sm font-medium">
+        Destination address
+      </label>
+      <Input
+        id="destination"
+        variant="outline"
+        isError={hasError}
+        value={destination}
+        placeholder="GABC..."
+        aria-invalid={hasError}
+        aria-required="true"
+        aria-describedby={hasError ? errorId : undefined}
+        onBlur={(e) => validate(e.target.value)}
+        onChange={(e) => {
+          setDestination(e.target.value);
+          if (hasError) validate(e.target.value); // clear as soon as it's fixed
+        }}
+      />
+      {hasError && (
+        <p id={errorId} role="alert" className="mt-1 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+The `Input` component's `isError` prop handles the visual state (`docs/components/input.mdx`), while `aria-invalid` + `aria-describedby` carry the same information to assistive tech.
+
+---
+
+## Error Copy Suggestions
+
+Good error copy says **what happened**, **why**, and **what to do** — in that order, under ~100 characters:
+
+| Scenario | Weak copy | Suggested copy |
+|---|---|---|
+| Empty destination | "Invalid input" | "Enter the destination address." |
+| Malformed address | "Bad address" | "Stellar addresses start with G and are 56 characters long." |
+| Sending to self | — | "This is your own address. Choose a different recipient." |
+| Amount exceeds balance | "Insufficient funds" | "You have 12.4 XLM available. Enter a smaller amount." |
+| Below existence minimum | "Too low" | "Accounts must hold at least 1 XLM. Send 1 XLM or more." |
+| Wallet rejected signing | "Error" | "Signing was cancelled in Freighter. No funds were sent — try again when you're ready." |
+| Network failure during submit | "Submission failed" | "We couldn't reach the network. Your funds are untouched — retry the payment." |
+
+Guidelines:
+
+- **Never include secret data.** Echo back the amount or asset, never keys or memos.
+- **State the actual numbers.** "You have 12.4 XLM" beats "insufficient funds".
+- **Reassure on money movement.** For signing and network errors, say explicitly that nothing was sent.
+- **Avoid blame.** "Signing was cancelled" instead of "You cancelled".
+
+---
+
+## Summary
+
+- Set `aria-invalid`, point `aria-describedby` at the error only while it exists, and announce with `role="alert"` or a single assertive live region.
+- Mirror visual state (`isError`) with programmatic state (`aria-invalid`) so both channels agree.
+- Write copy that names the problem, includes real values, and reassures users their funds are safe.
+
+---
+
+## Related
+
+- [Input](/docs/components/input) - Component used in this guide, including the `isError` prop
+- [Wallets (Freighter, Albedo, Lobstr, xBull, Hana)](/docs/integrations/wallets) - Signing and rejection flows
+- [Common Error Messages](/docs/troubleshooting/common-error-messages) - Troubleshooting reference


### PR DESCRIPTION
## Summary

Adds four documentation-only guide drafts to `routes-d/`, one per issue, matching the existing MDX frontmatter and writing style:

| File | Issue | Topic |
|---|---|---|
| `routes-d/901-freighter-offline-detection.mdx` | #901 | Detecting Freighter offline/unresponsive states (health probes, request timeouts, browser events, user messaging) |
| `routes-d/903-skeleton-loading-account-data.mdx` | #903 | Skeleton placeholders for account data (shapes, 250ms delay / 10s fallback timing, accessible example) |
| `routes-d/904-staggered-animations-lists.mdx` | #904 | Staggered list animations with framer-motion (implementation, `prefers-reduced-motion`, stagger limits) |
| `routes-d/905-accessible-form-errors-wallets.mdx` | #905 | Accessible wallet form errors (`aria-invalid`/`aria-describedby`/`role="alert"`, example, error copy table) |

## Requirements coverage

- **#901** — detection patterns (4), user messaging table + guidelines, small example
- **#903** — placeholder shapes table, fallback timing (delay + timeout), small example
- **#904** — small framer-motion implementation, motion accessibility section, limits table
- **#905** — ARIA attribute table, small example, suggested error copy

## Constraints

- All changes scoped to documentation only (4 new files in `routes-d/`)
- Frontmatter matches repo convention (`title`, `description`, `date`)
- Internal links point to existing docs routes

## Acceptance criteria

- [x] MDX written to build cleanly with `pnpm build:content` (frontmatter valid, fences balanced)
- [x] Internal links target existing routes for `pnpm check:links`
- [ ] Reviewed and approved by a maintainer before merge

Closes #901
Closes #903
Closes #904
Closes #905