### PR TITLE
docs: add Soroban token, vault, staking, and SEP-6 deposit/withdraw guides

### DIFF
--- a/routes-d/911-sep6-deposit-withdraw-tutorial.mdx
+++ b/routes-d/911-sep6-deposit-withdraw-tutorial.mdx
@@ -1,0 +1,462 @@
+---
+title: Comprehensive SEP-6 Deposit and Withdraw Tutorial
+description: Implement the SEP-6 non-interactive deposit and withdraw flow end to end — request shapes, status polling, and SEP-12 KYC integration points — with a working sample.
+date: 2026-08-25
+---
+
+# Comprehensive SEP-6 Deposit and Withdraw Tutorial
+
+**SEP-6** defines a non-interactive (machine-to-machine) protocol for depositing external assets into Stellar and withdrawing Stellar assets back out through an Anchor. Unlike SEP-24 (which redirects the user to an Anchor-hosted interactive webview), SEP-6 is built for apps that want to render their **own** UI around the deposit/withdraw flow and talk to the Anchor purely over HTTP. This tutorial implements the flow end to end: discovery, authentication, KYC, deposit, withdraw, and status polling.
+
+---
+
+## Protocol Overview
+
+<Note type="info">
+  SEP-6 is intentionally low-level — your application owns the UI and calls the
+  Anchor's REST endpoints directly. If you'd rather have the Anchor host the
+  entire flow in a popup, see SEP-24 instead; this tutorial is specifically for
+  the non-interactive SEP-6 case.
+</Note>
+
+```
+Client App                         Anchor Server                    Stellar Network
+    │                                    │                                  │
+    │── GET /.well-known/stellar.toml ──►│                                  │
+    │◄── TRANSFER_SERVER, SIGNING_KEY ───│                                  │
+    │                                    │                                  │
+    │── GET /sep6/info ──────────────────►│                                  │
+    │◄── supported assets + KYC fields ──│                                  │
+    │                                    │                                  │
+    │── SEP-10 auth challenge/response ──►│                                  │
+    │◄── JWT ─────────────────────────────│                                  │
+    │                                    │                                  │
+    │── PUT /sep12/customer (JWT) ───────►│                                  │
+    │◄── customer_id + status ───────────│                                  │
+    │                                    │                                  │
+    │── GET /sep6/deposit (JWT) ─────────►│                                  │
+    │◄── id + how + status ──────────────│                                  │
+    │                                    │── issues asset on deposit ──────►│
+    │── GET /sep6/transaction (poll) ────►│                                  │
+    │◄── status: completed ──────────────│                                  │
+```
+
+---
+
+## Step 1: Discover the Anchor (`stellar.toml`)
+
+Every Anchor publishes a `stellar.toml` file at its home domain describing its capabilities.
+
+```bash
+curl -s https://testanchor.stellar.org/.well-known/stellar.toml
+```
+
+```toml
+SIGNING_KEY="GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLII2Q2ZH8AAPGMPMYWECSZH"
+TRANSFER_SERVER="https://testanchor.stellar.org/sep6"
+KYC_SERVER="https://testanchor.stellar.org/sep12"
+WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"
+
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+```
+
+Parse and store `TRANSFER_SERVER`, `KYC_SERVER`, `WEB_AUTH_ENDPOINT`, and `SIGNING_KEY` — every subsequent request is built from these values.
+
+---
+
+## Step 2: `GET /info` — Capabilities & Required Fields
+
+```bash
+curl -s https://testanchor.stellar.org/sep6/info
+```
+
+Response shape:
+
+```json
+{
+  "deposit": {
+    "USDC": {
+      "enabled": true,
+      "min_amount": 10,
+      "max_amount": 10000,
+      "fields": {
+        "email_address": {
+          "description": "Your email address",
+          "optional": false
+        }
+      }
+    }
+  },
+  "withdraw": {
+    "USDC": {
+      "enabled": true,
+      "types": {
+        "bank_account": {
+          "fields": {
+            "dest": { "description": "Bank account number" },
+            "dest_extra": { "description": "Bank routing number" }
+          }
+        }
+      }
+    }
+  },
+  "fee": { "enabled": true },
+  "transactions": { "enabled": true },
+  "transaction": { "enabled": true }
+}
+```
+
+Use this response to decide which fields your deposit/withdraw form needs to collect, and whether the Anchor requires separate SEP-12 KYC data on top of the `fields` listed here.
+
+---
+
+## Step 3: SEP-10 Authentication
+
+Both `/deposit` and `/withdraw` require a JWT obtained via SEP-10 Web Authentication.
+
+```bash
+# 1. Request a challenge transaction
+curl -s "https://testanchor.stellar.org/auth?account=GYOUR_STELLAR_ADDRESS"
+```
+
+```json
+{
+  "transaction": "AAAAAgAAAAA...(base64 XDR challenge transaction)...",
+  "network_passphrase": "Test SDF Network ; September 2015"
+}
+```
+
+Sign the returned transaction envelope with your Stellar keypair (client-side, never send your secret key to the Anchor), then submit it back:
+
+```bash
+# 2. Submit the signed challenge
+curl -s -X POST https://testanchor.stellar.org/auth \
+  -H "Content-Type: application/json" \
+  -d '{"transaction": "AAAAAgAAAAA...(signed)..."}'
+```
+
+```json
+{ "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }
+```
+
+Attach this `token` as `Authorization: Bearer <token>` on every subsequent request. SEP-10 JWTs are typically valid for 24 hours — check the `exp` claim and re-authenticate before it lapses.
+
+---
+
+## Step 4: SEP-12 KYC Integration
+
+Before the Anchor will process a deposit or withdraw for a new customer, submit their KYC data via SEP-12's `/customer` endpoint.
+
+```bash
+curl -s -X PUT https://testanchor.stellar.org/sep12/customer \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account": "GYOUR_STELLAR_ADDRESS",
+    "first_name": "Ada",
+    "last_name": "Lovelace",
+    "email_address": "ada@example.com",
+    "birth_date": "1815-12-10"
+  }'
+```
+
+```json
+{
+  "id": "d1ce3c1c-a1e6-4d28-b5be-aa0e3c91c2c3",
+  "status": "NEEDS_INFO",
+  "fields": {
+    "bank_account_number": {
+      "description": "US bank account number",
+      "optional": true
+    }
+  }
+}
+```
+
+**Integration points to handle in your app:**
+
+- `status: NEEDS_INFO` — re-submit `PUT /customer` with the additional `fields` listed in the response.
+- `status: PROCESSING` — the Anchor is manually reviewing; poll `GET /customer` on an interval (e.g. every 10–30s) rather than blocking the UI.
+- `status: ACCEPTED` — proceed to `/deposit` or `/withdraw`.
+- `status: REJECTED` — surface a generic "unable to verify identity" message; do not expose the Anchor's internal rejection reason to the end user.
+
+```bash
+# Poll KYC status
+curl -s https://testanchor.stellar.org/sep12/customer?account=GYOUR_STELLAR_ADDRESS \
+  -H "Authorization: Bearer $JWT"
+```
+
+<Note type="warning">
+  Do not persist raw KYC fields (name, birth date, bank details) in your own
+  database. The Anchor is the data controller. If you cache anything locally,
+  store only the opaque `id` (customer id) and `status` string so you can skip
+  re-submission on the next visit.
+</Note>
+
+---
+
+## Step 5: Initiate a Deposit
+
+```bash
+curl -s "https://testanchor.stellar.org/sep6/deposit?asset_code=USDC&account=GYOUR_STELLAR_ADDRESS&amount=100" \
+  -H "Authorization: Bearer $JWT"
+```
+
+Request query parameters:
+
+| Field        | Required | Description                                                                                 |
+| ------------ | -------- | ------------------------------------------------------------------------------------------- |
+| `asset_code` | Yes      | The Stellar asset code to receive (e.g. `USDC`).                                            |
+| `account`    | Yes      | The Stellar account to credit.                                                              |
+| `amount`     | No       | Requested deposit amount; the Anchor may ignore this and let the user specify it off-chain. |
+| `memo_type`  | No       | `text`, `id`, or `hash` — required if the destination account needs a memo.                 |
+
+Response:
+
+```json
+{
+  "id": "82fhs729f63dh0v4",
+  "how": "Make a payment to Bank: 121122676, Account: 13719713158835300",
+  "min_amount": 10,
+  "max_amount": 10000,
+  "eta": 1800,
+  "extra_info": {
+    "message": "Deposit sent from a US bank account will arrive in 2-3 business days."
+  }
+}
+```
+
+The `id` returned here is the **transaction id** you will poll in Step 7. `how` is a human-readable instruction to show the user — display it verbatim; do not try to parse structured banking data out of it, since its format is Anchor-specific free text.
+
+---
+
+## Step 6: Initiate a Withdrawal
+
+```bash
+curl -s -X POST https://testanchor.stellar.org/sep6/withdraw \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "asset_code=USDC&type=bank_account&dest=123456789&dest_extra=021000021&account=GYOUR_STELLAR_ADDRESS"
+```
+
+Request fields:
+
+| Field        | Required | Description                                                              |
+| ------------ | -------- | ------------------------------------------------------------------------ |
+| `asset_code` | Yes      | Asset to withdraw.                                                       |
+| `type`       | Yes      | Withdrawal method — e.g. `bank_account`, `cash`. From `/info`'s `types`. |
+| `dest`       | Yes      | Destination identifier for that type (e.g. bank account number).         |
+| `dest_extra` | No       | Extra routing info (e.g. bank routing number).                           |
+| `account`    | No       | Stellar account withdrawing from, if different from the JWT subject.     |
+
+Response:
+
+```json
+{
+  "account_id": "GDANCHOR6WITHDRAWALADDRESSEXAMPLE",
+  "memo_type": "id",
+  "memo": "88271",
+  "id": "9c33f7ea-1234-4a4a-8a1b-abcdef123456",
+  "min_amount": 10,
+  "max_amount": 10000,
+  "eta": 172800
+}
+```
+
+Now send the Stellar payment yourself: submit a Stellar `payment` operation to `account_id`, attaching `memo` (typed as `memo_type`) so the Anchor can match your on-chain payment to this withdrawal request.
+
+```ts
+import {
+  TransactionBuilder,
+  Operation,
+  Memo,
+  Networks,
+  BASE_FEE,
+} from '@stellar/stellar-sdk';
+
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    Operation.payment({
+      destination: 'GDANCHOR6WITHDRAWALADDRESSEXAMPLE',
+      asset: usdcAsset,
+      amount: '50',
+    })
+  )
+  .addMemo(Memo.id('88271'))
+  .setTimeout(60)
+  .build();
+```
+
+<Note type="warning">
+  Omitting or mistyping the memo is the single most common integration bug in
+  SEP-6 withdrawals — the Anchor cannot attribute an unmemo'd payment to your
+  withdrawal request, and funds can become stuck in manual reconciliation.
+</Note>
+
+---
+
+## Step 7: Poll Transaction Status
+
+Both deposits and withdrawals are tracked through the same `/transaction` endpoint, keyed by the `id` returned in Steps 5/6.
+
+```bash
+curl -s "https://testanchor.stellar.org/sep6/transaction?id=82fhs729f63dh0v4" \
+  -H "Authorization: Bearer $JWT"
+```
+
+```json
+{
+  "transaction": {
+    "id": "82fhs729f63dh0v4",
+    "kind": "deposit",
+    "status": "pending_external",
+    "status_eta": 1800,
+    "amount_in": "100.00",
+    "amount_out": "98.00",
+    "amount_fee": "2.00",
+    "started_at": "2026-08-25T10:00:00Z"
+  }
+}
+```
+
+### Status Values & Required Client Handling
+
+| Status                        | Meaning                                   | Client action                                    |
+| ----------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| `incomplete`                  | Missing required info                     | Prompt user for missing fields, resubmit         |
+| `pending_user_transfer_start` | Waiting on the user to send fiat/crypto   | Show `how` instructions again                    |
+| `pending_external`            | Anchor is processing (e.g. bank clearing) | Poll every 15–30s; show an ETA from `status_eta` |
+| `pending_anchor`              | Anchor manual processing                  | Poll on a longer interval (e.g. every 60s)       |
+| `completed`                   | Funds delivered                           | Stop polling; show success + `amount_out`        |
+| `error`                       | Something failed                          | Stop polling; show `message` field, offer retry  |
+| `refunded`                    | Anchor returned the funds                 | Stop polling; show refund details                |
+
+```ts
+async function pollTransaction(
+  id: string,
+  jwt: string,
+  onUpdate: (tx: any) => void
+) {
+  const terminal = new Set(['completed', 'error', 'refunded']);
+  while (true) {
+    const res = await fetch(
+      `https://testanchor.stellar.org/sep6/transaction?id=${id}`,
+      {
+        headers: { Authorization: `Bearer ${jwt}` },
+      }
+    );
+    const { transaction } = await res.json();
+    onUpdate(transaction);
+    if (terminal.has(transaction.status)) return transaction;
+    await new Promise((r) => setTimeout(r, 15_000));
+  }
+}
+```
+
+---
+
+## Full Client Wrapper
+
+```ts
+// lib/sep6.ts
+export class Sep6Client {
+  constructor(
+    private transferServer: string,
+    private kycServer: string,
+    private jwt: string
+  ) {}
+
+  async info() {
+    const res = await fetch(`${this.transferServer}/info`);
+    return res.json();
+  }
+
+  async submitKyc(fields: Record<string, string>) {
+    const res = await fetch(`${this.kycServer}/customer`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${this.jwt}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(fields),
+    });
+    if (!res.ok) throw new Error(`KYC submission failed: ${res.status}`);
+    return res.json();
+  }
+
+  async deposit(params: {
+    asset_code: string;
+    account: string;
+    amount?: string;
+  }) {
+    const qs = new URLSearchParams(params as Record<string, string>);
+    const res = await fetch(`${this.transferServer}/deposit?${qs}`, {
+      headers: { Authorization: `Bearer ${this.jwt}` },
+    });
+    if (!res.ok) throw new Error(`Deposit request failed: ${res.status}`);
+    return res.json();
+  }
+
+  async withdraw(params: {
+    asset_code: string;
+    type: string;
+    dest: string;
+    dest_extra?: string;
+  }) {
+    const res = await fetch(`${this.transferServer}/withdraw`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.jwt}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+    if (!res.ok) throw new Error(`Withdraw request failed: ${res.status}`);
+    return res.json();
+  }
+
+  async transaction(id: string) {
+    const res = await fetch(`${this.transferServer}/transaction?id=${id}`, {
+      headers: { Authorization: `Bearer ${this.jwt}` },
+    });
+    if (!res.ok) throw new Error(`Transaction lookup failed: ${res.status}`);
+    const { transaction } = await res.json();
+    return transaction;
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+### `403 Forbidden` on `/deposit` or `/withdraw`
+
+The JWT is missing, expired, or was issued for a different `account`. Re-run the SEP-10 flow.
+
+### KYC stuck at `NEEDS_INFO` indefinitely
+
+Re-check the `fields` object on every `PUT /customer` response — the Anchor may request _additional_ fields after each submission round, not all up front.
+
+### Withdrawal payment isn't recognized
+
+Confirm the memo type and value exactly match what `/withdraw` returned (`memo_type` + `memo`). A `text` memo truncated at 28 bytes, or an `id` memo sent as `hash`, will both fail silent matching on the Anchor's side.
+
+### `pending_external` never resolves on testnet
+
+Some reference Anchor implementations only progress `pending_external` transactions via manual triggers. Check the Anchor's documentation for a testnet-specific "simulate completion" endpoint.
+
+---
+
+## Related docs
+
+- [Anchor Onboarding with KYC](/docs/guides/anchor-onboarding-kyc) — the Nextellar CLI's higher-level wrapper around this same flow
+- [Recurring Payments via CLI](/docs/guides/recurring-payments-cli) — automate payments on a schedule
+- [SEP-6 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) — full protocol reference
+- [SEP-12 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md) — KYC data API reference
+- [SEP-10 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) — Stellar Web Authentication

--- a/routes-d/915-soroban-token-contract-guide.mdx
+++ b/routes-d/915-soroban-token-contract-guide.mdx
@@ -1,0 +1,440 @@
+---
+title: Comprehensive Soroban Token Contract Implementation Guide
+description: End-to-end guide to implementing a Soroban token contract — balance, transfer, and approve — with SEP-41 compatibility notes and a working sample.
+date: 2026-08-25
+---
+
+# Comprehensive Soroban Token Contract Implementation Guide
+
+A **token contract** is the Soroban equivalent of an ERC-20 contract: it tracks balances for a set of addresses and exposes `balance`, `transfer`, and `approve`/`transfer_from` so other contracts and wallets can move value in and out of it. This guide implements a token contract from scratch, end to end, and calls out where it aligns with — and diverges from — the Stellar **SEP-41** token interface standard.
+
+---
+
+## Why SEP-41 Compatibility Matters
+
+Any contract that wants to be usable by wallets, DEXs, and other Soroban contracts (including `soroban-sdk`'s own `token::Client`) should implement the **SEP-41** interface — the standard token contract interface for Soroban. Implementing SEP-41 means:
+
+- Wallets like Freighter can display balances without custom integration code.
+- Other contracts (vaults, AMMs, escrow) can call your token through the generic `token::Client` rather than a bespoke client.
+- Standard tooling (block explorers, indexers) can classify and display transfers correctly.
+
+<Note type="info">
+  SEP-41 does not mandate an implementation — only a function signature
+  contract. You are free to add extra functions (minting, pausing, blacklists)
+  as long as the required functions keep their exact signatures.
+</Note>
+
+---
+
+## Contract Design
+
+```
+Holder ──transfer(to, amount)────────► Token Contract
+                                         │
+                                         ├── require_auth() on `from`
+                                         ├── debit balance[from]
+                                         └── credit balance[to]
+
+Spender ──transfer_from(from, to, amt)─► Token Contract
+                                         │
+                                         ├── require_auth() on `spender`
+                                         ├── check & debit allowance[from][spender]
+                                         ├── debit balance[from]
+                                         └── credit balance[to]
+```
+
+Balances and allowances are stored in **persistent** storage (they must survive indefinitely, unlike transient contract-call state), keyed by address (and by `(owner, spender)` pair for allowances).
+
+---
+
+## Project Layout
+
+```
+my-token-contract/
+├── Cargo.toml
+└── contracts/
+    └── token/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── contract.rs
+            ├── storage.rs
+            └── test.rs
+```
+
+### Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-token-contract"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = false
+panic = "abort"
+codegen-units = 1
+```
+
+---
+
+## Storage Layout
+
+```rust
+// contracts/token/src/storage.rs
+use soroban_sdk::{contracttype, Address, Env};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    TotalSupply,
+    Balance(Address),
+    Allowance(Address, Address), // (owner, spender)
+    AllowanceExpiry(Address, Address),
+}
+
+pub fn read_balance(env: &Env, addr: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(addr.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_balance(env: &Env, addr: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(addr.clone()), &amount);
+    // Refresh TTL every write so an active balance never expires unexpectedly.
+    env.storage().persistent().extend_ttl(
+        &DataKey::Balance(addr.clone()),
+        100_000,
+        100_000,
+    );
+}
+
+pub fn read_allowance(env: &Env, owner: &Address, spender: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Allowance(owner.clone(), spender.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_allowance(env: &Env, owner: &Address, spender: &Address, amount: i128, expiration_ledger: u32) {
+    let key = DataKey::Allowance(owner.clone(), spender.clone());
+    env.storage().temporary().set(&key, &amount);
+    env.storage().temporary().set(
+        &DataKey::AllowanceExpiry(owner.clone(), spender.clone()),
+        &expiration_ledger,
+    );
+}
+```
+
+<Note type="warning">
+  Allowances use **temporary** storage keyed to an explicit `expiration_ledger`,
+  matching the SEP-41 `approve` signature. This prevents a stale, forgotten
+  approval from remaining spendable forever — it simply expires with the ledger
+  entry.
+</Note>
+
+---
+
+## Contract Implementation
+
+```rust
+// contracts/token/src/contract.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use crate::storage::{
+    read_allowance, read_balance, write_allowance, write_balance, DataKey,
+};
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    /// One-time setup. Mints the initial supply to `admin`.
+    pub fn initialize(env: Env, admin: Address, decimal: u32, name: String, symbol: String) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TotalSupply, &0i128);
+        let _ = (decimal, name, symbol); // stored via a Metadata struct in production
+    }
+
+    // ---- SEP-41 required interface ----
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        read_balance(&env, &id)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let from_balance = read_balance(&env, &from);
+        assert!(from_balance >= amount, "insufficient balance");
+
+        write_balance(&env, &from, from_balance - amount);
+        let to_balance = read_balance(&env, &to);
+        write_balance(&env, &to, to_balance + amount);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("transfer"), from, to), amount);
+    }
+
+    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let allowance = read_allowance(&env, &from, &spender);
+        assert!(allowance >= amount, "insufficient allowance");
+
+        let from_balance = read_balance(&env, &from);
+        assert!(from_balance >= amount, "insufficient balance");
+
+        write_allowance(&env, &from, &spender, allowance - amount, 0);
+        write_balance(&env, &from, from_balance - amount);
+        let to_balance = read_balance(&env, &to);
+        write_balance(&env, &to, to_balance + amount);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("transfer"), from, to),
+            amount,
+        );
+    }
+
+    pub fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+        from.require_auth();
+        assert!(amount >= 0, "amount must be non-negative");
+
+        write_allowance(&env, &from, &spender, amount, expiration_ledger);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("approve"), from, spender),
+            (amount, expiration_ledger),
+        );
+    }
+
+    pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
+        read_allowance(&env, &from, &spender)
+    }
+
+    // ---- Admin-only extensions (not part of SEP-41) ----
+
+    pub fn mint(env: Env, admin: Address, to: Address, amount: i128) {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert_eq!(admin, stored_admin, "unauthorized");
+        admin.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let balance = read_balance(&env, &to);
+        write_balance(&env, &to, balance + amount);
+
+        let total: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalSupply, &(total + amount));
+    }
+}
+```
+
+---
+
+## Test Suite
+
+```rust
+// contracts/token/src/test.rs
+#![cfg(test)]
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Env, Address};
+
+#[test]
+fn test_mint_and_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TokenContract, ());
+    let client = TokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(&admin, &7, &String::from_str(&env, "Nextellar Token"), &String::from_str(&env, "NXT"));
+    client.mint(&admin, &alice, &1_000);
+    assert_eq!(client.balance(&alice), 1_000);
+
+    client.transfer(&alice, &bob, &400);
+    assert_eq!(client.balance(&alice), 600);
+    assert_eq!(client.balance(&bob), 400);
+}
+
+#[test]
+fn test_approve_and_transfer_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TokenContract, ());
+    let client = TokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.initialize(&admin, &7, &String::from_str(&env, "Nextellar Token"), &String::from_str(&env, "NXT"));
+    client.mint(&admin, &alice, &1_000);
+
+    client.approve(&alice, &bob, &300, &(env.ledger().sequence() + 1000));
+    assert_eq!(client.allowance(&alice, &bob), 300);
+
+    client.transfer_from(&bob, &alice, &carol, &200);
+    assert_eq!(client.balance(&alice), 800);
+    assert_eq!(client.balance(&carol), 200);
+    assert_eq!(client.allowance(&alice, &bob), 100);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_transfer_insufficient_balance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TokenContract, ());
+    let client = TokenContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(&admin, &7, &String::from_str(&env, "Nextellar Token"), &String::from_str(&env, "NXT"));
+    client.transfer(&alice, &bob, &1);
+}
+```
+
+---
+
+## Client Integration
+
+```ts
+// lib/token.ts
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  nativeToScVal,
+  Address,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+const TOKEN_ID = process.env.NEXT_PUBLIC_TOKEN_CONTRACT!;
+
+export async function getBalance(owner: string): Promise<bigint> {
+  const server = new rpc.Server(RPC_URL);
+  const contract = new Contract(TOKEN_ID);
+  const account = await server.getAccount(owner).catch(
+    () =>
+      // Falls back to a throwaway sequence-0 account for read-only simulation
+      new (require('@stellar/stellar-sdk').Account)(owner, '0')
+  );
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(contract.call('balance', new Address(owner).toScVal()))
+    .setTimeout(5)
+    .build();
+
+  const sim = (await server.simulateTransaction(
+    tx
+  )) as rpc.SimulateTransactionSuccessResponse;
+  return BigInt(scValToNative(sim.result!.retval).toString());
+}
+
+export async function transfer(
+  fromKeypair: { publicKey(): string; sign(tx: any): void },
+  to: string,
+  amount: bigint
+): Promise<void> {
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(fromKeypair.publicKey());
+  const contract = new Contract(TOKEN_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      contract.call(
+        'transfer',
+        new Address(fromKeypair.publicKey()).toScVal(),
+        new Address(to).toScVal(),
+        nativeToScVal(amount, { type: 'i128' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  fromKeypair.sign(prepared);
+  await server.sendTransaction(prepared);
+}
+```
+
+---
+
+## SEP-41 Compatibility Notes
+
+| Function                                            | SEP-41 required | Notes                                                                     |
+| --------------------------------------------------- | --------------- | ------------------------------------------------------------------------- |
+| `balance(id) -> i128`                               | Yes             | Matches exactly.                                                          |
+| `transfer(from, to, amount)`                        | Yes             | `from.require_auth()` is mandatory — do not skip it.                      |
+| `transfer_from(spender, from, to, amount)`          | Yes             | Signature order matters: `spender` first, matching `token::Client`.       |
+| `approve(from, spender, amount, expiration_ledger)` | Yes             | The `expiration_ledger` param is part of the standard signature.          |
+| `allowance(from, spender) -> i128`                  | Yes             | Returns `0` for both non-existent and expired allowances.                 |
+| `decimals`, `name`, `symbol`                        | Yes             | Read-only metadata; store in a dedicated `Metadata` struct.               |
+| `mint`, admin controls                              | No              | Not part of SEP-41 — safe to add, but keep required signatures untouched. |
+
+Because the signatures match `soroban-sdk`'s built-in `token::Client`, any contract in your codebase (a vault, an escrow, a staking pool) can call your custom token exactly like it would call the native Stellar Asset Contract:
+
+```rust
+let client = token::Client::new(&env, &your_token_contract_address);
+client.transfer(&from, &to, &amount);
+```
+
+---
+
+## Deploying & Invoking with the CLI
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/soroban_token_contract.wasm \
+  --source alice --network testnet
+
+stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- \
+  initialize --admin alice --decimal 7 --name "Nextellar Token" --symbol NXT
+```
+
+---
+
+## Related docs
+
+- [Comprehensive Soroban Vault Contract Guide](/docs/guides/soroban-vault-contract-guide) — build a vault on top of a SEP-41-compatible token
+- [Comprehensive Soroban Smart Contract Authoring Guide](/docs/guides/soroban-contract-authoring) — project layout, build, and deploy fundamentals
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — storage, auth, and cross-contract call primitives

--- a/routes-d/916-soroban-staking-contract-tutorial.mdx
+++ b/routes-d/916-soroban-staking-contract-tutorial.mdx
@@ -1,0 +1,513 @@
+---
+title: Complete Soroban Staking Contract Tutorial
+description: Build a Soroban staking contract from scratch — stake, unstake, and reward accrual — with client invocation examples.
+date: 2026-08-25
+---
+
+# Complete Soroban Staking Contract Tutorial
+
+This tutorial builds a **staking contract** on Soroban: users lock a token to earn rewards over time, and can unstake to reclaim their principal plus any accrued rewards. It covers the contract itself, the reward accrual math, and how to invoke it from a client application.
+
+---
+
+## Design Overview
+
+```
+Staker ──stake(amount)─────────► Staking Contract ──transfer(staker → contract)──► Stake Token
+                                       │
+                                       ├── settle pending rewards for staker (before changing their stake)
+                                       └── staked[staker] += amount
+
+Staker ──unstake(amount)────────► Staking Contract ──transfer(contract → staker)──► Stake Token
+                                       │
+                                       ├── settle pending rewards for staker
+                                       └── staked[staker] -= amount
+
+Staker ──claim_rewards()────────► Staking Contract ──transfer(contract → staker)──► Reward Token
+                                       └── pays out rewards[staker]; resets to 0
+```
+
+Rewards accrue continuously using an **accumulator (reward-per-token) pattern** — the same design used by most production staking contracts (e.g. Synthetix-style staking). This avoids ever having to loop over all stakers: each staker's pending reward is computed lazily, only when they interact with the contract.
+
+---
+
+## Reward Accrual Math
+
+Two numbers drive the whole system:
+
+- `reward_per_token_stored` — cumulative rewards earned per unit staked, since the contract's genesis.
+- `user_reward_per_token_paid[staker]` — the value of `reward_per_token_stored` the last time this staker's rewards were settled.
+
+On every stake/unstake/claim, before changing state:
+
+```
+elapsed = now - last_update_time
+reward_per_token_stored += elapsed * reward_rate / total_staked   (if total_staked > 0)
+last_update_time = now
+
+pending = staked[user] * (reward_per_token_stored - user_reward_per_token_paid[user])
+rewards[user] += pending
+user_reward_per_token_paid[user] = reward_per_token_stored
+```
+
+This guarantees each staker's reward accrues in proportion to _how much_ they staked and _for how long_, without ever iterating over the full staker set.
+
+---
+
+## Project Layout
+
+```
+my-staking-contract/
+├── Cargo.toml
+└── contracts/
+    └── staking/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── contract.rs
+            ├── storage.rs
+            └── test.rs
+```
+
+### Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-staking-contract"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = false
+panic = "abort"
+codegen-units = 1
+```
+
+---
+
+## Storage Layout
+
+```rust
+// contracts/staking/src/storage.rs
+use soroban_sdk::{contracttype, Address, Env};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    StakeToken,
+    RewardToken,
+    RewardRate,             // reward tokens emitted per second (fixed point, 1e7 scale)
+    TotalStaked,
+    RewardPerTokenStored,   // fixed point, 1e7 scale
+    LastUpdateTime,
+    Staked(Address),
+    Rewards(Address),
+    UserRewardPerTokenPaid(Address),
+}
+
+pub const SCALE: i128 = 1_0000000; // 7-decimal fixed point, matches Stellar asset precision
+
+pub fn read_i128(env: &Env, key: &DataKey) -> i128 {
+    env.storage().instance().get(key).unwrap_or(0)
+}
+
+pub fn read_staked(env: &Env, addr: &Address) -> i128 {
+    env.storage().persistent().get(&DataKey::Staked(addr.clone())).unwrap_or(0)
+}
+
+pub fn write_staked(env: &Env, addr: &Address, amount: i128) {
+    let key = DataKey::Staked(addr.clone());
+    env.storage().persistent().set(&key, &amount);
+    env.storage().persistent().extend_ttl(&key, 100_000, 100_000);
+}
+```
+
+---
+
+## Staking Contract
+
+```rust
+// contracts/staking/src/contract.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+use crate::storage::{read_i128, read_staked, write_staked, DataKey, SCALE};
+
+#[contract]
+pub struct StakingContract;
+
+#[contractimpl]
+impl StakingContract {
+    pub fn initialize(env: Env, admin: Address, stake_token: Address, reward_token: Address, reward_rate: i128) {
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::StakeToken, &stake_token);
+        env.storage().instance().set(&DataKey::RewardToken, &reward_token);
+        env.storage().instance().set(&DataKey::RewardRate, &reward_rate);
+        env.storage().instance().set(&DataKey::TotalStaked, &0i128);
+        env.storage().instance().set(&DataKey::RewardPerTokenStored, &0i128);
+        env.storage().instance().set(&DataKey::LastUpdateTime, &env.ledger().timestamp());
+    }
+
+    /// Recomputes the global reward accumulator and settles `who`'s pending rewards.
+    /// Must be called before any state-changing action (stake/unstake/claim).
+    fn update_reward(env: &Env, who: &Address) {
+        let total_staked = read_i128(env, &DataKey::TotalStaked);
+        let last_update: u64 = env.storage().instance().get(&DataKey::LastUpdateTime).unwrap();
+        let now = env.ledger().timestamp();
+        let mut reward_per_token = read_i128(env, &DataKey::RewardPerTokenStored);
+
+        if total_staked > 0 {
+            let elapsed = (now - last_update) as i128;
+            let reward_rate = read_i128(env, &DataKey::RewardRate);
+            reward_per_token += elapsed * reward_rate * SCALE / total_staked;
+            env.storage().instance().set(&DataKey::RewardPerTokenStored, &reward_per_token);
+        }
+        env.storage().instance().set(&DataKey::LastUpdateTime, &now);
+
+        let staked = read_staked(env, who);
+        let paid: i128 = env.storage().persistent()
+            .get(&DataKey::UserRewardPerTokenPaid(who.clone()))
+            .unwrap_or(0);
+        let pending = staked * (reward_per_token - paid) / SCALE;
+
+        let current_rewards: i128 = env.storage().persistent()
+            .get(&DataKey::Rewards(who.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Rewards(who.clone()), &(current_rewards + pending));
+        env.storage().persistent().set(&DataKey::UserRewardPerTokenPaid(who.clone()), &reward_per_token);
+    }
+
+    pub fn stake(env: Env, staker: Address, amount: i128) {
+        staker.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        Self::update_reward(&env, &staker);
+
+        let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
+        token::Client::new(&env, &stake_token)
+            .transfer(&staker, &env.current_contract_address(), &amount);
+
+        let current = read_staked(&env, &staker);
+        write_staked(&env, &staker, current + amount);
+
+        let total = read_i128(&env, &DataKey::TotalStaked);
+        env.storage().instance().set(&DataKey::TotalStaked, &(total + amount));
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("stake"), staker), amount);
+    }
+
+    pub fn unstake(env: Env, staker: Address, amount: i128) {
+        staker.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let current = read_staked(&env, &staker);
+        assert!(current >= amount, "insufficient staked balance");
+
+        Self::update_reward(&env, &staker);
+
+        write_staked(&env, &staker, current - amount);
+        let total = read_i128(&env, &DataKey::TotalStaked);
+        env.storage().instance().set(&DataKey::TotalStaked, &(total - amount));
+
+        let stake_token: Address = env.storage().instance().get(&DataKey::StakeToken).unwrap();
+        token::Client::new(&env, &stake_token)
+            .transfer(&env.current_contract_address(), &staker, &amount);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("unstake"), staker), amount);
+    }
+
+    /// Pays out all pending rewards to the caller without touching their stake.
+    pub fn claim_rewards(env: Env, staker: Address) -> i128 {
+        staker.require_auth();
+        Self::update_reward(&env, &staker);
+
+        let rewards: i128 = env.storage().persistent()
+            .get(&DataKey::Rewards(staker.clone()))
+            .unwrap_or(0);
+        assert!(rewards > 0, "no rewards to claim");
+
+        env.storage().persistent().set(&DataKey::Rewards(staker.clone()), &0i128);
+
+        let reward_token: Address = env.storage().instance().get(&DataKey::RewardToken).unwrap();
+        token::Client::new(&env, &reward_token)
+            .transfer(&env.current_contract_address(), &staker, &rewards);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("claim"), staker), rewards);
+
+        rewards
+    }
+
+    /// Read-only view of a staker's currently claimable rewards (including unsettled accrual).
+    pub fn earned(env: Env, staker: Address) -> i128 {
+        let total_staked = read_i128(&env, &DataKey::TotalStaked);
+        let mut reward_per_token = read_i128(&env, &DataKey::RewardPerTokenStored);
+
+        if total_staked > 0 {
+            let last_update: u64 = env.storage().instance().get(&DataKey::LastUpdateTime).unwrap();
+            let elapsed = (env.ledger().timestamp() - last_update) as i128;
+            let reward_rate = read_i128(&env, &DataKey::RewardRate);
+            reward_per_token += elapsed * reward_rate * SCALE / total_staked;
+        }
+
+        let staked = read_staked(&env, &staker);
+        let paid: i128 = env.storage().persistent()
+            .get(&DataKey::UserRewardPerTokenPaid(staker.clone()))
+            .unwrap_or(0);
+        let settled: i128 = env.storage().persistent()
+            .get(&DataKey::Rewards(staker.clone()))
+            .unwrap_or(0);
+
+        settled + staked * (reward_per_token - paid) / SCALE
+    }
+
+    pub fn staked_balance(env: Env, staker: Address) -> i128 {
+        read_staked(&env, &staker)
+    }
+}
+```
+
+<Note type="warning">
+  `reward_rate` is denominated in reward tokens emitted **per second, across all
+  stakers combined** — not per staker. Fund the contract's reward-token balance
+  ahead of time (or top it up periodically); `claim_rewards` will fail with a
+  transfer error if the contract doesn't hold enough reward tokens to pay out.
+</Note>
+
+---
+
+## Test Suite
+
+```rust
+// contracts/staking/src/test.rs
+#![cfg(test)]
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::Env;
+
+fn setup_tokens(env: &Env) -> (Address, Address, Address) {
+    let admin = Address::generate(env);
+    let stake_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let reward_token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    (stake_token, reward_token, admin)
+}
+
+#[test]
+fn test_stake_and_earn_rewards_over_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (stake_token, reward_token, admin) = setup_tokens(&env);
+
+    let staking_id = env.register(StakingContract, ());
+    let staking = StakingContractClient::new(&env, &staking_id);
+    let alice = Address::generate(&env);
+
+    // Fund contracts
+    token::StellarAssetClient::new(&env, &stake_token).mint(&alice, &1_000);
+    token::StellarAssetClient::new(&env, &reward_token).mint(&staking_id, &10_000);
+
+    staking.initialize(&admin, &stake_token, &reward_token, &10); // 10 reward units/sec total
+
+    staking.stake(&alice, &500);
+    assert_eq!(staking.staked_balance(&alice), 500);
+    assert_eq!(staking.earned(&alice), 0);
+
+    env.ledger().with_mut(|l| l.timestamp += 100); // simulate 100 seconds passing
+
+    // Sole staker earns the full emission: 100s * 10/s = 1000
+    assert_eq!(staking.earned(&alice), 1_000);
+
+    let claimed = staking.claim_rewards(&alice);
+    assert_eq!(claimed, 1_000);
+    assert_eq!(staking.earned(&alice), 0);
+}
+
+#[test]
+fn test_rewards_split_proportionally_between_stakers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (stake_token, reward_token, admin) = setup_tokens(&env);
+
+    let staking_id = env.register(StakingContract, ());
+    let staking = StakingContractClient::new(&env, &staking_id);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    token::StellarAssetClient::new(&env, &stake_token).mint(&alice, &1_000);
+    token::StellarAssetClient::new(&env, &stake_token).mint(&bob, &1_000);
+    token::StellarAssetClient::new(&env, &reward_token).mint(&staking_id, &100_000);
+
+    staking.initialize(&admin, &stake_token, &reward_token, &10);
+
+    staking.stake(&alice, &300); // Alice: 300, 75% of pool
+    staking.stake(&bob, &100);   // Bob: 100, 25% of pool
+
+    env.ledger().with_mut(|l| l.timestamp += 100); // 1000 reward units emitted total
+
+    assert_eq!(staking.earned(&alice), 750);
+    assert_eq!(staking.earned(&bob), 250);
+}
+
+#[test]
+#[should_panic(expected = "insufficient staked balance")]
+fn test_unstake_more_than_staked_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (stake_token, reward_token, admin) = setup_tokens(&env);
+
+    let staking_id = env.register(StakingContract, ());
+    let staking = StakingContractClient::new(&env, &staking_id);
+    let alice = Address::generate(&env);
+
+    staking.initialize(&admin, &stake_token, &reward_token, &10);
+    staking.unstake(&alice, &1);
+}
+```
+
+---
+
+## Client Invocation
+
+```ts
+// lib/staking.ts
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  nativeToScVal,
+  Address,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+const STAKING_ID = process.env.NEXT_PUBLIC_STAKING_CONTRACT!;
+
+async function invoke(
+  method: string,
+  keypair: { publicKey(): string; sign(tx: any): void },
+  ...args: any[]
+) {
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(keypair.publicKey());
+  const contract = new Contract(STAKING_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  keypair.sign(prepared);
+  const result = await server.sendTransaction(prepared);
+  return scValToNative((result as any).returnValue);
+}
+
+export function stake(keypair: any, amount: bigint) {
+  return invoke(
+    'stake',
+    keypair,
+    new Address(keypair.publicKey()).toScVal(),
+    nativeToScVal(amount, { type: 'i128' })
+  );
+}
+
+export function unstake(keypair: any, amount: bigint) {
+  return invoke(
+    'unstake',
+    keypair,
+    new Address(keypair.publicKey()).toScVal(),
+    nativeToScVal(amount, { type: 'i128' })
+  );
+}
+
+export function claimRewards(keypair: any) {
+  return invoke(
+    'claim_rewards',
+    keypair,
+    new Address(keypair.publicKey()).toScVal()
+  );
+}
+
+// Read-only: simulate rather than submit, no signature required.
+export async function getEarned(staker: string): Promise<bigint> {
+  const server = new rpc.Server(RPC_URL);
+  const contract = new Contract(STAKING_ID);
+  const account = new (await import('@stellar/stellar-sdk')).Account(
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    '0'
+  );
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(contract.call('earned', new Address(staker).toScVal()))
+    .setTimeout(5)
+    .build();
+
+  const sim = (await server.simulateTransaction(
+    tx
+  )) as rpc.SimulateTransactionSuccessResponse;
+  return BigInt(scValToNative(sim.result!.retval).toString());
+}
+```
+
+---
+
+## CLI Walkthrough
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/soroban_staking_contract.wasm \
+  --source admin --network testnet
+
+stellar contract invoke --id <STAKING_ID> --source admin --network testnet -- \
+  initialize --admin admin --stake_token <STAKE_TOKEN_ID> --reward_token <REWARD_TOKEN_ID> --reward_rate 10
+
+stellar contract invoke --id <STAKING_ID> --source alice --network testnet -- \
+  stake --staker alice --amount 500
+
+stellar contract invoke --id <STAKING_ID> --source alice --network testnet -- \
+  earned --staker alice
+
+stellar contract invoke --id <STAKING_ID> --source alice --network testnet -- \
+  claim_rewards --staker alice
+```
+
+---
+
+## Reward Accrual: Design Alternatives
+
+| Approach                    | Gas / storage cost                         | Precision                                          | When to use                                                 |
+| --------------------------- | ------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------- |
+| **Accumulator (used here)** | O(1) per interaction, no iteration         | High, but rounding accumulates in fixed-point math | Default choice for most token-reward pools                  |
+| Snapshot per epoch          | O(1) per interaction, O(epochs) storage    | Exact per epoch                                    | Fixed-length reward campaigns (e.g. 30-day pool)            |
+| Merkle-distributed rewards  | Off-chain computation, on-chain claim only | Exact, auditable off-chain                         | Very large staker sets where on-chain accrual is too costly |
+
+---
+
+## Related docs
+
+- [Comprehensive Soroban Token Contract Implementation Guide](/docs/guides/soroban-token-contract-guide) — the SEP-41 token used for staking and rewards
+- [Comprehensive Soroban Vault Contract Guide](/docs/guides/soroban-vault-contract-guide) — a share-based alternative to a fixed reward rate
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — storage, auth, and cross-contract call primitives

--- a/routes-d/917-soroban-vault-contract-guide.mdx
+++ b/routes-d/917-soroban-vault-contract-guide.mdx
@@ -1,0 +1,439 @@
+---
+title: Comprehensive Soroban Vault Contract Guide
+description: In-depth guide to building a Soroban vault contract — deposits, share accounting, withdrawals, and optional price-oracle integration — with a working sample.
+date: 2026-08-25
+---
+
+# Comprehensive Soroban Vault Contract Guide
+
+A **vault contract** pools a single underlying asset from many depositors, issues **shares** proportional to each deposit, and lets depositors redeem shares for their proportional claim on the vault's assets at any time. This is the same share-accounting model used by ERC-4626 vaults on EVM chains, adapted to Soroban's storage and auth model. This guide covers the full lifecycle — deposits, share math, withdrawals, and (optionally) using a price oracle to value non-uniform collateral.
+
+---
+
+## Design Overview
+
+```
+Depositor ──deposit(amount)───► Vault Contract ──transfer(depositor → vault)──► Token Contract
+                                     │
+                                     ├── shares = amount × total_shares / total_assets  (or 1:1 if empty)
+                                     ├── total_assets += amount
+                                     └── total_shares += shares
+
+Depositor ◄─withdraw(shares)── Vault Contract ──transfer(vault → depositor)──► Token Contract
+                                     │
+                                     ├── assets_out = shares × total_assets / total_shares
+                                     ├── total_assets -= assets_out
+                                     └── total_shares -= shares
+```
+
+The vault never stores a per-user "balance" of the underlying asset directly — it stores **shares**, and the exchange rate (`total_assets / total_shares`) is what lets yield (or loss) be distributed proportionally without touching every depositor's record on every accrual.
+
+<Note type="info">
+  This guide builds on the token contract from the [Comprehensive Soroban Token
+  Contract Implementation Guide](/docs/guides/soroban-token-contract-guide). The
+  vault holds and moves the underlying asset entirely through that token's
+  SEP-41-compatible `transfer` function.
+</Note>
+
+---
+
+## Project Layout
+
+```
+my-vault-contract/
+├── Cargo.toml
+└── contracts/
+    └── vault/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── contract.rs
+            ├── storage.rs
+            ├── oracle.rs
+            └── test.rs
+```
+
+### Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-vault-contract"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = false
+panic = "abort"
+codegen-units = 1
+```
+
+---
+
+## Storage Layout
+
+```rust
+// contracts/vault/src/storage.rs
+use soroban_sdk::{contracttype, Address, Env};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Asset,          // underlying token contract address
+    Oracle,          // optional price oracle contract address
+    TotalAssets,
+    TotalShares,
+    Shares(Address), // per-depositor share balance
+}
+
+pub fn read_shares(env: &Env, addr: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Shares(addr.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_shares(env: &Env, addr: &Address, amount: i128) {
+    let key = DataKey::Shares(addr.clone());
+    env.storage().persistent().set(&key, &amount);
+    env.storage().persistent().extend_ttl(&key, 100_000, 100_000);
+}
+```
+
+---
+
+## Vault Contract
+
+```rust
+// contracts/vault/src/contract.rs
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+use crate::storage::{read_shares, write_shares, DataKey};
+
+#[contract]
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    pub fn initialize(env: Env, admin: Address, asset: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Asset, &asset);
+        env.storage().instance().set(&DataKey::TotalAssets, &0i128);
+        env.storage().instance().set(&DataKey::TotalShares, &0i128);
+    }
+
+    /// Deposit `amount` of the underlying asset; mint and return shares.
+    pub fn deposit(env: Env, depositor: Address, amount: i128) -> i128 {
+        depositor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let total_assets: i128 = env.storage().instance().get(&DataKey::TotalAssets).unwrap();
+        let total_shares: i128 = env.storage().instance().get(&DataKey::TotalShares).unwrap();
+
+        // First depositor sets the initial 1:1 exchange rate.
+        let shares = if total_shares == 0 || total_assets == 0 {
+            amount
+        } else {
+            amount
+                .checked_mul(total_shares)
+                .and_then(|v| v.checked_div(total_assets))
+                .expect("share calculation overflow")
+        };
+        assert!(shares > 0, "deposit too small to mint shares");
+
+        let asset: Address = env.storage().instance().get(&DataKey::Asset).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&depositor, &env.current_contract_address(), &amount);
+
+        env.storage().instance().set(&DataKey::TotalAssets, &(total_assets + amount));
+        env.storage().instance().set(&DataKey::TotalShares, &(total_shares + shares));
+
+        let current_shares = read_shares(&env, &depositor);
+        write_shares(&env, &depositor, current_shares + shares);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("deposit"), depositor), (amount, shares));
+
+        shares
+    }
+
+    /// Redeem `shares` for a proportional amount of the underlying asset.
+    pub fn withdraw(env: Env, depositor: Address, shares: i128) -> i128 {
+        depositor.require_auth();
+        assert!(shares > 0, "shares must be positive");
+
+        let current_shares = read_shares(&env, &depositor);
+        assert!(current_shares >= shares, "insufficient shares");
+
+        let total_assets: i128 = env.storage().instance().get(&DataKey::TotalAssets).unwrap();
+        let total_shares: i128 = env.storage().instance().get(&DataKey::TotalShares).unwrap();
+        assert!(total_shares > 0, "vault is empty");
+
+        let assets_out = shares
+            .checked_mul(total_assets)
+            .and_then(|v| v.checked_div(total_shares))
+            .expect("withdrawal calculation overflow");
+        assert!(assets_out > 0, "withdrawal too small");
+
+        write_shares(&env, &depositor, current_shares - shares);
+        env.storage().instance().set(&DataKey::TotalAssets, &(total_assets - assets_out));
+        env.storage().instance().set(&DataKey::TotalShares, &(total_shares - shares));
+
+        let asset: Address = env.storage().instance().get(&DataKey::Asset).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&env.current_contract_address(), &depositor, &assets_out);
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("withdraw"), depositor), (shares, assets_out));
+
+        assets_out
+    }
+
+    /// Admin deposits external yield directly (raises the exchange rate for everyone).
+    pub fn add_yield(env: Env, admin: Address, amount: i128) {
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert_eq!(admin, stored_admin, "unauthorized");
+        admin.require_auth();
+
+        let asset: Address = env.storage().instance().get(&DataKey::Asset).unwrap();
+        token::Client::new(&env, &asset)
+            .transfer(&admin, &env.current_contract_address(), &amount);
+
+        let total_assets: i128 = env.storage().instance().get(&DataKey::TotalAssets).unwrap();
+        env.storage().instance().set(&DataKey::TotalAssets, &(total_assets + amount));
+    }
+
+    pub fn exchange_rate(env: Env) -> i128 {
+        let total_assets: i128 = env.storage().instance().get(&DataKey::TotalAssets).unwrap_or(0);
+        let total_shares: i128 = env.storage().instance().get(&DataKey::TotalShares).unwrap_or(0);
+        if total_shares == 0 {
+            return 1_0000000; // 1.0 in 7-decimal fixed point
+        }
+        total_assets * 1_0000000 / total_shares
+    }
+
+    pub fn shares_of(env: Env, depositor: Address) -> i128 {
+        read_shares(&env, &depositor)
+    }
+}
+```
+
+---
+
+## Optional: Oracle-Priced Deposits
+
+If the vault should accept **multiple** collateral assets (not just its single underlying asset), each deposit must be converted to a common unit using a price oracle before minting shares. This adds one call per deposit and one extra trust assumption (the oracle's correctness and liveness).
+
+```rust
+// contracts/vault/src/oracle.rs
+use soroban_sdk::{contractclient, Address, Env};
+
+#[contractclient(name = "PriceOracleClient")]
+pub trait PriceOracle {
+    /// Returns the price of `asset` in the vault's unit of account,
+    /// scaled by 10^7 (matches Stellar's standard asset precision).
+    fn price(env: Env, asset: Address) -> i128;
+}
+
+pub fn value_in_vault_units(env: &Env, oracle: &Address, asset: &Address, amount: i128) -> i128 {
+    let client = PriceOracleClient::new(env, oracle);
+    let price = client.price(asset);
+    amount
+        .checked_mul(price)
+        .and_then(|v| v.checked_div(1_0000000))
+        .expect("oracle valuation overflow")
+}
+```
+
+Use it inside `deposit` by valuing `amount` in vault units _before_ computing `shares`:
+
+```rust
+let oracle: Address = env.storage().instance().get(&DataKey::Oracle).unwrap();
+let value = crate::oracle::value_in_vault_units(&env, &oracle, &deposited_asset, amount);
+// use `value` instead of `amount` in the shares formula
+```
+
+<Note type="warning">
+  Treat the oracle as a critical trust boundary. Prefer a well-audited oracle
+  (e.g. Reflector on Stellar) over a self-hosted price feed, and consider a
+  circuit breaker that pauses deposits if the reported price moves more than a
+  configured threshold between two consecutive reads.
+</Note>
+
+---
+
+## Test Suite
+
+```rust
+// contracts/vault/src/test.rs
+#![cfg(test)]
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Env;
+
+fn setup_token(env: &Env) -> (Address, Address) {
+    // Uses the built-in Stellar Asset Contract test helper as a stand-in
+    // for the SEP-41 token contract from the token guide.
+    let admin = Address::generate(env);
+    let contract_id = env.register_stellar_asset_contract_v2(admin.clone());
+    (contract_id.address(), admin)
+}
+
+#[test]
+fn test_first_deposit_mints_1to1_shares() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (asset, asset_admin) = setup_token(&env);
+    let asset_client = token::StellarAssetClient::new(&env, &asset);
+
+    let vault_id = env.register(VaultContract, ());
+    let vault = VaultContractClient::new(&env, &vault_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+
+    vault.initialize(&admin, &asset);
+    asset_client.mint(&alice, &1_000);
+
+    let shares = vault.deposit(&alice, &500);
+    assert_eq!(shares, 500);
+    assert_eq!(vault.shares_of(&alice), 500);
+    assert_eq!(vault.exchange_rate(), 1_0000000);
+}
+
+#[test]
+fn test_yield_raises_exchange_rate_for_existing_depositors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (asset, _admin) = setup_token(&env);
+    let asset_client = token::StellarAssetClient::new(&env, &asset);
+
+    let vault_id = env.register(VaultContract, ());
+    let vault = VaultContractClient::new(&env, &vault_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+
+    vault.initialize(&admin, &asset);
+    asset_client.mint(&alice, &1_000);
+    asset_client.mint(&admin, &100);
+
+    vault.deposit(&alice, &1_000); // 1000 shares at rate 1.0
+    vault.add_yield(&admin, &100); // total_assets = 1100, total_shares = 1000
+
+    let withdrawn = vault.withdraw(&alice, &1_000);
+    assert_eq!(withdrawn, 1_100); // Alice earned 100 in yield
+}
+
+#[test]
+#[should_panic(expected = "insufficient shares")]
+fn test_withdraw_more_than_owned_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (asset, _admin) = setup_token(&env);
+
+    let vault_id = env.register(VaultContract, ());
+    let vault = VaultContractClient::new(&env, &vault_id);
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+
+    vault.initialize(&admin, &asset);
+    vault.withdraw(&alice, &1);
+}
+```
+
+---
+
+## Client Integration
+
+```ts
+// lib/vault.ts
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  BASE_FEE,
+  rpc,
+  nativeToScVal,
+  Address,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL!;
+const VAULT_ID = process.env.NEXT_PUBLIC_VAULT_CONTRACT!;
+
+export async function deposit(
+  depositorKeypair: { publicKey(): string; sign(tx: any): void },
+  amount: bigint
+): Promise<bigint> {
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(depositorKeypair.publicKey());
+  const contract = new Contract(VAULT_ID);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(
+      contract.call(
+        'deposit',
+        new Address(depositorKeypair.publicKey()).toScVal(),
+        nativeToScVal(amount, { type: 'i128' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  depositorKeypair.sign(prepared);
+  const result = await server.sendTransaction(prepared);
+  return BigInt(scValToNative((result as any).returnValue).toString());
+}
+
+export async function getExchangeRate(): Promise<number> {
+  const server = new rpc.Server(RPC_URL);
+  const contract = new Contract(VAULT_ID);
+  const account = new (await import('@stellar/stellar-sdk')).Account(
+    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    '0'
+  );
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.MAINNET,
+  })
+    .addOperation(contract.call('exchange_rate'))
+    .setTimeout(5)
+    .build();
+
+  const sim = (await server.simulateTransaction(
+    tx
+  )) as rpc.SimulateTransactionSuccessResponse;
+  return Number(scValToNative(sim.result!.retval)) / 1e7;
+}
+```
+
+---
+
+## Recovery & Edge Cases
+
+- **Dust deposits**: if `amount * total_shares / total_assets` rounds down to `0`, the deposit is rejected (`assets!(shares > 0, ...)`) rather than silently minting nothing for a paid transfer.
+- **Storage TTL expiry**: per-depositor share entries use `extend_ttl` on every write. For long-dormant positions, run an off-chain keeper that periodically bumps TTLs, or require an explicit `ping()` call before large time gaps.
+- **First-depositor inflation attack**: a classic ERC-4626 pitfall is an attacker depositing `1` unit, then donating assets directly to the vault to inflate the exchange rate and round later depositors down to `0` shares. Mitigate by requiring a minimum first deposit and/or seeding the vault with a small admin-owned "dead" deposit at initialization.
+
+---
+
+## Related docs
+
+- [Comprehensive Soroban Token Contract Implementation Guide](/docs/guides/soroban-token-contract-guide) — the SEP-41 token this vault wraps
+- [Comprehensive Soroban Smart Contract Authoring Guide](/docs/guides/soroban-contract-authoring) — project layout, build, and deploy fundamentals
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — storage, auth, and cross-contract call primitives


### PR DESCRIPTION
## Summary

This batch adds four in-depth documentation drafts covering common Soroban contract patterns and the SEP-6 deposit/withdraw protocol. All four are placed in `routes-d/` as working drafts, named after their issue number, per the contribution constraints on each issue (scoped to documentation only, pending maintainer review before being promoted into `docs/`).

closes #917
closes #916
closes #915
closes #911

## Changes

- **#915 — Comprehensive Soroban Token Contract Implementation Guide** (`routes-d/915-soroban-token-contract-guide.mdx`): Implements a SEP-41-compatible Soroban token contract covering `balance`, `transfer`, `transfer_from`, and `approve`/`allowance`, plus admin-only `mint`. Includes persistent-storage layout with TTL extension, a full Rust test suite (mint/transfer, approve/transfer_from, insufficient-balance failure), a TypeScript client using `@stellar/stellar-sdk`, and a compatibility table mapping each function to the SEP-41 spec so other contracts (e.g. the vault and staking guides below) can call it through the generic `token::Client`.
- **#917 — Comprehensive Soroban Vault Contract Guide** (`routes-d/917-soroban-vault-contract-guide.mdx`): Builds a share-accounting vault contract (deposit/withdraw/add_yield) on top of the token contract from #915, using the standard `shares = amount * total_shares / total_assets` exchange-rate model. Covers optional oracle-priced deposits for multi-asset vaults (with a `PriceOracleClient` trait via `#[contractclient]`), a full test suite (first-deposit 1:1 minting, yield accrual raising the exchange rate, insufficient-shares failure), a TypeScript client, and an edge-case section on dust deposits, storage TTL expiry, and the classic ERC-4626-style first-depositor inflation attack.
- **#916 — Complete Soroban Staking Contract Tutorial** (`routes-d/916-soroban-staking-contract-tutorial.mdx`): Implements stake/unstake/claim_rewards using the reward-per-token accumulator pattern (O(1) per interaction, no iteration over stakers). Documents the accrual math explicitly, includes a test suite verifying proportional reward splitting between multiple stakers and time-based accrual, a TypeScript client invocation module, a CLI walkthrough with `stellar contract invoke`, and a comparison table of alternative reward-accrual designs (accumulator vs. per-epoch snapshot vs. Merkle-distributed).
- **#911 — Comprehensive SEP-6 Deposit and Withdraw Tutorial** (`routes-d/911-sep6-deposit-withdraw-tutorial.mdx`): Protocol-level walkthrough of the non-interactive SEP-6 flow — `stellar.toml` discovery, `/info`, SEP-10 authentication, SEP-12 KYC submission (including the `NEEDS_INFO`/`PROCESSING`/`ACCEPTED`/`REJECTED` status handling and explicit guidance not to persist raw KYC fields locally), `/deposit` and `/withdraw` request/response shapes with full parameter tables, a memo-matching warning for withdrawals, a transaction status-polling table and helper function, and a complete `Sep6Client` TypeScript wrapper class.

## Test plan

- `pnpm build:content` — passes with exit code 0, identical output (same 2 pre-existing warnings, "Generated 156 documents") as a clean checkout of `upstream/main`. `routes-d/` is outside `contentlayer.config.ts`'s `contentDirPath: 'docs'`, so these additions are inherently out of scope for that build.
- `pnpm check:links` — fails identically on this branch and on a clean `upstream/main` checkout (no dev server running; it only checks `docs/components/*` sidebar links via HTTP, unrelated to `routes-d/`). Pre-existing, not introduced by this PR.
- `node scripts/validate-sidebar.cjs` — passes, 100% valid, unaffected by these changes.
- `pnpm test:unit` — no test files exist in the repo for either branch (pre-existing; not applicable to documentation-only changes).
- Each Rust code sample includes its own `#[test]` functions demonstrating the described behavior (not run in CI, since these are documentation drafts rather than a buildable crate in this repo).

---

Per each issue's constraints, all four files are scoped to documentation only and placed in `routes-d/` rather than wired into `docs/`'s sidebar/navigation — that step is intentionally left for maintainer review, consistent with prior batches in this repo (e.g. #772, #773).