### PR TITLE
docs: mock Horizon guide, T&C template, privacy policy, and bug bounty tutorial

### DIFF
--- a/docs/guides/bug-bounty.mdx
+++ b/docs/guides/bug-bounty.mdx
@@ -1,0 +1,186 @@
+---
+title: Bug Bounty Program Tutorial
+description: 'Launch a responsible disclosure program for your Stellar dApp — covering scope, payouts, reporting, and a starter template.'
+date: 2026-08-26
+---
+
+# Bug Bounty Program Tutorial
+
+Smart contracts deployed on Stellar are immutable. A bug discovered after deployment cannot be patched with a server-side hotfix — it may require a contract migration or, in the worst case, result in permanent fund loss. A bug bounty program incentivises the security community to find and report vulnerabilities before malicious actors can exploit them.
+
+This tutorial covers how to define scope, set payout tiers, establish reporting channels, and provides a program-rules template you can adapt for your dApp.
+
+## Why Run a Bug Bounty?
+
+- **Prevention over remediation** — on a public blockchain, you cannot silently patch a vulnerability. Early disclosure gives you time to migrate or warn users.
+- **Community trust** — a transparent bounty program signals that you take security seriously, which matters to users and institutional partners.
+- **Cost efficiency** — paying a bounty for a critical find is almost always cheaper than the cost of a hack.
+
+## Step 1 — Define Your Scope
+
+A clearly scoped program attracts focused, high-quality reports and prevents researchers from wasting time on assets you do not control.
+
+### In-Scope Assets
+
+| Asset | Notes |
+| --- | --- |
+| Stellar smart contracts (Soroban) | All contract addresses listed at `[your-site]/security` |
+| Backend API | `api.[your-domain].com` — authenticated endpoints only |
+| Web frontend | `[your-domain].com` — XSS, CSRF, auth bypass |
+| Stellar transaction construction | Logic errors in XDR building |
+
+### Out-of-Scope
+
+- Third-party services (Stellar network, Horizon, Freighter wallet)
+- Social engineering attacks against your team
+- Denial-of-service attacks that require large XLM balances
+- Known issues listed in your public audit reports
+- Issues that require physical access to a user's device
+- Findings in dependencies outside your control (report these upstream)
+
+### Clarifying the Boundary
+
+Add a note explaining that any finding affecting the **Stellar network itself** should be reported to the Stellar Development Foundation, not to your program.
+
+## Step 2 — Set Payout Tiers
+
+Map payouts to CVSS v3 severity scores so researchers know what to expect before they submit.
+
+| Severity | CVSS Score | Example Vulnerabilities | Payout Range |
+| --- | --- | --- | --- |
+| Critical | 9.0 – 10.0 | Direct fund drain, privilege escalation, total contract compromise | 5 000 – 50 000 XLM |
+| High | 7.0 – 8.9 | Partial fund drain, bypass of key access controls | 1 000 – 5 000 XLM |
+| Medium | 4.0 – 6.9 | Logic errors that cause incorrect state, denial-of-service against a single user | 100 – 1 000 XLM |
+| Low | 0.1 – 3.9 | Minor information disclosure, non-exploitable misconfigurations | 10 – 100 XLM |
+| Informational | N/A | Best-practice recommendations, no direct security impact | None (acknowledgement only) |
+
+### Payout Considerations
+
+- Pay in XLM or stablecoins (USDC on Stellar) so payouts are on-chain and verifiable.
+- Reserve the right to adjust payout within the tier based on exploitability and impact.
+- State whether payouts are subject to KYC or tax reporting requirements in your jurisdiction.
+
+## Step 3 — Establish Reporting Channels
+
+Researchers need a clear, confidential channel to submit reports.
+
+### Recommended Channels
+
+**GitHub Security Advisories (preferred)**
+
+Enable private vulnerability reporting in your repository settings. Researchers can submit a report without publicly disclosing the vulnerability. You can communicate privately until a fix or mitigation is in place.
+
+**Dedicated security email**
+
+Set up `security@[your-domain].com` and configure GPG encryption so researchers can send sensitive details securely. Publish your GPG public key at `[your-domain]/.well-known/security.txt`.
+
+**security.txt**
+
+Add a `public/security.txt` (or `.well-known/security.txt`) to your site:
+
+```txt
+Contact: mailto:security@[your-domain].com
+Encryption: https://[your-domain]/pgp-key.txt
+Acknowledgments: https://[your-domain]/security/hall-of-fame
+Scope: https://[your-domain]/security/scope
+Preferred-Languages: en
+```
+
+### Response SLAs
+
+Set expectations for how quickly you will respond:
+
+| Milestone | Target |
+| --- | --- |
+| Initial acknowledgement | 2 business days |
+| Triage and severity assessment | 7 business days |
+| Status update to researcher | Every 14 days |
+| Payout after fix / mitigation | 30 days |
+
+## Step 4 — Publish and Maintain the Program
+
+1. **Publish a `/security` page** on your site with your program rules, scope, and contact information.
+2. **Keep audit reports public** and link them from your security page. Researchers need to know what has already been audited.
+3. **Maintain a hall of fame** — acknowledge researchers who report valid findings (with their consent).
+4. **Review scope periodically** — update in-scope assets as you deploy new contracts or add features.
+
+## Program Rules Template
+
+```markdown
+# [DAPP NAME] Bug Bounty Program
+
+**Effective date:** [DATE]
+**Contact:** security@[your-domain].com
+**Response target:** 2 business days for acknowledgement
+
+---
+
+## Scope
+
+### In Scope
+
+- Soroban smart contracts deployed at addresses listed on our security page
+- Backend API at api.[your-domain].com
+- Web frontend at [your-domain].com
+
+### Out of Scope
+
+- The Stellar network and Horizon API (report to the SDF)
+- Social engineering
+- Denial-of-service requiring significant resources
+- Findings in unmodified third-party libraries
+
+---
+
+## Payout Tiers
+
+| Severity | Payout |
+| --- | --- |
+| Critical (CVSS 9–10) | [AMOUNT] XLM |
+| High (CVSS 7–8.9) | [AMOUNT] XLM |
+| Medium (CVSS 4–6.9) | [AMOUNT] XLM |
+| Low (CVSS 0.1–3.9) | [AMOUNT] XLM |
+
+Payouts are made in XLM to the Stellar address you provide. Amounts within
+each tier are determined at our discretion based on exploitability and impact.
+
+---
+
+## Reporting
+
+Submit reports via GitHub Security Advisories or by email to
+security@[your-domain].com. Encrypt sensitive reports with our PGP key
+published at [your-domain]/pgp-key.txt.
+
+Please include:
+1. A description of the vulnerability and affected component
+2. Step-by-step reproduction instructions or a proof-of-concept
+3. CVSS score and vector string (if known)
+4. Your Stellar public key for payout
+
+---
+
+## Rules of Engagement
+
+- Do not access, modify, or delete data belonging to other users.
+- Do not perform denial-of-service attacks.
+- Do not publicly disclose a finding before we have confirmed a fix or
+  mitigation (90-day disclosure deadline applies).
+- Test only against Testnet accounts you control; never use Mainnet.
+
+---
+
+## Safe Harbour
+
+We will not pursue legal action against researchers who:
+- Act in good faith and follow these program rules.
+- Report findings promptly and confidentially.
+- Do not exploit a vulnerability beyond what is necessary to demonstrate it.
+
+---
+
+## Hall of Fame
+
+We publicly thank researchers who report valid findings (with their consent)
+at [your-domain]/security/hall-of-fame.
+```

--- a/docs/guides/mock-horizon.mdx
+++ b/docs/guides/mock-horizon.mdx
@@ -1,0 +1,215 @@
+---
+title: Mock Horizon Reference Guide
+description: 'Use a local mock Horizon server for deterministic, offline Stellar dApp development and testing.'
+date: 2026-08-26
+---
+
+# Mock Horizon Reference Guide
+
+Running your dApp against the live Stellar Testnet works for manual checks, but CI pipelines need reproducible, offline responses. A mock Horizon server replaces the real HTTP API with a local process that returns pre-seeded fixture data so your tests never depend on network availability or shared testnet state.
+
+## Why Use a Mock Server?
+
+| Concern | Live Testnet | Mock Horizon |
+| --- | --- | --- |
+| Network required | Yes | No |
+| Deterministic responses | No | Yes |
+| Test isolation | Shared global state | Per-run fixture |
+| Speed | 200–2 000 ms | < 5 ms |
+| Friendbot rate limits | Yes | No |
+
+## Endpoint Fidelity
+
+A typical mock Horizon implementation covers the endpoints that Nextellar and the Stellar SDK call most often. The table below lists common endpoints and their mock support level.
+
+### Fully Supported
+
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/accounts/{account_id}` | GET | Returns seeded account, balances, sequence number |
+| `/transactions` | POST | Accepts signed XDR; records it in in-memory ledger |
+| `/transactions/{hash}` | GET | Returns transaction by hash |
+| `/accounts/{id}/transactions` | GET | Returns transactions for account |
+| `/accounts/{id}/payments` | GET | Filters transaction list to payment operations |
+| `/fee_stats` | GET | Returns configurable fee stats |
+| `/ledgers/latest` | GET | Returns current mock ledger sequence |
+
+### Partially Supported
+
+| Endpoint | Limitation |
+| --- | --- |
+| `/order_book` | Static snapshot only — no live matching |
+| `/paths` | Returns a single static path; no real pathfinding |
+| `/offers` | Read-only; offer creation not reflected in order book |
+
+### Not Supported
+
+- `/claimable_balances` — return 404 in most mocks
+- Real-time SSE streams (`/accounts/{id}/transactions?stream=true`)
+- Multi-horizon federation queries
+
+If your dApp uses unsupported endpoints, add a `jest.fn()` override or intercept the request with `msw` (see [Working Sample](#working-sample) below).
+
+## Fixture Management
+
+Fixtures define the initial on-chain state your tests assume. Good fixture management means each test suite starts from a known baseline and cleans up after itself.
+
+### Seeding Accounts
+
+Create a fixture file that declares the accounts and balances the mock server should return:
+
+```json
+// fixtures/accounts.json
+[
+  {
+    "account_id": "GABC...XYZ",
+    "sequence": "1000",
+    "balances": [
+      { "asset_type": "native", "balance": "10000.0000000" }
+    ],
+    "thresholds": { "low_threshold": 0, "med_threshold": 0, "high_threshold": 0 },
+    "flags": { "auth_required": false, "auth_revocable": false }
+  }
+]
+```
+
+Load this file when the mock server starts:
+
+```ts
+import { createMockHorizon } from '@stellar-mock/horizon';
+import accounts from './fixtures/accounts.json';
+
+const mock = createMockHorizon({ port: 8000 });
+mock.seed({ accounts });
+await mock.start();
+```
+
+### Seeding Transactions
+
+```ts
+mock.seed({
+  accounts,
+  transactions: [
+    {
+      hash: 'abc123...',
+      source_account: 'GABC...XYZ',
+      created_at: '2026-01-01T00:00:00Z',
+      envelope_xdr: '<base64-xdr>',
+    },
+  ],
+});
+```
+
+### Resetting State Between Tests
+
+Call `mock.reset()` in your test framework's `afterEach` / `afterAll` hook to restore the server to its seeded state:
+
+```ts
+afterEach(() => mock.reset());
+afterAll(() => mock.stop());
+```
+
+This prevents one test's submitted transactions from polluting the next test's expectations.
+
+## Working Sample
+
+The following example uses `msw` (Mock Service Worker / Node) to intercept Horizon calls in a Jest/Vitest environment. No separate server process is needed.
+
+### Install dependencies
+
+```bash
+pnpm add -D msw @stellar/stellar-sdk
+```
+
+### Set up the handler
+
+```ts
+// tests/mocks/horizon.ts
+import { http, HttpResponse } from 'msw';
+
+export const horizonHandlers = [
+  http.get('https://horizon-testnet.stellar.org/accounts/:id', ({ params }) => {
+    return HttpResponse.json({
+      account_id: params.id,
+      sequence: '1000',
+      balances: [{ asset_type: 'native', balance: '10000.0000000' }],
+    });
+  }),
+
+  http.get('https://horizon-testnet.stellar.org/fee_stats', () => {
+    return HttpResponse.json({
+      last_ledger_base_fee: '100',
+      fee_charged: { p50: '100', p99: '1000' },
+    });
+  }),
+];
+```
+
+### Configure the test server
+
+```ts
+// tests/setup.ts
+import { setupServer } from 'msw/node';
+import { horizonHandlers } from './mocks/horizon';
+
+export const server = setupServer(...horizonHandlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+### Write a test
+
+```ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+const horizonServer = new Horizon.Server(
+  'https://horizon-testnet.stellar.org'
+);
+
+test('fetches account balance', async () => {
+  const account = await horizonServer.loadAccount(
+    'GABC...XYZ'
+  );
+  expect(account.balances[0].balance).toBe('10000.0000000');
+});
+```
+
+### Override a handler for a single test
+
+```ts
+import { http, HttpResponse } from 'msw';
+
+test('handles account not found', async () => {
+  server.use(
+    http.get('https://horizon-testnet.stellar.org/accounts/:id', () => {
+      return HttpResponse.json({ type: 'not_found' }, { status: 404 });
+    })
+  );
+
+  await expect(
+    horizonServer.loadAccount('GNOT...FOUND')
+  ).rejects.toThrow();
+});
+```
+
+## Configuring the SDK to Use a Local Server
+
+If you prefer a real local mock process (e.g. `stellar-mock-horizon` npm package), point the SDK at it:
+
+```ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+const horizonServer = new Horizon.Server('http://localhost:8000', {
+  allowHttp: true, // required for non-HTTPS local server
+});
+```
+
+Set `HORIZON_URL=http://localhost:8000` in your `.env.test` so Nextellar hooks pick it up automatically.
+
+## Known Limitations
+
+- **Sequence number management** — mock servers auto-increment the sequence number on each POST but do not validate XDR signatures by default. Add signature validation only if your tests exercise auth logic.
+- **Streaming endpoints** — SSE is not supported by `msw`. Use polling or skip stream-specific tests in CI.
+- **Claimable balances and DEX** — stub these endpoints manually if your dApp uses them.

--- a/docs/guides/privacy-policy.mdx
+++ b/docs/guides/privacy-policy.mdx
@@ -1,0 +1,195 @@
+---
+title: Privacy Policy Template Tutorial
+description: 'Understand the data flows unique to Stellar dApps and use the starter template to write your privacy policy.'
+date: 2026-08-26
+---
+
+# Privacy Policy Template Tutorial
+
+A Stellar dApp has data flows that differ from traditional web applications. This tutorial walks through what data your dApp collects, why it matters for a privacy policy, and provides a starter template you can adapt for your jurisdiction.
+
+> **Legal disclaimer:** This tutorial and template are provided for informational purposes only and do not constitute legal advice. Have a qualified attorney review your final privacy policy before publishing.
+
+## Stellar-Specific Data Flows
+
+Understanding what data flows through your dApp is the first step to writing an accurate privacy policy.
+
+### The public ledger
+
+Every transaction, account, and asset on the Stellar network is publicly visible. This means:
+
+- A user's **public key** and their entire **transaction history** are readable by anyone, forever.
+- You do not need to store transaction data in your own database — it already exists on-chain. But your policy should acknowledge that the ledger is permanently public.
+
+### Wallet connection — public key only
+
+When a user connects a Stellar wallet (e.g. Freighter, Albedo, xBull), the wallet shares only the user's **public key** with your dApp. The private key never leaves the wallet extension. Your policy should clarify this.
+
+### Horizon API calls
+
+Every call your frontend makes to a Horizon server (whether Stellar's public servers or your own) may log the caller's IP address. If you proxy Horizon calls through your own server, you may receive and store IP addresses. If you use Stellar's public endpoints directly from the browser, Stellar's own privacy policy applies to those requests.
+
+### Soroban RPC calls
+
+Calls to Soroban RPC (for smart contract simulation and submission) follow the same pattern as Horizon. Note whether you run your own RPC node or rely on a public endpoint.
+
+### Analytics and error tracking
+
+If you use analytics tools (Mixpanel, Plausible, Sentry, etc.), list them explicitly and describe what is collected. Public keys are pseudonymous but may still constitute personal data under GDPR if they can be linked to a natural person.
+
+## Common Privacy Policy Sections
+
+### 1. Data controller
+
+Identify the entity responsible for data processing. This is your company or team.
+
+### 2. What data we collect
+
+Break this into categories:
+
+| Category | Examples |
+| --- | --- |
+| On-chain data | Public key, transaction history (public ledger — we do not store this separately) |
+| Technical data | IP address (from server logs), browser type, device type |
+| Usage data | Pages visited, features used (only if analytics are enabled) |
+| Contact data | Email address (only if you have a contact form or mailing list) |
+
+### 3. Why we collect it (legal basis)
+
+For each category, state the purpose and legal basis. Under GDPR the common bases are:
+
+- **Contract performance** — necessary to provide the Service
+- **Legitimate interests** — security logging, fraud prevention
+- **Consent** — optional analytics or marketing
+
+### 4. On-chain vs. off-chain data
+
+Make clear that data written to the Stellar blockchain is **permanently public and outside your control**. You cannot delete it on behalf of a user even if they invoke a right to erasure.
+
+### 5. Third-party services
+
+List every external service that may receive user data:
+
+| Service | Data shared | Purpose |
+| --- | --- | --- |
+| Stellar public Horizon | IP address (browser requests) | Account and transaction queries |
+| Soroban RPC endpoint | IP address | Smart contract calls |
+| [Analytics provider] | Anonymous page views | Usage analytics |
+| [Error tracking] | Stack traces, browser info | Error monitoring |
+
+### 6. User rights
+
+Describe the rights available to users. Under GDPR these include:
+
+- Right to access
+- Right to rectification
+- Right to erasure (with the caveat that on-chain data cannot be erased)
+- Right to restriction of processing
+- Right to data portability
+- Right to object
+
+### 7. Cookies and local storage
+
+List any cookies or local-storage keys your dApp sets, their purpose, and their expiry.
+
+### 8. Data retention
+
+State how long you keep server logs and any other off-chain data.
+
+### 9. Children's data
+
+State that the Service is not directed to children under 13 (or 16 in the EU) and that you do not knowingly collect their data.
+
+### 10. Changes to this policy
+
+Explain how you will notify users of material changes.
+
+## Starter Template
+
+Replace every `[PLACEHOLDER]` with your details and have a lawyer review before publishing.
+
+```markdown
+# Privacy Policy
+
+**Last updated:** [DATE]
+
+## 1. Who We Are
+
+[DAPP NAME] ("we", "us", "our") operates the decentralised application at
+[URL] ("Service"). Questions about this policy can be directed to
+[CONTACT EMAIL].
+
+## 2. What Data We Collect
+
+**On-chain data:** When you use the Service, transactions are recorded on the
+Stellar public ledger. This includes your public key and transaction history.
+This data is permanently public and not under our control.
+
+**Technical data:** Our servers may log your IP address, browser type, and
+referring URL when you access the Service. Logs are retained for [NUMBER] days.
+
+**Wallet data:** When you connect a Stellar wallet, we receive only your public
+key. We never receive or store your private key.
+
+**Analytics data (if applicable):** We use [ANALYTICS TOOL] to collect
+anonymous usage statistics, including pages visited and features used. No
+personally identifiable information is shared with [ANALYTICS TOOL].
+
+## 3. How We Use Your Data
+
+| Data | Purpose | Legal basis |
+| --- | --- | --- |
+| Public key | Identify your account and display balances | Contract performance |
+| IP address (server logs) | Security and abuse prevention | Legitimate interests |
+| Analytics | Improve the Service | Consent |
+
+## 4. Third-Party Services
+
+| Service | Data received | Privacy policy |
+| --- | --- | --- |
+| Stellar Horizon (public) | IP address (browser requests) | stellar.org/privacy |
+| [Soroban RPC provider] | IP address | [LINK] |
+| [Analytics] | Anonymous usage | [LINK] |
+
+## 5. On-Chain Data and the Right to Erasure
+
+Data written to the Stellar blockchain is permanent and publicly visible. We
+are unable to delete on-chain data on your behalf. If you request erasure of
+off-chain data we hold (e.g. server logs), we will fulfil that request within
+30 days.
+
+## 6. Your Rights
+
+Depending on your jurisdiction, you may have the right to:
+- Access the personal data we hold about you.
+- Correct inaccurate data.
+- Request deletion of off-chain data we hold.
+- Object to certain processing activities.
+- Lodge a complaint with your local data protection authority.
+
+To exercise these rights, contact us at [CONTACT EMAIL].
+
+## 7. Cookies and Local Storage
+
+| Name | Purpose | Expiry |
+| --- | --- | --- |
+| `theme` | Stores your light/dark mode preference | 1 year |
+| `wallet_address` | Remembers your connected wallet | Session |
+
+## 8. Data Retention
+
+Server access logs are retained for [NUMBER] days. No other personal data is
+retained beyond what is described in this policy.
+
+## 9. Children
+
+The Service is not directed to anyone under the age of 13. We do not knowingly
+collect personal data from children. If you believe a child has provided us
+with personal data, contact us so we can delete it.
+
+## 10. Changes to This Policy
+
+We may update this policy from time to time. Material changes will be
+communicated via [EMAIL / IN-APP NOTICE] at least [NUMBER] days before taking
+effect. The "Last updated" date at the top reflects the most recent revision.
+```

--- a/docs/guides/terms-and-conditions.mdx
+++ b/docs/guides/terms-and-conditions.mdx
@@ -1,0 +1,180 @@
+---
+title: Terms and Conditions Template Guide
+description: 'A starter guide and template for writing terms and conditions for your Stellar dApp.'
+date: 2026-08-26
+---
+
+# Terms and Conditions Template Guide
+
+Every Stellar dApp that interacts with real users needs terms and conditions (T&C). Because dApps interact with an immutable public ledger, standard SaaS boilerplate is not sufficient — you need additional clauses that address smart contract behaviour, wallet-based identity, and the absence of a traditional account recovery path.
+
+This guide explains the common sections, when to adapt them, and provides a starter template.
+
+> **Legal disclaimer:** This guide and template are provided for informational purposes only and do not constitute legal advice. Have a qualified attorney review your final terms before publishing.
+
+## Why dApps Need Custom Terms
+
+### Smart contract immutability
+
+Transactions submitted to the Stellar network are final. Your T&C must make clear that:
+
+- Once a transaction is signed and submitted by the user's wallet, it cannot be reversed by your team.
+- Upgrades to smart contracts are possible but may require user action (re-initialisation, migration).
+
+### Wallet-based identity
+
+Users are identified by their Stellar public key, not by a username or email address. This means:
+
+- You cannot reset a user's access if they lose their private key.
+- You cannot freeze or seize funds held in a user's self-custodied wallet.
+
+### Regulatory considerations
+
+If your dApp issues or distributes tokens, additional obligations may apply depending on jurisdiction (securities law, money transmission, GDPR, etc.). Consult a lawyer for anything involving:
+
+- Token sales or initial offerings
+- Staking rewards or yield
+- User funds held in a custodial contract
+
+## Common T&C Sections
+
+### 1. Acceptance of Terms
+
+State how users indicate acceptance (e.g. by connecting a wallet or using the service) and the effective date.
+
+### 2. Description of Service
+
+Describe what the dApp does in plain language. Reference the underlying Stellar network and clarify that your team operates the frontend and (where applicable) the smart contract, but not the Stellar network itself.
+
+### 3. Eligibility
+
+Specify:
+
+- Minimum age (typically 18+)
+- Jurisdictions where the service is not available
+- KYC/AML requirements if applicable
+
+### 4. Token and Asset Disclaimers
+
+Clearly state:
+
+- Whether tokens are utility tokens or might be considered securities.
+- That token values may be zero or highly volatile.
+- That past performance is not indicative of future results.
+
+### 5. User Responsibilities
+
+List what users must not do, including:
+
+- Using the service for illegal purposes
+- Attempting to exploit smart contract vulnerabilities
+- Providing false identity information
+
+### 6. Limitation of Liability
+
+Cap your liability to the amount the user paid for the service (often zero for free dApps) and disclaim liability for losses arising from:
+
+- User error (sending to the wrong address)
+- Smart contract bugs not caused by gross negligence
+- Downtime of the Stellar network or Horizon
+
+### 7. Dispute Resolution and Governing Law
+
+Specify the governing jurisdiction and dispute resolution mechanism (arbitration, mediation, or courts).
+
+### 8. Changes to Terms
+
+Explain how you will notify users of material changes (e.g. email, in-app notice, on-chain event) and the grace period before changes take effect.
+
+## When to Adapt the Template
+
+| Situation | Adaptation needed |
+| --- | --- |
+| Token sale or fundraise | Add securities law disclosures; consult a securities attorney |
+| Custodial contract (you hold user funds) | Add money-transmission disclosures; may require a licence |
+| EU users | Add GDPR-compliant data processing terms |
+| US users | Add CCPA notices; consider state-specific requirements |
+| DAO governance | Add voting rights disclaimer and governance risk section |
+| Minors may access | Strengthen age-gating and parental consent section |
+
+## Starter Template
+
+Copy the template below, replace every `[PLACEHOLDER]` with your details, and have it reviewed by a lawyer before publishing.
+
+```markdown
+# Terms and Conditions
+
+**Last updated:** [DATE]
+
+## 1. Acceptance of Terms
+
+By connecting your Stellar wallet to [DAPP NAME] ("Service") or by otherwise
+accessing or using the Service, you agree to be bound by these Terms and
+Conditions ("Terms"). If you do not agree, do not use the Service.
+
+## 2. Description of Service
+
+[DAPP NAME] is a decentralised application built on the Stellar network that
+enables [SHORT DESCRIPTION, e.g. "royalty splitting for digital assets"]. The
+Service is provided by [YOUR COMPANY / TEAM NAME] ("we", "us", "our").
+
+We operate the web interface and, where stated, the smart contracts deployed on
+Stellar. We do not operate the Stellar network itself; network behaviour is
+governed by the Stellar Development Foundation and the open-source protocol.
+
+## 3. Eligibility
+
+You must be at least 18 years old and not a resident of a jurisdiction where
+use of the Service is prohibited by law to use the Service.
+
+## 4. Wallet and Private Keys
+
+You are solely responsible for the security of your Stellar wallet and private
+key. We never have custody of your private key. If you lose access to your
+wallet, we cannot recover your funds or restore your access.
+
+## 5. Token Disclaimers
+
+[Any tokens accessible through the Service] are [utility tokens / not
+securities — adapt as appropriate]. Token values may fluctuate significantly or
+reach zero. Nothing in the Service constitutes investment advice.
+
+## 6. Prohibited Uses
+
+You agree not to use the Service to:
+- Violate any applicable law or regulation.
+- Launder money or finance terrorism.
+- Attempt to exploit or reverse-engineer smart contracts.
+- Impersonate another person or entity.
+
+## 7. Finality of Transactions
+
+All transactions submitted through the Service are broadcast to the Stellar
+network and are final once confirmed. We cannot reverse or modify on-chain
+transactions.
+
+## 8. Limitation of Liability
+
+To the maximum extent permitted by law, we are not liable for any indirect,
+incidental, special, or consequential damages arising from your use of the
+Service, including but not limited to loss of funds resulting from user error,
+smart contract vulnerabilities, or Stellar network downtime.
+
+## 9. Governing Law and Dispute Resolution
+
+These Terms are governed by the laws of [JURISDICTION]. Any disputes shall be
+resolved by binding arbitration in [CITY/COUNTRY] under the rules of
+[ARBITRATION BODY], except that either party may seek injunctive relief in a
+court of competent jurisdiction.
+
+## 10. Changes to Terms
+
+We may update these Terms at any time. Material changes will be communicated
+via [EMAIL / IN-APP NOTICE / ON-CHAIN EVENT] at least [NUMBER] days before
+taking effect. Continued use of the Service after the effective date constitutes
+acceptance of the updated Terms.
+
+## 11. Contact
+
+Questions about these Terms? Contact us at [CONTACT EMAIL / LINK].
+```

--- a/routes-d/949-mock-horizon-reference.md
+++ b/routes-d/949-mock-horizon-reference.md
@@ -1,0 +1,41 @@
+# Issue #949 — Add a comprehensive Stellar mock Horizon reference guide
+
+Working draft for the docs change requested in issue #949.
+
+## Planned doc location
+
+- `docs/guides/mock-horizon.mdx`
+
+## Scope
+
+- Explain why a mock Horizon service is useful for local development
+- Cover endpoint fidelity and what is / isn't replicated
+- Explain fixture management (seeding accounts, ledgers, transactions)
+- Provide a working sample integration with `@stellar/stellar-sdk`
+- Match the existing MDX frontmatter and writing style
+
+## Sections
+
+### Why Mock Horizon?
+- Deterministic responses without network latency
+- Offline development
+- Reproducible CI test scenarios
+
+### Endpoint Fidelity
+- Which Horizon REST endpoints are covered
+- Known omissions and workarounds
+
+### Fixture Management
+- Loading test accounts via friendbot equivalent
+- Seeding transactions and ledger state
+- Resetting state between test runs
+
+### Working Sample
+- Pointing the SDK at a local mock server
+- Running a basic account fetch
+
+## Acceptance Criteria
+
+- Content builds with `pnpm build:content` without errors
+- Internal links pass `pnpm check:links`
+- Reviewed and approved by a maintainer before merge

--- a/routes-d/961-terms-and-conditions-guide.md
+++ b/routes-d/961-terms-and-conditions-guide.md
@@ -1,0 +1,42 @@
+# Issue #961 — Add a comprehensive Stellar dApp terms and conditions template guide
+
+Working draft for the docs change requested in issue #961.
+
+## Planned doc location
+
+- `docs/guides/terms-and-conditions.mdx`
+
+## Scope
+
+- Explain why a Stellar dApp needs its own terms and conditions
+- Cover the common sections every dApp T&C should include
+- Note when and how to adapt the template (jurisdiction, token type, etc.)
+- Provide a small starter template teams can copy and customise
+- Match the existing MDX frontmatter and writing style
+
+## Sections
+
+### Why dApps Need Custom Terms
+- Smart contract immutability implications
+- Wallet-based identity vs. account-based identity
+- Regulatory considerations for token issuers
+
+### Common T&C Sections
+- Acceptance of terms
+- Description of service
+- Eligibility and KYC
+- Token / asset disclaimers
+- Dispute resolution and governing law
+
+### When to Adapt the Template
+- Different jurisdictions
+- Securities vs. utility tokens
+- Custodial vs. non-custodial flows
+
+### Starter Template
+
+## Acceptance Criteria
+
+- Content builds with `pnpm build:content` without errors
+- Internal links pass `pnpm check:links`
+- Reviewed and approved by a maintainer before merge

--- a/routes-d/962-privacy-policy-tutorial.md
+++ b/routes-d/962-privacy-policy-tutorial.md
@@ -1,0 +1,43 @@
+# Issue #962 — Build a complete Stellar dApp privacy policy template tutorial
+
+Working draft for the docs change requested in issue #962.
+
+## Planned doc location
+
+- `docs/guides/privacy-policy.mdx`
+
+## Scope
+
+- Explain data flows unique to Stellar dApps (public ledger, wallet keys)
+- Cover common privacy policy sections required in most jurisdictions
+- Note what data is collected by the app vs. visible on-chain
+- Provide a small starter template teams can copy and customise
+- Match the existing MDX frontmatter and writing style
+
+## Sections
+
+### Stellar-Specific Data Flows
+- Public key as pseudonymous identifier
+- On-chain transaction history
+- Third-party services (Horizon, Soroban RPC)
+
+### Common Privacy Policy Sections
+- Data controller identity
+- What data is collected and why
+- On-chain vs. off-chain data distinction
+- User rights (GDPR / CCPA)
+- Cookie and analytics policy
+- Data retention
+
+### What to Describe per Integration
+- Horizon calls — IP address logging
+- Wallet connection — public key only, no private key
+- Analytics — if applicable
+
+### Starter Template
+
+## Acceptance Criteria
+
+- Content builds with `pnpm build:content` without errors
+- Internal links pass `pnpm check:links`
+- Reviewed and approved by a maintainer before merge

--- a/routes-d/964-bug-bounty-tutorial.md
+++ b/routes-d/964-bug-bounty-tutorial.md
@@ -1,0 +1,43 @@
+# Issue #964 — Build a complete Stellar dApp bug bounty program tutorial
+
+Working draft for the docs change requested in issue #964.
+
+## Planned doc location
+
+- `docs/guides/bug-bounty.mdx`
+
+## Scope
+
+- Explain why a bug bounty program matters for a Stellar dApp
+- Cover scope definition (in-scope / out-of-scope assets)
+- Explain payout tiers keyed to CVSS severity
+- Note reporting channels and response SLAs
+- Provide a small program-rules template teams can adapt
+- Match the existing MDX frontmatter and writing style
+
+## Sections
+
+### Why Run a Bug Bounty?
+- Smart contracts are immutable — prevention matters more than patching
+- Community incentives for responsible disclosure
+- Trust signal for users and auditors
+
+### Defining Scope
+- In-scope: smart contracts, backend API, web frontend
+- Out-of-scope: third-party services, social engineering
+
+### Payout Tiers
+- Critical / High / Medium / Low mapped to CVSS score ranges
+- Example XLM payout ranges
+
+### Reporting Channels
+- Security email / GitHub Security Advisory
+- Disclosure timeline expectations
+
+### Program Rules Template
+
+## Acceptance Criteria
+
+- Content builds with `pnpm build:content` without errors
+- Internal links pass `pnpm check:links`
+- Reviewed and approved by a maintainer before merge


### PR DESCRIPTION
Closes #949
Closes #961
Closes #962
Closes #964

## Summary

- **#949** — `docs/guides/mock-horizon.mdx`: Comprehensive mock Horizon reference covering endpoint fidelity table, fixture management (account/transaction seeding, per-test reset), and a working `msw` sample with handler overrides per test.
- **#961** — `docs/guides/terms-and-conditions.mdx`: dApp-specific T&C guide explaining smart contract immutability, wallet-based identity, common sections, a jurisdiction/token-type adaptation table, and a full starter template.
- **#962** — `docs/guides/privacy-policy.mdx`: Privacy policy tutorial covering Stellar-specific data flows (public ledger, wallet connection, Horizon/Soroban RPC), all required policy sections, and a starter template with on-chain erasure caveat.
- **#964** — `docs/guides/bug-bounty.mdx`: Step-by-step bug bounty tutorial covering scope definition, CVSS-mapped payout tiers, reporting channels (GitHub Security Advisories, security.txt), response SLAs, and a complete program-rules template.

All four drafts are also placed in `routes-d/` named after their issue numbers.