### PR TITLE
docs: fix broken CLI code fences

### DIFF
--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -16,7 +16,7 @@ Create a new Stellar dApp project.
 
 ````bash
 nextellar <project-name> [options]
-```css
+````
 
 **Arguments:**
 
@@ -42,7 +42,7 @@ nextellar my-app \
   --horizon-url https://horizon.stellar.org \
   --wallets freighter,xbull \
   --skip-install
-```css
+```
 
 ## Help Commands
 
@@ -73,7 +73,7 @@ Options:
   --install-timeout <ms>   Installation timeout in milliseconds
   -v, --version            Show CLI version
   -h, --help               Show help text
-```css
+```
 
 ### --version, -v
 
@@ -384,11 +384,10 @@ function nxt { npx nextellar $args }
 
 # Usage
 nxt my-app
-```bash
+```
 
 ## Related Documentation
 
 - [CLI Options](/docs/cli/options) - Detailed option reference
 - [Configuration](/docs/cli/configuration) - Project configuration
 - [Troubleshooting](/docs/troubleshooting/installation-issues) - Common issues
-````

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -25,7 +25,7 @@ npx nextellar my-app \
   --soroban-url https://soroban-rpc.stellar.org \
   --wallets freighter,xbull \
   --package-manager pnpm
-```typescript
+````
 
 ## Template Variables
 
@@ -52,7 +52,7 @@ After creating your project, you can modify these files:
 export const HORIZON_URL = 'https://horizon.stellar.org';
 export const SOROBAN_URL = 'https://soroban-rpc.stellar.org';
 export const NETWORK = Networks.PUBLIC;
-```typescript
+```
 
 ### 2. Wallet Configuration
 
@@ -89,7 +89,7 @@ const allowedWallets = [
     "lib": ["ES2022", "DOM"]
   }
 }
-```typescript
+````
 
 ### 5. Tailwind Configuration
 
@@ -274,11 +274,10 @@ export function validateConfig() {
     throw new Error('NEXT_PUBLIC_NETWORK is required');
   }
 }
-```typescript
+````
 
 ## Related Documentation
 
 - [CLI Commands](/docs/cli/commands) - Command reference
 - [CLI Options](/docs/cli/options) - Option reference
 - [Environment Variables](/docs/guides/deployment#environment-variables) - Deployment config
-````

--- a/docs/cli/options.mdx
+++ b/docs/cli/options.mdx
@@ -18,7 +18,7 @@ Generate a TypeScript project (default).
 nextellar my-app --typescript
 # or
 nextellar my-app -t
-```css
+````
 
 **Default:** `true`
 **Type:** Boolean
@@ -32,7 +32,7 @@ Generate a JavaScript project.
 nextellar my-app --javascript
 # or
 nextellar my-app -j
-```css
+```
 
 **Default:** `false`
 **Type:** Boolean
@@ -48,7 +48,7 @@ Override the default Horizon endpoint.
 
 ```bash
 nextellar my-app --horizon-url https://horizon.stellar.org
-```css
+```
 
 **Default:** `https://horizon-testnet.stellar.org`
 **Type:** String (URL)
@@ -66,7 +66,7 @@ Override the default Soroban RPC endpoint.
 
 ```bash
 nextellar my-app --soroban-url https://soroban-rpc.stellar.org
-```css
+```
 
 **Default:** `https://soroban-testnet.stellar.org`
 **Type:** String (URL)
@@ -112,7 +112,7 @@ nextellar my-app --wallets freighter,xbull,ledger
 
 # All supported wallets
 nextellar my-app --wallets freighter,albedo,lobstr,xbull,ledger
-```css
+````
 
 ## Installation Options
 
@@ -137,7 +137,7 @@ nextellar my-app --skip-install
 ````bash
 cd my-app
 npm install  # or yarn install, pnpm install
-```css
+````
 
 ### --package-manager
 
@@ -145,7 +145,7 @@ Choose which package manager to use.
 
 ```bash
 nextellar my-app --package-manager pnpm
-```css
+```
 
 **Default:** Auto-detected
 **Type:** String
@@ -164,7 +164,7 @@ Set installation timeout in milliseconds.
 
 ```bash
 nextellar my-app --install-timeout 3600000
-```css
+```
 
 **Default:** `1200000` (20 minutes)
 **Type:** Number (milliseconds)
@@ -194,7 +194,7 @@ Skip prompts and use default values.
 nextellar my-app --defaults
 # or
 nextellar my-app -d
-```css
+```
 
 **Default:** `false`
 **Type:** Boolean
@@ -303,7 +303,7 @@ Display CLI version.
 nextellar --version
 # or
 nextellar -v
-```css
+````
 
 **Output:** Version number (e.g., `1.0.4`)
 
@@ -401,7 +401,7 @@ nextellar my-dapp-2024
 nextellar "my app"        # Spaces not allowed
 nextellar my@app          # Special characters not allowed
 nextellar ../my-app       # Path traversal not allowed
-```bash
+````
 
 ### URLs
 
@@ -420,4 +420,3 @@ nextellar ../my-app       # Path traversal not allowed
 - [CLI Commands](/docs/cli/commands) - Command reference
 - [Configuration](/docs/cli/configuration) - Project configuration
 - [Troubleshooting](/docs/troubleshooting/installation-issues) - Common issues
-````

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -22,7 +22,7 @@ Nextellar CLI is a one-command solution that:
 
 ````bash
 npx nextellar my-stellar-app
-```bash
+````
 
 That's it! Your Stellar dApp is ready in under 2 minutes.
 
@@ -76,7 +76,7 @@ Install once, use everywhere:
 ````bash
 npm install -g nextellar
 nextellar my-app
-```bash
+````
 
 **Pros:**
 
@@ -161,7 +161,7 @@ npx nextellar my-app \
 npx nextellar my-app --skip-install
 cd my-app
 pnpm install  # Install with your preferred package manager
-```css
+````
 
 ### Verify Environment
 
@@ -190,7 +190,7 @@ Nextellar respects these environment variables:
 npx nextellar --version
 # or
 nextellar -v
-```bash
+````
 
 ### Update to Latest
 
@@ -250,7 +250,7 @@ npx nextellar my-app --install-timeout 3600000
 npx nextellar my-app --skip-install
 cd my-app
 npm install
-```bash
+````
 
 ## Next Steps
 
@@ -297,4 +297,3 @@ npm install
 - [Installation Guide](/docs/getting-started/installation) - Detailed installation instructions
 - [Quick Start](/docs/getting-started/quick-start) - Build your first app
 - [Project Structure](/docs/getting-started/project-structure) - Understand the generated code
-````

--- a/docs/cli/templates.mdx
+++ b/docs/cli/templates.mdx
@@ -32,7 +32,7 @@ Example (future):
 
 ````bash
 npx nextellar my-app --example payments-demo
-```css
+````
 
 Until templates are released, this command will not function.
 
@@ -88,11 +88,10 @@ Planned command:
 
 ```bash
 nextellar generate template <name>
-```bash
+```
 
 More details will be provided once the feature is implemented.
 
 ---
 
 This page will be updated as soon as official scaffolding templates are released in Nextellar.
-````


### PR DESCRIPTION
## Summary

- Fix malformed closing fences across the five CLI documentation pages.
- Preserve the existing examples and prose while restoring correct Markdown boundaries.
- Remove the stray trailing fences.

## Verification

- Fence counts: commands 46, configuration 40, options 52, overview 34, templates 6.
- pnpm run build:content passes.
- Full build compiles successfully before stopping on the existing duplicate title property in config/sidebar.tsx line 152.

Closes #625