### PR TITLE
docs(routes-d): SEP-30 recovery signer, SEP-24 anchor client, tx confirmation ceremony, inline previews

### DIFF
--- a/routes-d/906-inline-transaction-previews.mdx
+++ b/routes-d/906-inline-transaction-previews.mdx
@@ -1,0 +1,144 @@
+---
+title: Add a Guide on Inline Transaction Previews
+description: How to render a clear preview before submitting a Stellar transaction — what to summarize, warning states to surface, and a small worked example.
+date: 2026-08-25
+---
+
+# Inline Transaction Previews
+
+Before a user signs anything, they should see a clear, plain-language preview of exactly what the transaction will do — rendered inline in the flow they're already in, not buried behind a "view details" tap. This guide covers what to summarize, which warning states to surface, and a small example implementation.
+
+---
+
+## What to Summarize
+
+A preview should answer three questions at a glance: _what_ is happening, _to whom_, and _what does it cost_.
+
+### Operation summary
+
+Decode every operation in the transaction and describe each one in plain language, in order:
+
+```ts
+function summarizeOperation(op: Operation): string {
+  switch (op.type) {
+    case 'payment':
+      return `Send ${op.amount} ${assetLabel(op.asset)} to ${shortenAddress(op.destination)}`;
+    case 'pathPaymentStrictSend':
+      return `Send ${op.sendAmount} ${assetLabel(op.sendAsset)}, receive at least ${op.destMin} ${assetLabel(op.destAsset)}`;
+    case 'changeTrust':
+      return op.limit === '0'
+        ? `Remove trustline for ${assetLabel(op.asset)}`
+        : `Add trustline for ${assetLabel(op.asset)}`;
+    case 'setOptions':
+      return summarizeSetOptions(op); // signer/threshold/home-domain changes — never collapse this to "Update account"
+    case 'accountMerge':
+      return `Close this account and send remaining balance to ${shortenAddress(op.destination)}`;
+    default:
+      return `${op.type} (unrecognized — review raw operation)`;
+  }
+}
+```
+
+A multi-operation transaction must show **every** operation, not just the first or the one the UI flow expects — a payment bundled with a hidden `setOptions` op is a known phishing pattern, and collapsing the summary to "Payment" hides exactly the part the user most needs to see.
+
+### Fee and total cost
+
+Show the network fee separately from the amount being sent, and the total (amount + fee) when the fee is paid in the same asset:
+
+```
+Send:     500 USDC → GDXKI...ZR9F
+Network fee: 0.00001 XLM
+```
+
+If the fee is unusually high relative to the recent network baseline, flag it (see warning states below) rather than silently including it.
+
+### Source and sequence context
+
+Show which account is initiating the transaction (helpful for multi-account wallets) and, for anything involving `setOptions` or trustlines, the account's _current_ state next to the _resulting_ state — a before/after, not just the after.
+
+## Warning States
+
+Surface these distinctly from the routine summary — visually separated, not just another line of text:
+
+| Condition                                                             | Warning                                                                                                             |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Destination has never received a payment from this account            | "New destination — you haven't sent here before."                                                                   |
+| Destination account does not exist on-chain yet                       | "This account doesn't exist yet. This payment will create it and requires at least the base reserve."               |
+| `changeTrust` with `limit: 0` and a non-zero balance                  | "Removing this trustline requires a zero balance first — this transaction will fail."                               |
+| No `timebounds.maxTime` set                                           | "This transaction has no expiration and will remain valid indefinitely once signed."                                |
+| Fee well above recent network average                                 | "Network fee is higher than usual for this transaction."                                                            |
+| `setOptions` changes signer weights or thresholds                     | "This changes who can control your account."                                                                        |
+| Memo is missing but destination is a known exchange/custodial address | "This destination typically requires a memo to credit your deposit — sending without one may result in lost funds." |
+
+Each warning should be specific and actionable — "Something looks unusual" tells the user nothing they can act on.
+
+## Rendering: A Small Example
+
+```tsx
+function TransactionPreview({
+  tx,
+  accountHistory,
+}: {
+  tx: Transaction;
+  accountHistory: AccountHistory;
+}) {
+  const warnings = collectWarnings(tx, accountHistory);
+
+  return (
+    <div className="tx-preview">
+      <ol className="tx-preview__operations">
+        {tx.operations.map((op, i) => (
+          <li key={i}>{summarizeOperation(op)}</li>
+        ))}
+      </ol>
+
+      <dl className="tx-preview__cost">
+        <dt>Network fee</dt>
+        <dd>{formatAmount(tx.fee)} XLM</dd>
+      </dl>
+
+      {warnings.length > 0 && (
+        <ul className="tx-preview__warnings" role="alert">
+          {warnings.map((w) => (
+            <li key={w.code} className={`warning warning--${w.severity}`}>
+              {w.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+`collectWarnings` runs the checks from the table above against the decoded transaction plus whatever local context the wallet has (address book, prior payment history, recent fee stats) — none of it requires a network round-trip beyond what the wallet already fetches to build the transaction.
+
+## Worked Example
+
+A payment to a new destination with an elevated fee:
+
+```
+┌─────────────────────────────────────────────┐
+│  Confirm Payment                             │
+│                                               │
+│  Send 500 USDC                               │
+│  to GDXKI...ZR9F                             │
+│                                               │
+│  Network fee: 0.005 XLM                      │
+│                                               │
+│  ⚠ New destination — you haven't sent        │
+│    here before.                              │
+│  ⚠ Network fee is higher than usual for      │
+│    this transaction.                         │
+│                                               │
+│         [ Cancel ]      [ Confirm ]          │
+└─────────────────────────────────────────────┘
+```
+
+Both warnings render together rather than the UI picking one to show — a user acting on incomplete information is the exact failure mode this pattern exists to prevent. For transactions that also cross the high-value or signer-change thresholds, pair this preview with the full [confirmation ceremony pattern](/routes-d/907-tx-confirmation-ceremony-pattern) rather than treating the two as alternatives — the preview is what's shown, the ceremony is how the user acknowledges it.
+
+## Verifying the Guide
+
+- Build a transaction with a payment op and a trustline-removal op with a non-zero balance; confirm the preview shows both operations and the "will fail" warning.
+- Build a transaction with no `timebounds.maxTime`; confirm the no-expiration warning renders.
+- Confirm a routine payment to a known address with a normal fee renders with zero warnings — the warning list should not appear at all when there's nothing to flag.

--- a/routes-d/906-inline-transaction-previews.mdx
+++ b/routes-d/906-inline-transaction-previews.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add a Guide on Inline Transaction Previews
+title: Inline Transaction Previews
 description: How to render a clear preview before submitting a Stellar transaction — what to summarize, warning states to surface, and a small worked example.
 date: 2026-08-25
 ---

--- a/routes-d/907-tx-confirmation-ceremony-pattern.mdx
+++ b/routes-d/907-tx-confirmation-ceremony-pattern.mdx
@@ -1,10 +1,10 @@
 ---
-title: Document the Tx Confirmation Ceremony Pattern
+title: Transaction Confirmation Ceremony Pattern
 description: A ceremony pattern for confirming high-value Stellar transactions before signing — explicit confirmation steps, the friction-versus-safety tradeoff, and a worked example.
 date: 2026-08-25
 ---
 
-# The Transaction Confirmation Ceremony Pattern
+# Transaction Confirmation Ceremony Pattern
 
 Most wallet mistakes that lose funds aren't protocol bugs — they're a user tapping "confirm" on something they didn't actually read. A confirmation ceremony is a deliberate sequence of UI steps that slows the user down _specifically_ when a transaction is high-value or high-risk, without adding friction to routine payments. This guide documents the pattern: when to trigger it, what steps it should contain, and how to balance friction against safety.
 

--- a/routes-d/907-tx-confirmation-ceremony-pattern.mdx
+++ b/routes-d/907-tx-confirmation-ceremony-pattern.mdx
@@ -1,0 +1,105 @@
+---
+title: Document the Tx Confirmation Ceremony Pattern
+description: A ceremony pattern for confirming high-value Stellar transactions before signing — explicit confirmation steps, the friction-versus-safety tradeoff, and a worked example.
+date: 2026-08-25
+---
+
+# The Transaction Confirmation Ceremony Pattern
+
+Most wallet mistakes that lose funds aren't protocol bugs — they're a user tapping "confirm" on something they didn't actually read. A confirmation ceremony is a deliberate sequence of UI steps that slows the user down _specifically_ when a transaction is high-value or high-risk, without adding friction to routine payments. This guide documents the pattern: when to trigger it, what steps it should contain, and how to balance friction against safety.
+
+---
+
+## When to Trigger the Ceremony
+
+Not every transaction deserves the same scrutiny. Reserve the full ceremony for transactions that meet one or more of these conditions:
+
+- **Value above a threshold.** Define a threshold relative to the account's typical activity (e.g. 5x the account's median payment over the last 30 days), not a single hardcoded number — a $50 threshold is annoying for a high-volume trader and meaningless for someone moving their life savings.
+- **Unfamiliar destination.** The destination account has never received a payment from this wallet before, and isn't in the user's address book.
+- **Irreversible or high-privilege operations.** `setOptions` changes to signers/thresholds, `accountMerge`, trustline removal with a non-zero balance, or anything that changes who can control the account in the future.
+- **Elevated fee or unusual time bounds.** A fee far above the network's recent baseline, or a transaction with no expiration (no `timebounds.maxTime`) — both are patterns seen in phishing flows that try to keep a signed transaction valid indefinitely.
+
+Routine, low-value payments to known destinations should skip the ceremony entirely and use the wallet's normal single-tap confirm — that's the friction budget you're protecting by reserving the ceremony for the transactions that actually warrant it.
+
+## The Ceremony Steps
+
+### 1. Plain-language summary, not raw XDR
+
+Lead with what the transaction _does_, not its wire format:
+
+> "Send **500 USDC** to **GDXKI...ZR9F** (new destination — you haven't paid this address before)"
+
+Decode every operation in the transaction and describe it in the same plain language — a transaction with a payment op _and_ a hidden `setOptions` op must show both, not just the one the user expects.
+
+### 2. Explicit destination confirmation
+
+For unfamiliar destinations, require the user to actively acknowledge the address rather than just seeing it fly by:
+
+- Show the full address, not a truncated `GDXK...ZR9F` — truncation is exactly what a lookalike-address attack exploits.
+- Consider requiring the user to confirm the first and last several characters against a source they trust (e.g. a QR code they scanned, or copy-paste with a visible clipboard-source indicator) rather than typing blind.
+
+### 3. Risk-specific callouts
+
+Attach a specific, human-readable warning for whatever triggered the ceremony — not a generic "this is important" banner:
+
+- New destination → "You've never sent to this address before."
+- Signer/threshold change → "This changes who can control your account. Review carefully."
+- No expiration → "This transaction has no expiration — it will remain valid indefinitely once signed."
+
+### 4. A deliberate final action
+
+The final confirm should require an action that can't be triggered by reflexive tapping — a slide-to-confirm gesture, a short hold-to-confirm, or (for the highest-risk operations) re-entering a PIN/biometric even if the session is already unlocked. The goal is to interrupt the "I've tapped confirm a hundred times today" muscle memory.
+
+### 5. Post-sign receipt
+
+After submission, show a receipt with the same plain-language summary and a link to view the transaction on an explorer — this closes the loop and gives the user a paper trail if something later looks wrong.
+
+## Friction vs. Safety
+
+The ceremony's cost is real: every extra step is a chance for a legitimate user to bail, get confused, or contact support. Calibrate deliberately:
+
+| Signal strength                                                    | Ceremony weight                                                                             |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| Routine payment, known destination, normal fee                     | No ceremony — single-tap confirm                                                            |
+| Elevated value OR new destination (not both)                       | Plain-language summary + risk callout, standard confirm                                     |
+| Elevated value AND new destination, or any signer/threshold change | Full ceremony: summary, explicit destination confirm, risk callout, deliberate final action |
+
+Two failure modes to avoid:
+
+- **Ceremony fatigue.** If routine activity keeps triggering the full ceremony (threshold set too low, address book not being consulted), users learn to blow through it without reading — which defeats the entire purpose. Tune thresholds against real usage data, not a guess.
+- **False confidence from partial ceremonies.** Showing a plain-language summary without decoding _every_ operation in a multi-op transaction is worse than no summary — it tells the user "you've reviewed this" when they've only reviewed part of it.
+
+## Worked Example
+
+A wallet detects a `setOptions` operation that raises another account's signer weight to match the medium threshold, effectively adding co-signing power:
+
+```
+┌─────────────────────────────────────────────┐
+│  Review Transaction                          │
+│                                               │
+│  ⚠️  This changes who can control your       │
+│      account.                                │
+│                                               │
+│  Add signer                                  │
+│  GDNEW...F82Q  (new signer — not previously  │
+│                 authorized on this account)   │
+│  Weight: 5                                    │
+│                                               │
+│  After this change, this signer combined     │
+│  with your device key would meet your        │
+│  medium threshold (10) and could authorize   │
+│  payments without your confirmation.          │
+│                                               │
+│  [ Type "ADD SIGNER" to confirm ]            │
+│  ______________________                      │
+│                                               │
+│         [ Cancel ]      [ Confirm ]          │
+└─────────────────────────────────────────────┘
+```
+
+The "type to confirm" step here is intentionally heavier than a slide gesture — signer changes are one of the few operations where the cost of a mistake (permanent loss of exclusive control) justifies the extra friction.
+
+## Verifying the Guide
+
+- Render the worked example's mockup against a real decoded `setOptions` transaction on testnet and confirm the summary text matches the operation's actual effect.
+- Walk through the threshold table with a routine payment, a new-destination payment, and a signer change, and confirm each renders the ceremony weight the table specifies.

--- a/routes-d/908-sep24-anchor-client-library.mdx
+++ b/routes-d/908-sep24-anchor-client-library.mdx
@@ -1,10 +1,10 @@
 ---
-title: Build a Complete SEP-24 Anchor Client Library
+title: SEP-24 Anchor Client Library
 description: A full tutorial for building a SEP-24 anchor client library — session setup, the interactive deposit/withdraw flow, status polling, and error handling.
 date: 2026-08-25
 ---
 
-# Build a Complete SEP-24 Anchor Client Library
+# SEP-24 Anchor Client Library
 
 [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md) defines the interactive flow wallets use to let a user deposit fiat (or another off-chain asset) into a Stellar account, or withdraw a Stellar asset back out, through an anchor's hosted UI. This guide builds a small client library around the three parts of that flow: the authenticated session, the interactive popup, and status polling.
 

--- a/routes-d/908-sep24-anchor-client-library.mdx
+++ b/routes-d/908-sep24-anchor-client-library.mdx
@@ -1,0 +1,165 @@
+---
+title: Build a Complete SEP-24 Anchor Client Library
+description: A full tutorial for building a SEP-24 anchor client library — session setup, the interactive deposit/withdraw flow, status polling, and error handling.
+date: 2026-08-25
+---
+
+# Build a Complete SEP-24 Anchor Client Library
+
+[SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md) defines the interactive flow wallets use to let a user deposit fiat (or another off-chain asset) into a Stellar account, or withdraw a Stellar asset back out, through an anchor's hosted UI. This guide builds a small client library around the three parts of that flow: the authenticated session, the interactive popup, and status polling.
+
+---
+
+## Session Setup
+
+SEP-24 endpoints require a SEP-10 web auth token. Fetch the anchor's `stellar.toml` to discover its endpoints, then complete web auth before calling anything else.
+
+```ts
+import { StellarTomlResolver } from '@stellar/stellar-sdk';
+
+async function createAnchorSession(homeDomain: string, account: Keypair) {
+  const toml = await StellarTomlResolver.resolve(homeDomain);
+  const authEndpoint = toml.WEB_AUTH_ENDPOINT;
+  const transferServer = toml.TRANSFER_SERVER_SEP0024;
+  const signingKey = toml.SIGNING_KEY;
+
+  if (!authEndpoint || !transferServer || !signingKey) {
+    throw new Error(`${homeDomain} does not advertise SEP-24 support`);
+  }
+
+  const token = await completeSep10(authEndpoint, signingKey, account);
+  return new AnchorSession(transferServer, token);
+}
+```
+
+`completeSep10` follows the standard SEP-10 challenge/sign/submit cycle: `GET` a challenge transaction, sign it with the account's keypair, `POST` it back, and receive a JWT. Wrap this once and reuse it — every SEP-24 call below needs the resulting token as a bearer credential.
+
+## The Interactive Flow
+
+### 1. Discover supported assets
+
+```ts
+class AnchorSession {
+  constructor(
+    private transferServer: string,
+    private token: string
+  ) {}
+
+  async info() {
+    const res = await fetch(`${this.transferServer}/info`);
+    return res.json(); // { deposit: {...}, withdraw: {...}, fee: {...} }
+  }
+}
+```
+
+Check `deposit[asset_code].enabled` / `withdraw[asset_code].enabled` before offering an asset in the UI — not every anchor supports every asset for both directions.
+
+### 2. Start a deposit or withdrawal
+
+```ts
+async startDeposit(assetCode: string, account: string) {
+  const res = await fetch(`${this.transferServer}/transactions/deposit/interactive`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ asset_code: assetCode, account }),
+  });
+  if (!res.ok) throw new AnchorError(await res.json());
+  return res.json(); // { type: 'interactive_customer_info_needed', url, id }
+}
+```
+
+Withdrawals use the mirrored `/transactions/withdraw/interactive` endpoint with the same request shape.
+
+### 3. Open the interactive popup
+
+The response's `url` is a one-time link to the anchor's hosted UI (KYC forms, bank details, amount entry). Open it in a popup or webview — don't embed it in a way that lets your app read its contents, since it may collect sensitive personal data the anchor is responsible for, not your app.
+
+```ts
+function openInteractivePopup(url: string) {
+  const popup = window.open(url, 'sep24_interactive', 'width=480,height=720');
+  if (!popup) throw new Error('Popup blocked — retry from a user gesture');
+  return popup;
+}
+```
+
+The `id` from the start-deposit response is what you'll use to poll status — store it alongside the transaction in your app's local state before opening the popup, since the user may close it before finishing.
+
+## Polling for Status
+
+The anchor's UI runs asynchronously — the user might complete KYC, then the anchor takes minutes or days to actually process a bank transfer. Poll `/transaction` for status changes rather than blocking on the popup closing.
+
+```ts
+type Sep24Status =
+  | 'incomplete'
+  | 'pending_user_transfer_start'
+  | 'pending_user_transfer_complete'
+  | 'pending_external'
+  | 'pending_anchor'
+  | 'pending_stellar'
+  | 'pending_trust'
+  | 'completed'
+  | 'refunded'
+  | 'expired'
+  | 'error'
+  | 'no_market'
+  | 'too_small'
+  | 'too_large';
+
+async function pollTransaction(
+  session: AnchorSession,
+  id: string,
+  onUpdate: (status: Sep24Status) => void,
+  { intervalMs = 3000, timeoutMs = 10 * 60_000 } = {}
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: Sep24Status | undefined;
+
+  while (Date.now() < deadline) {
+    const res = await fetch(`${session.transferServer}/transaction?id=${id}`, {
+      headers: { Authorization: `Bearer ${session.token}` },
+    });
+    const { transaction } = await res.json();
+
+    if (transaction.status !== lastStatus) {
+      lastStatus = transaction.status;
+      onUpdate(transaction.status);
+    }
+
+    if (
+      ['completed', 'refunded', 'expired', 'error'].includes(transaction.status)
+    ) {
+      return transaction;
+    }
+
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  throw new Error(
+    `Polling timed out after ${timeoutMs}ms for transaction ${id}`
+  );
+}
+```
+
+Key statuses to surface distinctly in the UI:
+
+- `pending_user_transfer_start` — waiting on the user to send fiat (deposit) or the asset (withdraw); show instructions.
+- `pending_anchor` / `pending_external` — out of the user's hands; show a progress indicator, not an error.
+- `pending_trust` — the destination account needs a trustline for the asset before the anchor can complete a deposit; prompt the user to add it.
+- `completed` — done; the `stellar_transaction_id` field links to the on-chain payment.
+- `error` / `expired` — surface `message` from the transaction object, don't just say "failed."
+
+## Error Handling
+
+- **Network/auth errors** (SEP-10 token expired mid-flow): catch `401` responses from any SEP-24 call and re-run the session setup before retrying — don't silently drop the user's in-progress transaction.
+- **Anchor-side validation errors**: the `/transactions/deposit|withdraw/interactive` endpoints return `400` with a JSON `error` field for unsupported assets or malformed accounts — surface this directly, it's usually anchor-specific and user-actionable.
+- **Popup closed early**: if the popup closes before the transaction reaches a terminal or `pending_user_transfer_start` status, keep polling anyway — many anchors let the user resume from a link, and the transaction record persists server-side regardless of the popup.
+- **Timeouts**: cap total polling duration (see `timeoutMs` above) and let the caller decide whether to keep the transaction record around for a manual "check status" action later, rather than polling forever.
+
+## Verifying the Tutorial
+
+- Run the full flow against a testnet reference anchor (e.g. one of the SDF's test anchors) end to end: session → interactive deposit → complete the popup's test KYC form → poll to `completed`.
+- Confirm a `pending_trust` transaction correctly prompts for a trustline and resumes polling after one is added.
+- Force a SEP-10 token expiry mid-poll and confirm the client re-authenticates rather than surfacing a raw `401`.

--- a/routes-d/912-sep30-recovery-signer-service.mdx
+++ b/routes-d/912-sep30-recovery-signer-service.mdx
@@ -1,0 +1,158 @@
+---
+title: Build a Complete SEP-30 Recovery Signer Service
+description: A tutorial for building a small SEP-30 recovery signer service — enrollment and recovery endpoints, trust considerations, and a working sample.
+date: 2026-08-25
+---
+
+# Build a Complete SEP-30 Recovery Signer Service
+
+[SEP-30](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md) defines an account recovery protocol where one or more independent recovery servers hold signatures that can be used to recover access to a Stellar account whose device key was lost. This guide walks through building a minimal recovery signer service: the enrollment endpoint, the recovery endpoint, and the trust model that keeps the service from becoming a custodian.
+
+---
+
+## Trust Model
+
+A SEP-30 recovery signer is **not** a custodian — it never holds the funds and never has unilateral authority to move them. Keep these boundaries in mind while implementing the service:
+
+- **No single point of failure.** A wallet should register with multiple independent recovery servers, each contributing one signer to the account's multisig configuration. No single server's signature should be enough to authorize a transaction — the account's signer weights and thresholds must require at least one other party (typically the device key, while it's still available, or a second recovery server).
+- **The server signs a specific transaction, not "on behalf of the user."** It should only ever countersign a transaction the account owner (or a verified identity flow) explicitly requested for recovery — never open-ended signing authority.
+- **Identity verification is the real security boundary.** The protocol delegates _how_ to authenticate account ownership (email, phone, SMS OTP, or third-party identity providers) to the implementer. Treat this as the most security-critical part of the service — a weak identity check turns the recovery signer into an account-takeover vector.
+- **Auth tokens are short-lived and scoped.** Every request after enrollment uses a JWT bound to that one Stellar `address`. Don't accept a token for one account when authorizing an action on another.
+
+---
+
+## Enrollment
+
+Enrollment registers an account with the recovery server and stores one or more identities that can later trigger recovery.
+
+```
+POST /accounts/{address}
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+{
+  "identities": [
+    {
+      "role": "owner",
+      "auth_methods": [
+        { "type": "stellar_address", "value": "GABCDEF...OWNER" }
+      ]
+    },
+    {
+      "role": "other",
+      "auth_methods": [
+        { "type": "phone_number", "value": "+15555550100" }
+      ]
+    }
+  ]
+}
+```
+
+The server should:
+
+1. Verify the bearer JWT matches `address` (the SEP-10 web auth flow is the typical way a wallet obtains this token before enrollment).
+2. Generate (or look up) a signing keypair dedicated to this account — never reuse one signer across unrelated accounts.
+3. Persist the identities and their auth methods. Each identity is a distinct way _someone_ can later prove they should be allowed to trigger recovery for this account (the owner via their still-working device key, a trusted contact via SMS, etc.).
+4. Return the account's recovery signer's public key so the wallet can add it to the account's signer list on-chain, with an appropriate weight.
+
+```json
+{
+  "address": "GABCDEF...OWNER",
+  "identities": [
+    { "role": "owner", "authenticated": false },
+    { "role": "other", "authenticated": false }
+  ],
+  "signers": [
+    { "key": "GRECOVERY...SIGNER", "added_at": "2026-08-25T00:00:00Z" }
+  ]
+}
+```
+
+## Recovery
+
+Recovery happens after the device key is lost. The user proves their identity through one of the registered auth methods, then asks the server to sign a specific transaction (typically one that swaps in a new device key).
+
+```
+POST /accounts/{address}/sign/{signing-address}
+Authorization: Bearer <jwt-for-recovery-identity>
+Content-Type: application/json
+
+{
+  "transaction": "AAAAAgAAAAA...<base64 envelope>"
+}
+```
+
+The server should:
+
+1. Verify the bearer token corresponds to one of the account's registered identities (not necessarily the owner — a trusted contact's identity is a valid path if that's how the wallet configured recovery).
+2. Decode the transaction and check that it does what a recovery transaction is expected to do for this integration (e.g. only touches the signer list, doesn't move funds, doesn't change the home domain). **Never blindly sign an arbitrary transaction** — an unconstrained signer is a bigger liability than no recovery signer at all.
+3. Sign with the account's dedicated recovery keypair and return the signature.
+
+```json
+{
+  "signature": "3Vg0...base64-sig",
+  "network_passphrase": "Public Global Stellar Network ; September 2015"
+}
+```
+
+The wallet then combines this signature with any other required signatures (e.g. from a second recovery server) and submits the transaction to Horizon or an RPC node.
+
+## Polling and Status
+
+Expose a read endpoint so a wallet can check enrollment status without re-triggering side effects:
+
+```
+GET /accounts/{address}
+Authorization: Bearer <jwt>
+```
+
+Returns the same shape as the enrollment response, with each identity's `authenticated` flag reflecting whether that identity has completed its auth method at least once.
+
+## Error Handling
+
+| Status | Meaning            | When to return it                                                   |
+| ------ | ------------------ | ------------------------------------------------------------------- |
+| `400`  | Malformed request  | Missing `identities`, invalid transaction XDR                       |
+| `401`  | Bad or expired JWT | Token doesn't decode, or is expired                                 |
+| `404`  | Unknown account    | `address` was never enrolled                                        |
+| `409`  | Already enrolled   | Enrollment called twice for the same address without an update flag |
+
+Return a JSON body with an `error` field describing the problem — don't leak internal identifiers (database IDs, stack traces) in the message.
+
+## Minimal Working Sample
+
+```ts
+// recovery-server.ts (sketch — swap the in-memory store for a real database)
+import { Keypair, Transaction, Networks } from '@stellar/stellar-sdk';
+
+const accounts = new Map<
+  string,
+  { signerSecret: string; identities: Identity[] }
+>();
+
+async function enroll(address: string, identities: Identity[]) {
+  const signer = Keypair.random();
+  accounts.set(address, { signerSecret: signer.secret(), identities });
+  return { address, signers: [{ key: signer.publicKey() }] };
+}
+
+async function sign(address: string, envelopeXdr: string) {
+  const account = accounts.get(address);
+  if (!account) throw new NotFoundError(address);
+
+  const tx = new Transaction(envelopeXdr, Networks.PUBLIC);
+  assertIsRecoveryTransaction(tx); // reject anything that isn't a signer-list change
+
+  const signer = Keypair.fromSecret(account.signerSecret);
+  tx.sign(signer);
+  return { signature: tx.signatures.at(-1)!.signature().toString('base64') };
+}
+```
+
+This is intentionally a sketch, not a production service — a real implementation needs persistent storage, real identity verification (SMS/email delivery, rate limiting), and audit logging of every sign request.
+
+## Verifying the Tutorial
+
+- Enroll a test account, confirm the returned signer key, and add it to the account with `setOptions` at a weight that requires cooperation with another signer.
+- Simulate losing the device key: build a recovery transaction that installs a new device key, request a signature from the recovery server, combine signatures, and submit to testnet.
+- Confirm the server rejects a transaction that tries to do anything other than the expected recovery operation.

--- a/routes-d/912-sep30-recovery-signer-service.mdx
+++ b/routes-d/912-sep30-recovery-signer-service.mdx
@@ -1,10 +1,10 @@
 ---
-title: Build a Complete SEP-30 Recovery Signer Service
+title: SEP-30 Recovery Signer Service
 description: A tutorial for building a small SEP-30 recovery signer service — enrollment and recovery endpoints, trust considerations, and a working sample.
 date: 2026-08-25
 ---
 
-# Build a Complete SEP-30 Recovery Signer Service
+# SEP-30 Recovery Signer Service
 
 [SEP-30](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0030.md) defines an account recovery protocol where one or more independent recovery servers hold signatures that can be used to recover access to a Stellar account whose device key was lost. This guide walks through building a minimal recovery signer service: the enrollment endpoint, the recovery endpoint, and the trust model that keeps the service from becoming a custodian.
 


### PR DESCRIPTION
## Summary
Adds four documentation drafts to `routes-d/`, each covering one assigned Stellar Wave issue: a SEP-30 recovery signer service tutorial, a SEP-24 anchor client library tutorial, a transaction confirmation ceremony pattern guide, and an inline transaction preview guide. All four are docs-only, follow the existing `routes-d/` MDX frontmatter and writing conventions, and stay out of `docs/` per each issue's constraint to keep drafts unregistered until a maintainer reviews them.

closes #912
closes #908
closes #907
closes #906

## Changes
- **#912 — SEP-30 recovery signer service**: `routes-d/912-sep30-recovery-signer-service.mdx`. Covers the trust model (why a recovery signer must never be a de-facto custodian), the enrollment endpoint (`POST /accounts/{address}` with identity registration and signer key issuance), the recovery endpoint (`POST /accounts/{address}/sign/{signing-address}` with transaction-scope validation before countersigning), a status/polling read endpoint, an error table (400/401/404/409), and a minimal TypeScript sketch of the enroll/sign flow using `@stellar/stellar-sdk`.
- **#908 — SEP-24 anchor client library**: `routes-d/908-sep24-anchor-client-library.mdx`. Covers session setup (stellar.toml discovery + SEP-10 web auth), the interactive flow (asset discovery via `/info`, starting deposit/withdraw, opening the interactive popup), a polling implementation with a typed `Sep24Status` union and terminal-state detection, and error handling for expired auth tokens, anchor-side validation errors, early-closed popups, and polling timeouts.
- **#907 — Tx confirmation ceremony pattern**: `routes-d/907-tx-confirmation-ceremony-pattern.mdx`. Defines trigger conditions (value threshold, unfamiliar destination, irreversible/high-privilege ops, unusual fee or missing time bounds), the five ceremony steps (plain-language summary, explicit destination confirmation, risk-specific callouts, a deliberate final action, post-sign receipt), a friction-vs-safety calibration table, and a worked `setOptions` signer-change example.
- **#906 — Inline transaction previews**: `routes-d/906-inline-transaction-previews.mdx`. Covers what to summarize (per-operation plain-language descriptions, fee vs. total, before/after account state), a warning-state table (new destination, nonexistent destination account, non-zero-balance trustline removal, missing time bounds, elevated fee, signer/threshold changes, missing memo to a custodial destination), a small React example component, and a worked payment example. Cross-references the #907 ceremony guide for when a preview should be paired with the full ceremony.

## Test plan
- `pnpm build:content` runs clean end-to-end (156 documents generated); the two pre-existing warnings it reports (`examples/payment-app.mdx` extra fields, `guides/custom-hook-authoring-playbook.mdx` missing title) are unrelated to this PR and unaffected by it — `routes-d/` isn't part of `contentDirPath: 'docs'`, so these new files aren't processed by contentlayer at all.
- `pnpm check:links` fails on a clean checkout of `main` before this PR's changes too (2 hardcoded component links fail because they require a running `pnpm dev` server) — pre-existing and unrelated to these additions.
- Content was manually reviewed against each issue's acceptance criteria and against the existing `routes-d/` MDX files for frontmatter/style consistency.

---
These are documentation drafts, not yet wired into the site's nav — per each issue's constraint, they're placed in `routes-d/` for maintainer review before promotion into `docs/`. No code paths, working samples are illustrative TypeScript sketches (clearly marked as such) rather than fully executable packages, consistent with how the assigned issues describe "a working sample" for a documentation tutorial.