### PR TITLE
docs: add comprehensive guides for accessibility, marketing, cachingand visual testing

### DIFF
--- a/routes-d/947-visual-regression-testing-guide.mdx
+++ b/routes-d/947-visual-regression-testing-guide.mdx
@@ -1,0 +1,1019 @@
+---
+title: Visual Regression Testing for Stellar Wallet UIs
+description: A comprehensive guide to implementing visual regression testing for Stellar dApp wallet interfaces — covering tool selection, baseline management, flakiness mitigation, and CI/CD integration with working examples.
+date: 2026-08-25
+---
+
+# Visual Regression Testing for Stellar Wallet UIs
+
+Wallet UIs demand pixel-perfect accuracy. A CSS refactor that shifts a decimal point, a modal that clips the user's balance, or a button that vanishes on mobile — any of these can erode trust or trigger a support flood. Visual regression testing catches layout breakage that unit tests miss. This guide shows you how to build a reliable visual testing pipeline for Stellar dApp wallet interfaces, with working examples using Playwright and strategies that apply to Percy, Chromatic, or any screenshot-based tool.
+
+---
+
+## 1. Why Visual Regression Testing Matters for Wallet UIs
+
+### The Problem Space
+
+Wallet interfaces have unique constraints:
+
+- **High-stakes data display**: Account balances, transaction amounts, asset codes. A formatting bug that swaps "1,000.00 XLM" with "1.00 XLM" is catastrophic.
+- **Responsive layout complexity**: Users check balances on desktop, sign transactions on mobile. Breakpoint logic must work across viewports without clipping critical UI.
+- **Multi-state flows**: Send → Confirm → Sign → Success. Each step shows different data (recipient, amount, fees) in different layouts. Visual tests catch state-specific regressions.
+- **Dynamic content**: Real-time prices, last-updated timestamps, transaction hashes. If not masked, these cause false positives.
+
+### What Visual Tests Catch
+
+- **CSS regressions**: A global style change that breaks the transaction history table.
+- **Responsive breakpoints**: A media query that hides the "Send" button on tablets.
+- **Truncation and overflow**: Long asset names or addresses that break out of containers.
+- **Modal and overlay positioning**: A confirmation dialog that renders off-screen on small viewports.
+- **Icon and logo rendering**: SVG changes that distort wallet provider logos or asset icons.
+
+Unit tests verify *logic*. Visual tests verify *what the user sees*.
+
+---
+
+## 2. Tool Selection
+
+### Option A: Playwright with Built-in Screenshot Comparison
+
+**Pros**:
+- No external service dependency.
+- Fast local execution.
+- Full control over masking and thresholds.
+- Works offline.
+
+**Cons**:
+- Baselines stored in your repo (can bloat Git history).
+- No hosted dashboard for visual diffs.
+
+**Best for**: Teams that want full control and already use Playwright for E2E tests.
+
+### Option B: Percy (by BrowserStack)
+
+**Pros**:
+- Hosted dashboard with side-by-side diffs.
+- Parallel rendering across browsers and viewports.
+- Commit-level snapshots for PR reviews.
+
+**Cons**:
+- Paid service (free tier available).
+- Network dependency (slower in CI).
+
+**Best for**: Teams that want a turnkey solution and visual diff review in PRs.
+
+### Option C: Chromatic (by Storybook)
+
+**Pros**:
+- Native Storybook integration.
+- Component-level visual testing (test wallet components in isolation).
+- UI review workflow for designers.
+
+**Cons**:
+- Requires Storybook setup.
+- Paid service (free tier for open source).
+
+**Best for**: Design-system-first teams that already maintain a Storybook.
+
+### Recommendation
+
+Start with **Playwright screenshot comparison**. It is the fastest path to value and costs nothing. Move to Percy or Chromatic if you need multi-browser coverage or a hosted review workflow.
+
+---
+
+## 3. Creating and Managing Baselines
+
+### What Are Baselines?
+
+Baselines are the "known good" screenshots your tests compare against. When a test runs, Playwright captures a new screenshot and diffs it against the baseline. If the difference exceeds a threshold, the test fails.
+
+Playwright provides two comparison APIs:
+
+- `expect(page).toHaveScreenshot(name, options)` — captures the full page (`expect(locator).toHaveScreenshot()` captures a single element) and is the primary tool for visual regression testing. It auto-hides the text caret and can disable animations.
+- `expect(value).toMatchSnapshot(name, options)` — compares arbitrary serializable values or buffers (e.g., an element screenshot buffer). Use it when you need custom diff targets outside the standard page-screenshot flow.
+
+This guide uses `toHaveScreenshot()` throughout.
+
+### Creating Baselines
+
+Run your tests with `--update-snapshots`:
+
+```bash
+npx playwright test --update-snapshots
+```
+
+Playwright saves baseline images in a `{testFileName}-snapshots/` directory next to your test file (note: this is Playwright's convention, not Jest's `__snapshots__/`):
+
+```text
+tests/
+  wallet.visual.spec.ts
+  wallet.visual.spec.ts-snapshots/
+    send-form-empty-state-chromium-linux.png
+    send-form-filled-chromium-linux.png
+    transaction-history-chromium-linux.png
+```
+
+The `-chromium-linux` suffix is appended automatically based on the test project name and platform, so baselines never collide across browsers or operating systems.
+
+### When to Update Baselines
+
+- **Intentional UI changes**: You refactor the Send form. Run tests, review the diff, update baselines if correct.
+- **New viewports or browsers**: You add mobile testing. Generate new baselines for `iPhone 13` alongside existing `Desktop Chrome`.
+- **Breaking changes in dependencies**: A Stellar SDK upgrade changes how asset codes render. Update baselines after manual verification.
+
+### Baseline Storage
+
+**Option 1: Store in Git** (recommended for small projects)
+- Commit baselines to your repo.
+- Pros: no external dependency, full history.
+- Cons: bloats repo size (use Git LFS if baselines exceed 10 MB).
+
+**Option 2: Store in cloud storage**
+- Upload baselines to S3 or GCS, fetch in CI.
+- Pros: keeps repo lean.
+- Cons: adds pipeline complexity.
+
+For most teams, Git storage is fine. Use `.gitattributes` to mark baselines as binary so Git does not try to merge them:
+
+```text
+**/*-snapshots/**/*.png binary
+```
+
+---
+
+## 4. Handling Updates and Approving Changes
+
+### The Review Workflow
+
+1. **Developer makes a UI change** (e.g., updates button color).
+2. **CI runs visual tests** and detects a diff.
+3. **CI fails** and outputs a diff image showing pixel differences.
+4. **Developer reviews the diff** locally:
+   ```bash
+   npx playwright show-report
+   ```
+   Playwright's HTML report shows before/after/diff side by side.
+5. **If correct**, developer updates baselines:
+   ```bash
+   npx playwright test --update-snapshots
+   ```
+   and commits the new baselines.
+6. **If incorrect**, developer fixes the bug and re-runs tests.
+
+### Approving Changes in CI
+
+**GitHub Actions example**:
+
+```yaml
+name: Visual Regression Tests
+
+on: [pull_request]
+
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npx playwright test tests/visual/
+
+      # Upload diff images on failure
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: visual-diffs
+          path: test-results/**/*-diff.png
+
+      # Comment on PR with diff artifact link
+      - name: Comment PR
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ Visual regression tests failed. [Download diffs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            })
+```
+
+This workflow:
+- Runs visual tests on every PR.
+- Uploads diff images as artifacts if tests fail.
+- Posts a comment on the PR with a link to download diffs.
+
+---
+
+## 5. Flakiness Mitigation Strategies
+
+Visual tests are notorious for flakiness. Here is how to eliminate false positives.
+
+### 5.1 Consistent Viewport and Device Settings
+
+Always use the same viewport dimensions and device pixel ratio:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.use({
+  viewport: { width: 1280, height: 720 },
+  deviceScaleFactor: 1,
+});
+```
+
+**Why**: Different viewports produce different screenshots. Lock it down.
+
+### 5.2 Disable Animations and Wait for Stability
+
+Animations are the single biggest source of visual test flakiness. Do not screenshot mid-animation — disable them entirely with the `animations: 'disabled'` option, either per call or globally via `playwright.config.ts` (shown in Section 6):
+
+```typescript
+// Per call: fast-forwards CSS animations and transitions to their end state
+await expect(page).toHaveScreenshot('wallet-dashboard.png', {
+  animations: 'disabled',
+});
+```
+
+Also wait for the page to reach a stable state before capturing. `waitUntil: 'networkidle'` ensures in-flight requests (balance fetches, price feeds) have finished:
+
+```typescript
+await page.goto('http://localhost:3000/wallet', {
+  waitUntil: 'networkidle',
+});
+```
+
+For specific elements, wait until they are attached, visible, and stable:
+
+```typescript
+const sendButton = page.locator('[data-testid="send-button"]');
+await sendButton.waitFor({ state: 'visible' });
+await expect(sendButton).toBeVisible();
+```
+
+Avoid bare `waitForTimeout()` sleeps — they are a flakiness source themselves (too short on slow CI, wasted time locally). Prefer explicit waits on data test IDs.
+
+### 5.3 Mask Dynamic Content
+
+Dynamic data (timestamps, transaction hashes, live prices) changes on every run. Mask it:
+
+```typescript
+await expect(page).toHaveScreenshot('wallet-dashboard.png', {
+  mask: [
+    page.locator('[data-testid="last-updated-timestamp"]'),
+    page.locator('[data-testid="current-xlm-price"]'),
+    page.locator('[data-testid="tx-hash"]'),
+  ],
+});
+```
+
+Masked areas are filled with a solid color in the screenshot, so they never diff.
+
+**Masking strategy**:
+
+| Mask (dynamic, never deterministic) | Do NOT mask (what you are testing) |
+| --- | --- |
+| Timestamps and "last synced" labels | Account balances and amounts |
+| Transaction hashes and nonces | Asset codes and icons |
+| Live price feeds | Button labels and CTAs |
+| Randomized avatars or placeholders | Form fields and validation messages |
+
+### 5.4 Disable Font Anti-Aliasing Differences
+
+Font rendering varies slightly across OS and browser versions. Use a stable font stack and disable subpixel anti-aliasing:
+
+```css
+/* In your test CSS or global styles */
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```
+
+Or use a web font with consistent rendering (e.g., `Roboto` from Google Fonts).
+
+### 5.5 Set Diff Thresholds
+
+Small pixel differences (1-2 pixels due to rounding) should not fail tests. Playwright offers two knobs:
+
+- `maxDiffPixels` — the absolute number of pixels allowed to differ before the test fails.
+- `threshold` — the per-pixel perceived color difference tolerance in the YIQ color space, from `0` (strictest) to `1` (loosest). Default is `0.2`. Higher values tolerate small anti-aliasing shifts on individual pixels.
+
+```typescript
+await expect(page).toHaveScreenshot('send-form.png', {
+  maxDiffPixels: 100, // Allow up to 100 pixels to differ in total
+  threshold: 0.2,     // Tolerate minor per-pixel color differences
+});
+```
+
+**Recommended starting points**:
+
+| Layout | `maxDiffPixels` | Notes |
+| --- | --- | --- |
+| Desktop (1280x720) | 50-100 | Larger surface, more anti-aliased text |
+| Mobile (375x667) | 20-50 | Smaller surface area |
+
+Tune these per test: start strict (`maxDiffPixels: 0`) and loosen only where flakiness is proven, not preemptively.
+
+### 5.6 Use a Stable Test Environment
+
+Run tests in Docker or a CI container to ensure identical rendering:
+
+```dockerfile
+# Dockerfile for visual tests
+FROM mcr.microsoft.com/playwright:v1.49.1-jammy
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+CMD ["npx", "playwright", "test", "tests/visual/"]
+```
+
+This guarantees the same OS, browser version, and font libraries on every run.
+
+---
+
+## 6. Complete Working Example: Stellar Wallet Visual Tests
+
+### Project Setup
+
+```bash
+npm init playwright@latest
+npm install --save-dev @playwright/test
+```
+
+### Test File: `tests/visual/wallet.visual.spec.ts`
+
+```typescript
+import { test, expect, Page } from '@playwright/test';
+
+// Configure viewport and device settings
+test.use({
+  viewport: { width: 1280, height: 720 },
+  deviceScaleFactor: 1,
+});
+
+// Helper: Mock Stellar account data
+async function mockWalletData(page: Page) {
+  await page.route('**/api/account/*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'GABC...XYZ',
+        balances: [
+          { asset_code: 'XLM', balance: '1234.5678900' },
+          { asset_code: 'USDC', balance: '500.00', asset_issuer: 'GA...' },
+        ],
+        sequence: '123456789',
+      }),
+    });
+  });
+}
+
+test.describe('Wallet Dashboard', () => {
+  test('empty state', async ({ page }) => {
+    await page.goto('http://localhost:3000/wallet');
+    await page.waitForSelector('[data-testid="wallet-dashboard"]');
+    
+    await expect(page).toHaveScreenshot('dashboard-empty.png');
+  });
+
+  test('with account balances', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet');
+    
+    // Wait for balances to load
+    await page.waitForSelector('[data-testid="balance-xlm"]');
+    
+    // Mask dynamic timestamp
+    await expect(page).toHaveScreenshot('dashboard-with-balances.png', {
+      mask: [page.locator('[data-testid="last-synced"]')],
+      maxDiffPixels: 50,
+    });
+  });
+
+  test('mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet');
+    await page.waitForSelector('[data-testid="balance-xlm"]');
+    
+    await expect(page).toHaveScreenshot('dashboard-mobile.png', {
+      mask: [page.locator('[data-testid="last-synced"]')],
+      maxDiffPixels: 30,
+    });
+  });
+});
+
+test.describe('Send Flow', () => {
+  test('send form - initial state', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet/send');
+    await page.waitForSelector('[data-testid="send-form"]');
+    
+    await expect(page).toHaveScreenshot('send-form-empty.png');
+  });
+
+  test('send form - filled', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet/send');
+    
+    // Fill form
+    await page.fill('[data-testid="recipient-input"]', 'GDEF...ABC');
+    await page.fill('[data-testid="amount-input"]', '100');
+    await page.selectOption('[data-testid="asset-select"]', 'XLM');
+    
+    await expect(page).toHaveScreenshot('send-form-filled.png');
+  });
+
+  test('send form - validation error', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet/send');
+    
+    // Fill invalid amount
+    await page.fill('[data-testid="amount-input"]', '9999999');
+    await page.click('[data-testid="send-button"]');
+    
+    // Wait for error message
+    await page.waitForSelector('[data-testid="error-insufficient-balance"]');
+    
+    await expect(page).toHaveScreenshot('send-form-error.png');
+  });
+
+  test('confirmation modal', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet/send');
+    
+    await page.fill('[data-testid="recipient-input"]', 'GDEF...ABC');
+    await page.fill('[data-testid="amount-input"]', '100');
+    await page.click('[data-testid="send-button"]');
+    
+    // Wait for modal
+    await page.waitForSelector('[data-testid="confirm-modal"]');
+    
+    // Mask dynamic fee estimate (can vary)
+    await expect(page).toHaveScreenshot('send-confirm-modal.png', {
+      mask: [page.locator('[data-testid="estimated-fee"]')],
+    });
+  });
+});
+
+test.describe('Transaction History', () => {
+  test('transaction list', async ({ page }) => {
+    // Mock transaction history API
+    await page.route('**/api/transactions/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          _embedded: {
+            records: [
+              {
+                id: 'tx1',
+                type: 'payment',
+                created_at: '2026-08-25T12:00:00Z',
+                from: 'GABC...XYZ',
+                to: 'GDEF...ABC',
+                amount: '100.0000000',
+                asset_code: 'XLM',
+              },
+              {
+                id: 'tx2',
+                type: 'payment',
+                created_at: '2026-08-24T10:00:00Z',
+                from: 'GDEF...ABC',
+                to: 'GABC...XYZ',
+                amount: '50.0000000',
+                asset_code: 'USDC',
+              },
+            ],
+          },
+        }),
+      });
+    });
+
+    await page.goto('http://localhost:3000/wallet/transactions');
+    await page.waitForSelector('[data-testid="transaction-list"]');
+    
+    // Mask transaction IDs and timestamps (dynamic)
+    await expect(page).toHaveScreenshot('transaction-history.png', {
+      mask: [
+        page.locator('[data-testid="tx-id"]'),
+        page.locator('[data-testid="tx-timestamp"]'),
+      ],
+      maxDiffPixels: 100,
+    });
+  });
+
+  test('empty transaction history', async ({ page }) => {
+    await page.route('**/api/transactions/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ _embedded: { records: [] } }),
+      });
+    });
+
+    await page.goto('http://localhost:3000/wallet/transactions');
+    await page.waitForSelector('[data-testid="empty-state"]');
+    
+    await expect(page).toHaveScreenshot('transaction-history-empty.png');
+  });
+});
+
+test.describe('Asset Selection', () => {
+  test('asset dropdown - open', async ({ page }) => {
+    await mockWalletData(page);
+    await page.goto('http://localhost:3000/wallet/send');
+    
+    // Open asset dropdown
+    await page.click('[data-testid="asset-select"]');
+    await page.waitForSelector('[data-testid="asset-option-XLM"]');
+    
+    await expect(page).toHaveScreenshot('asset-dropdown-open.png');
+  });
+
+  test('asset with logo', async ({ page }) => {
+    await page.route('**/api/account/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'GABC...XYZ',
+          balances: [
+            {
+              asset_code: 'AQUA',
+              balance: '1000.00',
+              asset_issuer: 'GA...',
+              // Mock TOML data would include logo
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('http://localhost:3000/wallet');
+    await page.waitForSelector('[data-testid="balance-AQUA"]');
+    
+    // Wait for asset logo to load
+    await page.waitForSelector('[data-testid="asset-logo-AQUA"]');
+    
+    await expect(page).toHaveScreenshot('asset-with-logo.png');
+  });
+});
+```
+
+### Playwright Configuration: `playwright.config.ts`
+
+```typescript
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/visual',
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  // Playwright already defaults to a single worker on CI; keep retries for
+  // infrastructure flakes only. Visual diffs should never be retried away.
+  retries: process.env.CI ? 2 : 0,
+
+  reporter: process.env.CI ? 'github' : 'html',
+
+  // Global defaults applied to every expect(page).toHaveScreenshot() call.
+  // Individual tests can override any of these per call.
+  expect: {
+    toHaveScreenshot: {
+      animations: 'disabled',   // Fast-forward CSS animations/transitions
+      caret: 'hide',            // Hide the blinking text caret
+      maxDiffPixels: 100,       // Allow up to 100 differing pixels
+      threshold: 0.2,           // Per-pixel YIQ color tolerance (0-1)
+    },
+  },
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { 
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+        deviceScaleFactor: 1,
+      },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { 
+        ...devices['Pixel 5'],
+        deviceScaleFactor: 1, // Override device default
+      },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});
+```
+
+### Running Tests
+
+```bash
+# Run all visual tests
+npx playwright test tests/visual/
+
+# Run specific test
+npx playwright test tests/visual/wallet.visual.spec.ts
+
+# Update baselines (after verifying changes are correct)
+npx playwright test tests/visual/ --update-snapshots
+
+# Show HTML report with visual diffs
+npx playwright show-report
+```
+
+### Directory Structure
+
+```text
+my-stellar-wallet/
+├── tests/
+│   └── visual/
+│       ├── wallet.visual.spec.ts
+│       └── wallet.visual.spec.ts-snapshots/
+│           ├── dashboard-empty-chromium-linux.png
+│           ├── dashboard-empty-mobile-chrome-linux.png
+│           ├── dashboard-with-balances-chromium-linux.png
+│           ├── send-form-empty-chromium-linux.png
+│           └── ...
+├── playwright.config.ts
+└── package.json
+```
+
+---
+
+## 7. CI/CD Integration
+
+### GitHub Actions (Full Example)
+
+```yaml
+# .github/workflows/visual-regression.yml
+name: Visual Regression Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+
+jobs:
+  visual-tests:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run visual regression tests
+        run: npx playwright test tests/visual/
+        env:
+          CI: true
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload visual diffs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-diffs
+          path: test-results/**/*-diff.png
+          retention-days: 7
+
+      - name: Comment on PR with results
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## ❌ Visual Regression Tests Failed\n\n` +
+                    `Visual differences detected. [View test results and diffs](${runUrl})\n\n` +
+                    `### Next Steps:\n` +
+                    `1. Download the \`visual-diffs\` artifact from the workflow run\n` +
+                    `2. Review each diff image\n` +
+                    `3. If changes are intentional, update baselines:\n` +
+                    `   \`\`\`bash\n   npx playwright test tests/visual/ --update-snapshots\n   \`\`\`\n` +
+                    `4. Commit the updated snapshots`
+            });
+```
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+visual-tests:
+  image: mcr.microsoft.com/playwright:v1.49.1-jammy
+  stage: test
+  script:
+    - npm ci
+    - npx playwright test tests/visual/
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+      - test-results/
+    expire_in: 1 week
+  only:
+    - merge_requests
+    - main
+```
+
+### CircleCI
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+orbs:
+  node: circleci/node@5.1.0
+
+jobs:
+  visual-tests:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.49.1-jammy
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Install Playwright
+          command: npx playwright install --with-deps chromium
+      - run:
+          name: Run visual tests
+          command: npx playwright test tests/visual/
+      - store_artifacts:
+          path: playwright-report
+      - store_artifacts:
+          path: test-results
+
+workflows:
+  test:
+    jobs:
+      - visual-tests
+```
+
+---
+
+## 8. Advanced Patterns
+
+### 8.1 Parameterized Visual Tests (Multiple Viewports)
+
+```typescript
+const viewports = [
+  { name: 'desktop', width: 1280, height: 720 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 375, height: 667 },
+];
+
+for (const viewport of viewports) {
+  test(`dashboard - ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await page.goto('http://localhost:3000/wallet');
+    await page.waitForSelector('[data-testid="wallet-dashboard"]');
+    
+    await expect(page).toHaveScreenshot(`dashboard-${viewport.name}.png`, {
+      maxDiffPixels: 50,
+    });
+  });
+}
+```
+
+### 8.2 Component-Level Visual Tests (Storybook)
+
+If you use Storybook, test components in isolation:
+
+```typescript
+// WalletBalance.stories.tsx
+import { Meta, StoryObj } from '@storybook/react';
+import { WalletBalance } from './WalletBalance';
+
+const meta: Meta<typeof WalletBalance> = {
+  component: WalletBalance,
+};
+export default meta;
+
+export const Default: StoryObj<typeof WalletBalance> = {
+  args: {
+    balance: '1234.5678900',
+    assetCode: 'XLM',
+  },
+};
+
+export const LongBalance: StoryObj<typeof WalletBalance> = {
+  args: {
+    balance: '123456789.1234567',
+    assetCode: 'XLM',
+  },
+};
+```
+
+Then run Playwright against Storybook:
+
+```typescript
+test('WalletBalance component', async ({ page }) => {
+  await page.goto('http://localhost:6006/iframe.html?id=walletbalance--default');
+  await page.waitForSelector('[data-testid="wallet-balance"]');
+  
+  await expect(page).toHaveScreenshot('wallet-balance-component.png');
+});
+```
+
+### 8.3 Percy Integration (Hosted Service)
+
+Install Percy SDK:
+
+```bash
+npm install --save-dev @percy/cli @percy/playwright
+```
+
+Update tests to use Percy snapshots:
+
+```typescript
+import percySnapshot from '@percy/playwright';
+
+test('dashboard with Percy', async ({ page }) => {
+  await page.goto('http://localhost:3000/wallet');
+  await page.waitForSelector('[data-testid="wallet-dashboard"]');
+  
+  // Percy snapshot (uploaded to Percy dashboard)
+  await percySnapshot(page, 'Wallet Dashboard');
+});
+```
+
+Run tests with Percy:
+
+```bash
+npx percy exec -- npx playwright test
+```
+
+Percy uploads screenshots to their cloud, where you review diffs in a web UI.
+
+### 8.4 Handling Theming (Light/Dark Mode)
+
+Test both themes:
+
+```typescript
+const themes = ['light', 'dark'];
+
+for (const theme of themes) {
+  test(`dashboard - ${theme} theme`, async ({ page }) => {
+    // Set theme via localStorage or cookie
+    await page.addInitScript((theme) => {
+      localStorage.setItem('theme', theme);
+    }, theme);
+    
+    await page.goto('http://localhost:3000/wallet');
+    await page.waitForSelector('[data-testid="wallet-dashboard"]');
+    
+    await expect(page).toHaveScreenshot(`dashboard-${theme}.png`);
+  });
+}
+```
+
+---
+
+## 9. Troubleshooting Common Issues
+
+### Issue: Tests pass locally but fail in CI
+
+**Cause**: Different OS/browser versions render fonts differently.
+
+**Solution**: Run tests in Docker locally with the same image as CI:
+
+```bash
+docker run --rm --network host -v $(pwd):/work -w /work -it \
+  mcr.microsoft.com/playwright:v1.49.1-jammy \
+  npx playwright test tests/visual/
+```
+
+### Issue: Flaky failures on dynamic content
+
+**Cause**: Timestamps, transaction hashes, or loading states not masked.
+
+**Solution**: Mask all dynamic content and wait for stable state:
+
+```typescript
+// Bad: screenshots mid-load
+await page.goto('http://localhost:3000/wallet');
+await expect(page).toHaveScreenshot('dashboard.png');
+
+// Good: wait for load + mask dynamic content
+await page.goto('http://localhost:3000/wallet', { waitUntil: 'networkidle' });
+await page.waitForSelector('[data-testid="balance-xlm"]');
+await expect(page).toHaveScreenshot('dashboard.png', {
+  mask: [
+    page.locator('[data-testid="last-synced"]'),
+    page.locator('[data-testid="tx-hash"]'),
+  ],
+});
+```
+
+### Issue: Diffs on anti-aliased text
+
+**Cause**: Subpixel rendering varies across machines.
+
+**Solution**: Use a stable font with `font-smoothing`:
+
+```css
+body {
+  font-family: 'Roboto', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+```
+
+### Issue: Large baseline file sizes
+
+**Cause**: Too many high-resolution screenshots.
+
+**Solution**:
+1. Use Git LFS for `*-snapshots/` directories.
+2. Test only critical paths (no need for every button state).
+3. Compress PNGs with `pngquant` in CI.
+
+---
+
+## 10. Best Practices Summary
+
+1. **Test critical paths only**: Dashboard, Send flow, Transaction history, Asset selection. Do not screenshot every pixel of your app.
+2. **Mask dynamic content**: Timestamps, hashes, prices, nonces.
+3. **Use consistent viewports**: Lock down `width`, `height`, and `deviceScaleFactor`.
+4. **Disable animations and wait for stable state**: `animations: 'disabled'` globally, plus `waitUntil: 'networkidle'` and explicit waits for data test IDs.
+5. **Set diff thresholds**: 50-100 pixels for desktop, 20-50 for mobile.
+6. **Run in Docker**: Use the same Playwright Docker image locally and in CI.
+7. **Review diffs before updating baselines**: Do not blindly accept changes.
+8. **Store baselines in Git**: Use Git LFS if they exceed 10 MB.
+9. **Fail fast in CI**: Post diff artifacts and links to PRs so reviewers can approve changes.
+10. **Keep tests fast**: Parallelize, reuse server instances, mock APIs.
+
+---
+
+## 11. Next Steps
+
+- **Add visual tests to your PR workflow**: Require passing visual tests before merge.
+- **Monitor baseline drift**: Track how often baselines change (high churn = unstable UI).
+- **Integrate with design reviews**: Share Percy/Chromatic links with designers for approval.
+- **Expand to E2E flows**: Add visual snapshots to existing E2E tests (sign transaction, swap assets).
+
+Visual regression testing is not a replacement for manual QA — it is a safety net that catches regressions before they reach users. Combine it with unit tests, E2E tests, and manual exploratory testing for full coverage.
+
+---
+
+## Resources
+
+### Internal
+
+- [Testing Guide](/docs/guides/testing) — repository test setup and conventions
+- [Screenshot Workflow](/docs/guides/screenshot-workflow) — capturing and maintaining docs screenshots
+
+### External
+
+- [Playwright Visual Comparisons](https://playwright.dev/docs/test-snapshots)
+- [Percy Documentation](https://docs.percy.io/)
+- [Chromatic Visual Testing](https://www.chromatic.com/docs/)
+- [Stellar SDK Testing Guide](https://developers.stellar.org/docs/building-apps/testing)
+- [Soroban dApp Testing Patterns](https://soroban.stellar.org/docs/how-to-guides/testing)

--- a/routes-d/952-caching-layer-tutorial.mdx
+++ b/routes-d/952-caching-layer-tutorial.mdx
@@ -1,0 +1,1044 @@
+---
+title: Caching Layer for Stellar dApp Horizon Reads
+description: Build an efficient caching layer over Horizon API calls with invalidation strategies, staleness bounds, and React Query implementation for Stellar dApps.
+date: 2026-08-25
+---
+
+# Caching Layer for Stellar dApp Horizon Reads
+
+Horizon API calls are the backbone of most Stellar dApps, but uncached reads create unnecessary latency, waste bandwidth, and risk hitting rate limits. A well-designed caching layer keeps your UI responsive while respecting data freshness constraints and Horizon's rate limits.
+
+This guide covers cache invalidation strategies, staleness bounds, and a complete working implementation using React Query.
+
+---
+
+## Why Caching Matters for Horizon
+
+Horizon is a shared resource with per-IP rate limits on public endpoints (roughly 100 requests per 10 seconds on testnet — see [Rate Limiting Horizon Requests](/docs/guides/rate-limiting-horizon-requests)). Without caching:
+
+- Every component re-render triggers a fresh API call
+- Users see spinners for data that hasn't changed
+- Rate limits are reached quickly during peak usage
+- Network latency directly impacts perceived performance
+
+A caching layer solves these problems by:
+
+1. **Reducing API calls** — serve repeated reads from memory
+2. **Improving response time** — eliminate network round-trip for cached data
+3. **Respecting rate limits** — stay well below quota with intelligent revalidation
+4. **Offline resilience** — show stale data when the network is unavailable
+
+---
+
+## Cache Invalidation Strategies
+
+Cache invalidation is famously one of the two hard problems in computer science. For Horizon data, you have four primary strategies:
+
+### 1. Time-Based Invalidation (TTL)
+
+Data expires after a fixed duration. Simple and predictable.
+
+**Best for**: Account balances, transaction history, offers, asset details
+
+```ts
+const CACHE_TTL = {
+  balances: 10_000,      // 10 seconds — frequently changing
+  account: 30_000,       // 30 seconds — moderate volatility
+  transactions: 60_000,  // 1 minute — historical data rarely changes
+  assets: 300_000,       // 5 minutes — static metadata
+};
+```
+
+**Pros**:
+- Easy to reason about
+- No complex dependency tracking
+- Works for all data types
+
+**Cons**:
+- May serve stale data if changes happen mid-TTL
+- May refresh unnecessarily if data hasn't changed
+
+### 2. Event-Based Invalidation
+
+Invalidate when a known event occurs (user submits transaction, receives payment, etc.).
+
+**Best for**: User-initiated actions where you know exactly what changed
+
+```ts
+async function submitPayment(tx: Transaction) {
+  const result = await server.submitTransaction(tx);
+  
+  if (result.successful) {
+    // Invalidate caches that this transaction affects
+    queryClient.invalidateQueries({ queryKey: ['balances', sourceAccount] });
+    queryClient.invalidateQueries({ queryKey: ['balances', destination] });
+    queryClient.invalidateQueries({ queryKey: ['transactions', sourceAccount] });
+  }
+  
+  return result;
+}
+```
+
+**Pros**:
+- Immediate UI updates after actions
+- No waiting for TTL expiration
+- Precise control over what gets refreshed
+
+**Cons**:
+- Doesn't catch external changes (other users' transactions)
+- Requires manual tracking of dependencies
+- Complex for multi-hop effects
+
+### 3. Polling with Background Revalidation
+
+Keep data fresh with periodic background checks while serving from cache.
+
+**Best for**: Critical real-time data (open orders, pending transactions)
+
+```ts
+useQuery({
+  queryKey: ['openOrders', accountId],
+  queryFn: () => fetchOpenOrders(accountId),
+  staleTime: 5_000,        // Consider fresh for 5s
+  refetchInterval: 10_000, // Poll every 10s in background
+});
+```
+
+**Pros**:
+- Catches external changes automatically
+- Balances freshness and API efficiency
+- User always sees up-to-date data
+
+**Cons**:
+- More API calls than pure TTL
+- Polling continues even when data rarely changes
+- Need to pause polling when tab is hidden
+
+### 4. Stream-Based Invalidation (SSE / Ledger Close Events)
+
+Horizon supports Server-Sent Events, letting you subscribe to account activity and invalidate reactively instead of polling. Every message corresponds to a ledger close event (~5 second cadence), so this catches external changes — incoming payments from other users, trustline changes — almost immediately.
+
+```ts
+// lib/horizonStreams.ts
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { horizonServer } from './horizon';
+import { stellarKeys } from '@/hooks/useStellarAccount';
+
+/**
+ * Subscribes to an account's transaction stream and invalidates all
+ * account-related queries whenever a new ledger entry arrives.
+ * Returns nothing; cleans up the stream on unmount.
+ */
+export function useAccountInvalidationStream(accountId: string | null) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!accountId) return;
+
+    const closeStream = horizonServer
+      .transactions()
+      .forAccount(accountId)
+      .stream({
+        onmessage: () => {
+          // A new transaction landed — refresh everything scoped to this account
+          queryClient.invalidateQueries({
+            queryKey: stellarKeys.account(accountId),
+          });
+        },
+        onerror: (error) => {
+          console.error('Horizon stream error:', error);
+        },
+      });
+
+    // Close the SSE connection on unmount to avoid leaks
+    return () => closeStream();
+  }, [accountId, queryClient]);
+}
+```
+
+**Best for**: Accounts displayed persistently where external changes matter (wallet dashboards)
+
+**Pros**:
+- Push-based — reacts to external changes with zero wasted requests
+- Aligned with actual ledger close events rather than arbitrary intervals
+- Complements TTL: streams trigger invalidation, TTL remains the safety net
+
+**Cons**:
+- Browsers limit concurrent SSE connections (six per domain on HTTP/1.1)
+- Requires cleanup on unmount and reconnection handling on network drops
+- Not suitable for server-side rendering without extra plumbing
+
+---
+
+## Staleness Bounds Configuration
+
+Staleness bounds define how old data can be before it must be refreshed. Different data types have different tolerance for staleness:
+
+| Data Type | Staleness Bound | Rationale |
+|-----------|----------------|-----------|
+| Account balances | 5-10 seconds | Users expect current balance, but sub-second precision rarely matters |
+| Transaction history | 30-60 seconds | Historical data doesn't change; recent transactions settle within seconds |
+| Open offers | 5 seconds | Order book changes frequently in active markets |
+| Asset metadata | 5 minutes | Issuer-defined properties rarely change |
+| Network info | 30 seconds | Ledger time and fee stats are useful but not critical |
+| Account details (signers, thresholds) | 1 minute | Configuration changes are rare |
+
+Configure staleness based on **user impact**:
+
+- **High impact** (user making decisions): tight bounds (5-10s)
+- **Medium impact** (informational display): moderate bounds (30-60s)
+- **Low impact** (background context): loose bounds (5+ minutes)
+
+One physical floor applies to everything: Stellar ledgers close roughly every 5 seconds, so data cannot change faster than that. Bounds tighter than ~5 seconds buy you nothing unless you pair them with stream-based invalidation (strategy 4 above), and even then a TTL safety net is still recommended in case a stream drops.
+
+---
+
+## Implementation with React Query
+
+React Query (TanStack Query) is the standard caching layer for React applications. It provides:
+
+- Automatic background refetching
+- Stale-while-revalidate pattern
+- Request deduplication
+- Cache persistence
+- Optimistic updates
+
+### Setup
+
+```bash
+npm install @tanstack/react-query @stellar/stellar-sdk
+```
+
+```tsx
+// app/providers.tsx
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 10_000,        // Default: 10s staleness
+            gcTime: 300_000,          // Keep in cache for 5 minutes
+            retry: 2,                 // Retry failed requests twice
+            refetchOnWindowFocus: true, // Refresh when user returns to tab
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+```
+
+### Horizon Client Setup
+
+```ts
+// lib/horizon.ts
+import { Horizon } from '@stellar/stellar-sdk';
+
+export const horizonServer = new Horizon.Server(
+  process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org'
+);
+
+export interface StellarBalance {
+  assetCode: string;
+  assetIssuer: string | null;
+  balance: string;
+  limit: string | null;
+  isNative: boolean;
+}
+
+export async function fetchAccountBalances(
+  accountId: string
+): Promise<StellarBalance[]> {
+  const account = await horizonServer.loadAccount(accountId);
+  
+  return account.balances.map((b) => {
+    if (b.asset_type === 'native') {
+      return {
+        assetCode: 'XLM',
+        assetIssuer: null,
+        balance: b.balance,
+        limit: null,
+        isNative: true,
+      };
+    }
+    
+    const assetBalance = b as Horizon.HorizonApi.BalanceLineAsset;
+    return {
+      assetCode: assetBalance.asset_code,
+      assetIssuer: assetBalance.asset_issuer,
+      balance: assetBalance.balance,
+      limit: assetBalance.limit,
+      isNative: false,
+    };
+  });
+}
+
+export async function fetchAccountTransactions(
+  accountId: string,
+  limit = 20
+): Promise<Horizon.ServerApi.TransactionRecord[]> {
+  const transactions = await horizonServer
+    .transactions()
+    .forAccount(accountId)
+    .limit(limit)
+    .order('desc')
+    .call();
+  
+  return transactions.records;
+}
+
+export async function fetchAccountDetails(
+  accountId: string
+): Promise<Horizon.AccountResponse> {
+  return horizonServer.loadAccount(accountId);
+}
+```
+
+---
+
+## Complete Working Example: Account Data Caching
+
+### Custom Hooks with React Query
+
+```tsx
+// hooks/useStellarAccount.ts
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchAccountBalances,
+  fetchAccountTransactions,
+  fetchAccountDetails,
+  type StellarBalance,
+} from '@/lib/horizon';
+import { Horizon } from '@stellar/stellar-sdk';
+
+// Query keys factory for type-safe cache access
+export const stellarKeys = {
+  all: ['stellar'] as const,
+  accounts: () => [...stellarKeys.all, 'accounts'] as const,
+  account: (id: string) => [...stellarKeys.accounts(), id] as const,
+  balances: (id: string) => [...stellarKeys.account(id), 'balances'] as const,
+  transactions: (id: string) => [...stellarKeys.account(id), 'transactions'] as const,
+  details: (id: string) => [...stellarKeys.account(id), 'details'] as const,
+};
+
+/**
+ * Fetch and cache account balances with 10-second staleness
+ */
+export function useAccountBalances(accountId: string | null) {
+  return useQuery({
+    queryKey: stellarKeys.balances(accountId!),
+    queryFn: () => fetchAccountBalances(accountId!),
+    enabled: !!accountId,
+    staleTime: 10_000,     // Consider fresh for 10 seconds
+    gcTime: 300_000,       // Keep in cache for 5 minutes
+    retry: 2,
+  });
+}
+
+/**
+ * Fetch and cache transaction history with 1-minute staleness
+ */
+export function useAccountTransactions(
+  accountId: string | null,
+  limit = 20
+) {
+  return useQuery({
+    queryKey: [...stellarKeys.transactions(accountId!), limit],
+    queryFn: () => fetchAccountTransactions(accountId!, limit),
+    enabled: !!accountId,
+    staleTime: 60_000,     // Consider fresh for 1 minute
+    gcTime: 600_000,       // Keep in cache for 10 minutes
+  });
+}
+
+/**
+ * Fetch and cache account details (signers, thresholds, etc.)
+ */
+export function useAccountDetails(accountId: string | null) {
+  return useQuery({
+    queryKey: stellarKeys.details(accountId!),
+    queryFn: () => fetchAccountDetails(accountId!),
+    enabled: !!accountId,
+    staleTime: 60_000,     // Consider fresh for 1 minute
+    gcTime: 300_000,
+  });
+}
+
+/**
+ * Hook to manually invalidate account-related caches
+ * Use after submitting transactions
+ */
+export function useInvalidateAccount() {
+  const queryClient = useQueryClient();
+  
+  return {
+    invalidateBalances: (accountId: string) => {
+      queryClient.invalidateQueries({
+        queryKey: stellarKeys.balances(accountId),
+      });
+    },
+    invalidateTransactions: (accountId: string) => {
+      queryClient.invalidateQueries({
+        queryKey: stellarKeys.transactions(accountId),
+      });
+    },
+    invalidateAll: (accountId: string) => {
+      queryClient.invalidateQueries({
+        queryKey: stellarKeys.account(accountId),
+      });
+    },
+  };
+}
+```
+
+### UI Component Using Cached Data
+
+```tsx
+// components/AccountBalances.tsx
+'use client';
+
+import { useAccountBalances } from '@/hooks/useStellarAccount';
+
+export function AccountBalances({ accountId }: { accountId: string }) {
+  const { data: balances, isLoading, error, dataUpdatedAt } = useAccountBalances(accountId);
+
+  if (isLoading) {
+    return <div className="animate-pulse">Loading balances...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-red-600">
+        Error loading balances: {error.message}
+      </div>
+    );
+  }
+
+  if (!balances || balances.length === 0) {
+    return <div>No balances found</div>;
+  }
+
+  const lastUpdated = new Date(dataUpdatedAt).toLocaleTimeString();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">Balances</h2>
+        <span className="text-sm text-gray-500">
+          Updated: {lastUpdated}
+        </span>
+      </div>
+      
+      <div className="space-y-2">
+        {balances.map((balance, idx) => (
+          <div
+            key={idx}
+            className="flex justify-between items-center p-3 bg-gray-50 rounded-lg"
+          >
+            <div>
+              <div className="font-medium">
+                {balance.assetCode}
+              </div>
+              {!balance.isNative && (
+                <div className="text-xs text-gray-500 truncate max-w-xs">
+                  {balance.assetIssuer}
+                </div>
+              )}
+            </div>
+            <div className="text-right">
+              <div className="font-mono">{balance.balance}</div>
+              {balance.limit && (
+                <div className="text-xs text-gray-500">
+                  Limit: {balance.limit}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+### Transaction Submission with Cache Invalidation
+
+```tsx
+// hooks/useSubmitPayment.ts
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import {
+  Keypair,
+  Asset,
+  Operation,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+} from '@stellar/stellar-sdk';
+import { horizonServer } from '@/lib/horizon';
+import { useInvalidateAccount } from './useStellarAccount';
+
+interface PaymentParams {
+  sourceKeypair: Keypair;
+  destination: string;
+  amount: string;
+  asset?: Asset;
+}
+
+export function useSubmitPayment() {
+  const { invalidateBalances, invalidateTransactions } = useInvalidateAccount();
+
+  return useMutation({
+    mutationFn: async ({ sourceKeypair, destination, amount, asset }: PaymentParams) => {
+      const sourceAccount = await horizonServer.loadAccount(sourceKeypair.publicKey());
+      
+      const transaction = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: Networks.TESTNET,
+      })
+        .addOperation(
+          Operation.payment({
+            destination,
+            asset: asset || Asset.native(),
+            amount,
+          })
+        )
+        .setTimeout(30)
+        .build();
+      
+      transaction.sign(sourceKeypair);
+      
+      const result = await horizonServer.submitTransaction(transaction);
+      return result;
+    },
+    onSuccess: (data, variables) => {
+      // Invalidate caches for both sender and receiver
+      const sourceId = variables.sourceKeypair.publicKey();
+      
+      invalidateBalances(sourceId);
+      invalidateBalances(variables.destination);
+      invalidateTransactions(sourceId);
+      invalidateTransactions(variables.destination);
+    },
+  });
+}
+```
+
+### Usage in Component
+
+```tsx
+// components/PaymentForm.tsx
+'use client';
+
+import { useState } from 'react';
+import { Keypair } from '@stellar/stellar-sdk';
+import { useSubmitPayment } from '@/hooks/useSubmitPayment';
+
+export function PaymentForm({ sourceKeypair }: { sourceKeypair: Keypair }) {
+  const [destination, setDestination] = useState('');
+  const [amount, setAmount] = useState('');
+  
+  const { mutate: submitPayment, isPending, isSuccess, error } = useSubmitPayment();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    submitPayment({ sourceKeypair, destination, amount });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          Destination Address
+        </label>
+        <input
+          type="text"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          className="w-full px-3 py-2 border rounded-lg"
+          placeholder="GABC..."
+          required
+        />
+      </div>
+      
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          Amount (XLM)
+        </label>
+        <input
+          type="number"
+          step="0.0000001"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full px-3 py-2 border rounded-lg"
+          placeholder="10.5"
+          required
+        />
+      </div>
+      
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:bg-gray-400"
+      >
+        {isPending ? 'Sending...' : 'Send Payment'}
+      </button>
+      
+      {isSuccess && (
+        <div className="text-green-600 text-sm">
+          Payment sent successfully! Balances will refresh automatically.
+        </div>
+      )}
+      
+      {error && (
+        <div className="text-red-600 text-sm">
+          Error: {error.message}
+        </div>
+      )}
+    </form>
+  );
+}
+```
+
+---
+
+## Advanced Patterns
+
+### Optimistic Updates
+
+Update the UI immediately before the transaction settles, then rollback if it fails:
+
+```ts
+// hooks/useOptimisticPayment.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useInvalidateAccount } from './useStellarAccount';
+// PaymentParams is the interface defined in useSubmitPayment.ts above
+
+export function useOptimisticPayment() {
+  const queryClient = useQueryClient();
+  const { invalidateBalances } = useInvalidateAccount();
+
+  return useMutation({
+    mutationFn: async (params: PaymentParams) => {
+      // ... submit transaction as shown in useSubmitPayment
+    },
+    onMutate: async (variables) => {
+      const sourceId = variables.sourceKeypair.publicKey();
+      
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: stellarKeys.balances(sourceId),
+      });
+      
+      // Snapshot current balances
+      const previousBalances = queryClient.getQueryData(
+        stellarKeys.balances(sourceId)
+      );
+      
+      // Optimistically update cache
+      queryClient.setQueryData(
+        stellarKeys.balances(sourceId),
+        (old: StellarBalance[] | undefined) => {
+          if (!old) return old;
+          return old.map((b) =>
+            b.isNative
+              ? {
+                  ...b,
+                  balance: (
+                    parseFloat(b.balance) - parseFloat(variables.amount)
+                  ).toFixed(7),
+                }
+              : b
+          );
+        }
+      );
+      
+      return { previousBalances };
+    },
+    onError: (err, variables, context) => {
+      // Rollback on error
+      if (context?.previousBalances) {
+        queryClient.setQueryData(
+          stellarKeys.balances(variables.sourceKeypair.publicKey()),
+          context.previousBalances
+        );
+      }
+    },
+    onSettled: (data, error, variables) => {
+      // Always refetch after mutation settles
+      invalidateBalances(variables.sourceKeypair.publicKey());
+      invalidateBalances(variables.destination);
+    },
+  });
+}
+```
+
+### Prefetching Related Data
+
+Preload data that the user is likely to need:
+
+```ts
+export function usePrefetchAccount(accountId: string | null) {
+  const queryClient = useQueryClient();
+
+  const prefetch = () => {
+    if (!accountId) return;
+    
+    // Prefetch balances
+    queryClient.prefetchQuery({
+      queryKey: stellarKeys.balances(accountId),
+      queryFn: () => fetchAccountBalances(accountId),
+      staleTime: 10_000,
+    });
+    
+    // Prefetch transactions
+    queryClient.prefetchQuery({
+      queryKey: stellarKeys.transactions(accountId),
+      queryFn: () => fetchAccountTransactions(accountId),
+      staleTime: 60_000,
+    });
+  };
+
+  return { prefetch };
+}
+
+// Usage: prefetch on hover
+function AccountLink({ accountId }: { accountId: string }) {
+  const { prefetch } = usePrefetchAccount(accountId);
+
+  return (
+    <button
+      onMouseEnter={() => prefetch()}
+      onClick={() => navigate(`/account/${accountId}`)}
+    >
+      View Account
+    </button>
+  );
+}
+```
+
+### Pagination with Cursor Caching
+
+Cache paginated results efficiently:
+
+```ts
+export function useTransactionPages(accountId: string | null) {
+  return useInfiniteQuery({
+    queryKey: [...stellarKeys.transactions(accountId!), 'infinite'],
+    queryFn: async ({ pageParam }) => {
+      const builder = horizonServer
+        .transactions()
+        .forAccount(accountId!)
+        .limit(20)
+        .order('desc');
+      
+      if (pageParam) {
+        builder.cursor(pageParam);
+      }
+      
+      const result = await builder.call();
+      return {
+        records: result.records,
+        nextCursor: result.records[result.records.length - 1]?.paging_token,
+      };
+    },
+    enabled: !!accountId,
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: 60_000,
+  });
+}
+```
+
+### Pause Polling on Hidden Tabs
+
+Stop background refetching when the tab is hidden:
+
+```tsx
+// app/providers.tsx
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 10_000,
+            refetchOnWindowFocus: true,
+            refetchOnMount: true,
+            // Stop refetching when tab is hidden
+            refetchInterval: (query) => {
+              if (typeof document === 'undefined') return false;
+              return document.hidden ? false : query.state.data ? 10_000 : false;
+            },
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}
+```
+
+---
+
+## Best Practices
+
+### 1. Use Query Key Factories
+
+Centralize query keys in a factory to avoid typos and enable type-safe invalidation:
+
+```ts
+export const stellarKeys = {
+  all: ['stellar'] as const,
+  accounts: () => [...stellarKeys.all, 'accounts'] as const,
+  account: (id: string) => [...stellarKeys.accounts(), id] as const,
+  // ... more keys
+};
+```
+
+### 2. Set Appropriate Staleness Per Data Type
+
+Don't use a global `staleTime` — configure per query based on data volatility:
+
+```ts
+// Fast-changing data
+staleTime: 5_000   // 5 seconds
+
+// Moderate data
+staleTime: 30_000  // 30 seconds
+
+// Slow-changing data
+staleTime: 300_000 // 5 minutes
+```
+
+### 3. Always Invalidate After Mutations
+
+Ensure the UI reflects reality after user actions:
+
+```ts
+onSuccess: (data, variables) => {
+  queryClient.invalidateQueries({
+    queryKey: stellarKeys.balances(accountId),
+  });
+}
+```
+
+### 4. Handle Errors Gracefully
+
+Show stale data with an error message rather than a blank screen:
+
+```tsx
+if (error) {
+  return (
+    <div>
+      <div className="text-red-600">Failed to refresh data</div>
+      {data && <BalancesList balances={data} />}
+    </div>
+  );
+}
+```
+
+### 5. Monitor Cache Size
+
+Large caches consume memory. Set `gcTime` to remove old data:
+
+```ts
+gcTime: 300_000  // Remove from cache after 5 minutes of inactivity
+```
+
+### 6. Use Dependent Queries Carefully
+
+When one query depends on another, use `enabled`:
+
+```ts
+const { data: account } = useAccountDetails(accountId);
+
+const { data: offers } = useQuery({
+  queryKey: ['offers', account?.id],
+  queryFn: () => fetchOffers(account!.id),
+  enabled: !!account, // Only run if account loaded
+});
+```
+
+### 7. Debounce User Input
+
+Don't query on every keystroke:
+
+```ts
+const [search, setSearch] = useState('');
+const debouncedSearch = useDebounce(search, 500);
+
+useQuery({
+  queryKey: ['search', debouncedSearch],
+  queryFn: () => searchAssets(debouncedSearch),
+  enabled: debouncedSearch.length > 2,
+});
+```
+
+---
+
+## Common Pitfalls
+
+### 1. Over-Caching
+
+**Problem**: Caching data that changes frequently or must always be fresh.
+
+**Solution**: Use shorter `staleTime` or skip caching for critical real-time data.
+
+```ts
+// Don't cache streaming order book updates
+// Do cache historical trades
+```
+
+### 2. Cache Invalidation Bugs
+
+**Problem**: Forgetting to invalidate related caches after mutations.
+
+**Solution**: Build invalidation maps and test thoroughly.
+
+```ts
+// Invalidate all related queries after a complex operation
+const accountKeys = [
+  stellarKeys.balances(accountId),
+  stellarKeys.transactions(accountId),
+  stellarKeys.details(accountId),
+];
+
+accountKeys.forEach((key) => {
+  queryClient.invalidateQueries({ queryKey: key });
+});
+```
+
+### 3. Memory Leaks from Infinite Queries
+
+**Problem**: Infinite scroll caches grow unbounded.
+
+**Solution**: Set `gcTime` and limit page count.
+
+```ts
+useInfiniteQuery({
+  // ...
+  gcTime: 300_000,
+  maxPages: 10, // React Query v5
+});
+```
+
+### 4. Not Handling Loading States
+
+**Problem**: Showing spinners for cached data.
+
+**Solution**: Check `isLoading` vs `isFetching`:
+
+```tsx
+if (isLoading) return <Spinner />; // First load
+if (data) return <Content data={data} />; // Show cached data even if refetching
+```
+
+### 5. Polling Too Aggressively
+
+**Problem**: `refetchInterval: 1000` hammers Horizon and drains user battery.
+
+**Solution**: Use intervals ≥5s and pause when tab is hidden.
+
+---
+
+## Performance Benchmarks
+
+Typical performance improvements with caching:
+
+| Scenario | Without Cache | With Cache | Improvement |
+|----------|--------------|------------|-------------|
+| Re-render same component | 200-500ms | \<10ms | 20-50x |
+| Navigate back to cached page | 200-500ms | \<10ms | 20-50x |
+| Rapid user actions | Each triggers API call | Batched/deduplicated | 5-10x fewer calls |
+| Rate limit exposure | High risk at scale | Stays under quota | N/A |
+
+---
+
+## Testing Your Cache
+
+```ts
+import { QueryClient } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAccountBalances } from './useStellarAccount';
+
+test('caches balance data', async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  
+  const wrapper = ({ children }: any) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  const { result, rerender } = renderHook(
+    () => useAccountBalances('GABC...'),
+    { wrapper }
+  );
+
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+  const firstData = result.current.data;
+  
+  // Unmount and remount
+  rerender();
+  
+  // Should serve from cache immediately
+  expect(result.current.data).toBe(firstData);
+  expect(result.current.isFetching).toBe(false);
+});
+```
+
+---
+
+## Related Resources
+
+| Resource | Link |
+|----------|------|
+| Rate limits and 429 recovery | [Rate Limiting Horizon Requests](/docs/guides/rate-limiting-horizon-requests) |
+| Horizon integration overview | [Stellar Horizon](/docs/integrations/horizon) |
+| Prebuilt balances hook | [useStellarBalances](/docs/hooks/use-stellar-balances) |
+| Prebuilt history hook | [useTransactionHistory](/docs/hooks/use-transaction-history) |
+| Mocking Horizon in tests | [Testing Integrations](/docs/integrations/testing) |
+
+---
+
+## Acceptance Checklist
+
+- [ ] Guide renders without build errors (`pnpm build:content`)
+- [ ] Internal links resolve (`pnpm check:links`)
+- [ ] Four invalidation strategies are explained with code (TTL, mutations, polling, SSE streams)
+- [ ] Staleness bounds table is present and comprehensive
+- [ ] Complete React Query setup with QueryClientProvider
+- [ ] Working hooks: `useAccountBalances`, `useAccountTransactions`, `useAccountDetails`
+- [ ] Transaction submission with cache invalidation example
+- [ ] UI component consuming cached data
+- [ ] Advanced patterns: optimistic updates, prefetching, pagination
+- [ ] Best practices section with 7+ actionable tips
+- [ ] Common pitfalls section with solutions
+- [ ] Performance benchmarks included
+- [ ] Testing example provided
+- [ ] All TypeScript code is type-safe and compiles
+- [ ] Code follows Next.js 14+ conventions (use client directives, app router patterns)
+

--- a/routes-d/963-accessibility-policy-guide.mdx
+++ b/routes-d/963-accessibility-policy-guide.mdx
@@ -1,0 +1,527 @@
+---
+title: Stellar dApp Accessibility Policy Guide
+description: Comprehensive guide to creating, implementing, and maintaining accessibility policies for Stellar dApps — covering WCAG conformance targets, reporting procedures, remediation workflows, and a customizable policy template.
+date: 2026-08-25
+---
+
+# Stellar dApp Accessibility Policy Guide
+
+Accessibility is not optional for production dApps. Users with disabilities must be able to connect wallets, review transactions, approve signatures, and manage assets independently. This guide provides a structured approach to establishing accessibility policies that meet WCAG standards and ensure your Stellar dApp is usable by everyone.
+
+---
+
+## 1. Why Accessibility Matters for Stellar dApps
+
+### 1.1 Legal and Ethical Obligations
+
+Accessibility regulations — including the Americans with Disabilities Act (ADA), European Accessibility Act (EAA), and Section 508 — apply to financial applications and blockchain interfaces. Non-compliance risks lawsuits, regulatory penalties, and reputational damage.
+
+### 1.2 Technical Considerations for Web3
+
+Stellar dApps introduce unique accessibility challenges:
+
+- **Transaction signing flows**: Screen readers must announce transaction details (amount, destination, fee) clearly before users approve.
+- **Wallet connection modals**: Keyboard navigation must allow users to select wallet providers without a mouse.
+- **Real-time data updates**: Balance changes, transaction confirmations, and network status must be announced to assistive technologies.
+- **Cryptographic addresses**: Long Stellar public keys (`G...` addresses) need proper labeling and copy mechanisms that work with screen readers.
+- **Error states**: Failed transactions, insufficient balance warnings, and network errors must be perceivable by all users.
+
+### 1.3 Business Impact
+
+Accessible dApps reach a broader audience. An estimated 15% of the global population lives with some form of disability. Improving accessibility increases user retention, reduces support costs, and demonstrates professional development standards.
+
+---
+
+## 2. Conformance Targets and Standards
+
+### 2.1 WCAG 2.1 Overview
+
+The **Web Content Accessibility Guidelines (WCAG) 2.1** provide the international standard for web accessibility. The guidelines are organized into three conformance levels:
+
+| Level | Description | Recommended for |
+|---|---|---|
+| **A** | Minimum baseline — addresses critical barriers | Internal tools, proofs-of-concept |
+| **AA** | Recommended standard for public-facing applications | Production dApps, marketplaces, exchanges |
+| **AAA** | Maximum conformance — stricter color contrast, language, timing | High-security financial applications, government portals |
+
+**For Stellar dApps, target WCAG 2.1 Level AA as the minimum production standard.**
+
+### 2.2 Four Core Principles (POUR)
+
+WCAG conformance is built on four principles:
+
+1. **Perceivable**: Information must be presented in ways all users can perceive.
+   - Provide text alternatives for images (including wallet logos, token icons).
+   - Ensure color is not the only means of conveying information (e.g., success/error states).
+   - Make content adaptable (responsive layouts, semantic HTML).
+
+2. **Operable**: Users must be able to operate the interface.
+   - Full keyboard navigation support (no mouse-only interactions).
+   - Sufficient time for users to complete transactions (configurable timeouts for signing).
+   - No content that causes seizures (avoid flashing animations above 3 Hz).
+   - Clear navigation and focus management (especially in modals).
+
+3. **Understandable**: Content and operation must be clear.
+   - Predictable behavior (wallet connection flow remains consistent).
+   - Input assistance (clear labels for amount fields, destination addresses).
+   - Error identification and recovery (explain "insufficient balance" with suggested actions).
+
+4. **Robust**: Content must work reliably across assistive technologies.
+   - Valid semantic HTML5 markup.
+   - ARIA attributes used correctly (roles, states, properties).
+   - Compatibility with common screen readers (NVDA, JAWS, VoiceOver).
+
+### 2.3 Critical Success Criteria for Stellar dApps
+
+Focus on these high-impact WCAG criteria:
+
+| Criterion | Level | Impact on dApps |
+|---|---|---|
+| **1.1.1 Non-text Content** | A | Alt text for wallet icons, token logos, QR codes |
+| **1.4.3 Contrast (Minimum)** | AA | 4.5:1 for body text, 3:1 for large text and UI components |
+| **2.1.1 Keyboard** | A | All wallet actions accessible via keyboard |
+| **2.4.3 Focus Order** | A | Logical tab order through transaction forms |
+| **2.4.7 Focus Visible** | AA | Clear focus indicators on buttons, inputs, links |
+| **3.2.2 On Input** | A | Changing network doesn't auto-submit transactions |
+| **3.3.1 Error Identification** | A | Transaction errors described in text, not just color |
+| **3.3.2 Labels or Instructions** | A | Clear labels for amount, address, memo fields |
+| **4.1.2 Name, Role, Value** | A | Proper ARIA for modals, alerts, live regions |
+| **4.1.3 Status Messages** | AA | Announce "Transaction confirmed" to screen readers |
+
+### 2.4 Emerging Standards: WCAG 3.0 and ATAG 2.0
+
+- **WCAG 3.0 (W3C Working Draft)**: Currently under development, introducing a scoring model rather than pass/fail criteria. Monitor progress at [w3.org/WAI/WCAG3](https://www.w3.org/WAI/WCAG3/).
+- **ATAG 2.0 (Authoring Tool Accessibility Guidelines)**: If your dApp includes content creation features (governance proposals, asset descriptions), ATAG 2.0 applies. Ensure editors produce accessible output.
+
+---
+
+## 3. Reporting Procedures
+
+### 3.1 Establishing a Clear Reporting Channel
+
+Users must know how to report accessibility issues. Provide a dedicated contact method:
+
+- **Email address**: `accessibility@yourdapp.com`
+- **Web form**: Embedded on your site's footer or `/accessibility` page
+- **GitHub repository**: Public issue template for open-source projects
+- **In-app feedback**: Accessible feedback widget (ensure the widget itself is keyboard-accessible)
+
+### 3.2 Accessibility Statement
+
+Publish an accessibility statement at `/accessibility` that includes:
+
+1. **Commitment**: "We are committed to ensuring our dApp is accessible to all users."
+2. **Conformance target**: "Our dApp aims to conform to WCAG 2.1 Level AA."
+3. **Known issues**: List any outstanding accessibility barriers with planned remediation dates.
+4. **Contact information**: How users can report new issues.
+5. **Response timeline**: "We respond to accessibility reports within 2 business days and provide remediation timelines within 5 business days."
+
+### 3.3 Information to Request from Reporters
+
+When users report issues, ask for:
+
+- **Assistive technology used**: Screen reader (name and version), browser, operating system.
+- **Steps to reproduce**: Specific page, wallet connection flow, or transaction step.
+- **Expected behavior**: What the user expected to happen.
+- **Actual behavior**: What occurred instead.
+- **Severity**: Blocker (cannot complete task), major (workaround exists), minor (inconvenience).
+
+### 3.4 Sample Reporting Form Template
+
+```html
+<form action="/accessibility-report" method="POST">
+  <label for="name">Your Name (optional):</label>
+  <input type="text" id="name" name="name" />
+
+  <label for="email">Email (for follow-up):</label>
+  <input type="email" id="email" name="email" required />
+
+  <label for="assistive-tech">Assistive Technology Used:</label>
+  <input type="text" id="assistive-tech" name="assistive-tech" 
+         placeholder="e.g., NVDA 2023.1, JAWS 2024, VoiceOver" />
+
+  <label for="page-url">Page or Feature Affected:</label>
+  <input type="url" id="page-url" name="page-url" 
+         placeholder="https://app.yourdapp.com/swap" />
+
+  <label for="issue-description">Description of Issue:</label>
+  <textarea id="issue-description" name="issue-description" 
+            rows="6" required></textarea>
+
+  <label for="severity">Severity:</label>
+  <select id="severity" name="severity">
+    <option value="blocker">Blocker - Cannot complete task</option>
+    <option value="major">Major - Workaround exists</option>
+    <option value="minor">Minor - Inconvenience</option>
+  </select>
+
+  <button type="submit">Submit Report</button>
+</form>
+```
+
+---
+
+## 4. Remediation Workflows
+
+### 4.1 Triage and Prioritization
+
+Classify reported issues by severity and WCAG level:
+
+| Priority | Criteria | Response Time | Fix Target |
+|---|---|---|---|
+| **P0 - Critical** | WCAG A violation, blocks core functionality | 24 hours | 1 week |
+| **P1 - High** | WCAG AA violation, significant barrier | 2 business days | 2 weeks |
+| **P2 - Medium** | WCAG AA violation, workaround available | 5 business days | 1 month |
+| **P3 - Low** | WCAG AAA or minor enhancement | 1 week | Next major release |
+
+### 4.2 Investigation and Root Cause Analysis
+
+For each reported issue:
+
+1. **Reproduce the issue**: Test with the same assistive technology the user reported.
+2. **Identify WCAG criterion**: Map the issue to specific WCAG success criteria.
+3. **Determine scope**: Is this a component library issue, a framework bug, or application-level code?
+4. **Check for regressions**: Did a recent deployment introduce this issue?
+
+### 4.3 Fix Implementation
+
+Apply fixes following these best practices:
+
+```tsx
+// ❌ BEFORE: Inaccessible wallet connection modal
+function WalletModal({ isOpen, onClose }) {
+  return (
+    <div className="modal">
+      <h2>Connect Wallet</h2>
+      <button onClick={() => connectFreighter()}>
+        <img src="/freighter.png" />
+      </button>
+      <span onClick={onClose}>×</span>
+    </div>
+  );
+}
+
+// ✅ AFTER: Accessible wallet connection modal
+function WalletModal({ isOpen, onClose }) {
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="wallet-modal-title"
+      aria-modal="true"
+      className="modal"
+    >
+      <h2 id="wallet-modal-title">Connect Wallet</h2>
+      <button onClick={() => connectFreighter()} aria-label="Connect with Freighter">
+        <img src="/freighter.png" alt="Freighter logo" />
+        <span>Freighter</span>
+      </button>
+      <button onClick={onClose} aria-label="Close modal">
+        ×
+      </button>
+    </div>
+  );
+}
+```
+
+Key improvements:
+- `role="dialog"` and `aria-modal="true"` announce modal context.
+- `aria-labelledby` connects modal title.
+- `alt` text for logo image.
+- `aria-label` for icon-only close button.
+- Visual text "Freighter" alongside logo for clarity.
+
+### 4.4 Verification and Testing
+
+Before marking an issue resolved:
+
+1. **Manual testing**: Verify fix with keyboard navigation and relevant screen reader.
+2. **Automated testing**: Run axe-core, Lighthouse, or Pa11y in CI pipeline.
+3. **Regression testing**: Ensure fix didn't break adjacent functionality.
+4. **User confirmation**: If possible, ask the original reporter to verify the fix.
+
+### 4.5 Documentation and Communication
+
+After remediation:
+
+- **Update accessibility statement**: Remove resolved issue from "Known Issues" section.
+- **Notify reporter**: Send follow-up email confirming fix and providing deployment timeline.
+- **Release notes**: Document accessibility fixes in changelogs.
+- **Internal tracking**: Log fix in issue tracker (GitHub, Jira, Linear) with WCAG reference.
+
+---
+
+## 5. Ongoing Maintenance and Audits
+
+### 5.1 Automated Testing in CI/CD
+
+Integrate accessibility testing into your deployment pipeline. Add these scripts to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:a11y": "pa11y-ci --config .pa11yci.json",
+    "test:axe": "jest --testMatch '**/*.a11y.test.ts'"
+  }
+}
+```
+
+Example Jest + axe-core test:
+
+```typescript
+// WalletModal.a11y.test.ts
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { WalletModal } from './WalletModal';
+
+expect.extend(toHaveNoViolations);
+
+test('WalletModal should have no accessibility violations', async () => {
+  const { container } = render(
+    <WalletModal isOpen={true} onClose={() => {}} />
+  );
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```
+
+### 5.2 Manual Audits
+
+Schedule manual audits quarterly:
+
+- **Screen reader testing**: NVDA (Windows), JAWS (Windows), VoiceOver (macOS/iOS), TalkBack (Android).
+- **Keyboard navigation**: Verify all interactive elements reachable via Tab, Enter, Escape.
+- **Color contrast**: Use tools like WebAIM's Contrast Checker.
+- **Zoom and magnification**: Test at 200% browser zoom and with screen magnification tools.
+
+### 5.3 Third-Party Audits
+
+For critical dApps handling significant user funds, engage professional accessibility auditors annually. Reputable firms include:
+
+- **Deque Systems**: Enterprise accessibility consulting and testing.
+- **Level Access**: WCAG conformance audits and remediation planning.
+- **TPGi (The Paciello Group)**: Accessibility training and certification.
+
+### 5.4 Training and Awareness
+
+Ensure your development team understands accessibility fundamentals:
+
+- **Onboarding**: Include accessibility in new engineer training.
+- **Design reviews**: Involve accessibility considerations in UI/UX design phase.
+- **Code reviews**: Check for ARIA usage, semantic HTML, keyboard support before merging.
+- **Resources**: Bookmark MDN Web Docs (Accessibility), W3C WAI, WebAIM.
+
+---
+
+## 6. Policy Template
+
+Use this template as a starting point for your dApp's accessibility policy. Customize sections in `[brackets]` to fit your organization.
+
+---
+
+### **[Your dApp Name] Accessibility Policy**
+
+**Effective Date:** [YYYY-MM-DD]  
+**Last Reviewed:** [YYYY-MM-DD]  
+**Policy Owner:** [Name, Title]
+
+---
+
+#### **1. Commitment Statement**
+
+[Your dApp Name] is committed to ensuring digital accessibility for all users, including those with disabilities. We strive to provide an inclusive experience that allows everyone to independently access, manage, and transact digital assets on the Stellar network.
+
+---
+
+#### **2. Conformance Target**
+
+Our dApp aims to conform to **WCAG 2.1 Level AA** standards. We continuously work to meet or exceed these guidelines across all user-facing features, including:
+
+- Wallet connection and authentication flows
+- Asset management and balance displays
+- Transaction creation, review, and signing
+- Real-time notifications and status updates
+- Documentation and help resources
+
+---
+
+#### **3. Known Limitations**
+
+As of [YYYY-MM-DD], the following accessibility issues are known and under active remediation:
+
+- **[Issue 1]**: [Brief description, affected pages, planned fix date]
+- **[Issue 2]**: [Brief description, affected pages, planned fix date]
+- **[Issue 3]**: [Brief description, affected pages, planned fix date]
+
+*This section will be updated as issues are resolved.*
+
+---
+
+#### **4. Reporting Accessibility Issues**
+
+We welcome feedback on accessibility barriers. To report an issue:
+
+- **Email:** [accessibility@yourdapp.com]
+- **Web Form:** [https://yourdapp.com/accessibility-report]
+- **GitHub:** [https://github.com/yourorg/yourrepo/issues (use "accessibility" label)]
+
+Please include:
+- The page or feature affected
+- Assistive technology used (name and version)
+- A description of the issue and expected behavior
+- Your contact information for follow-up (optional)
+
+**Response Timeline:**  
+We respond to accessibility reports within **[2 business days]** and provide a remediation plan within **[5 business days]**. Critical issues blocking core functionality are prioritized for resolution within **[1 week]**.
+
+---
+
+#### **5. Remediation Process**
+
+Reported issues are triaged by severity:
+
+| Priority | Criteria | Fix Target |
+|---|---|---|
+| **Critical** | Blocks core functionality (wallet connection, transaction signing) | 1 week |
+| **High** | Significant barrier, limited workaround | 2 weeks |
+| **Medium** | Moderate barrier, workaround available | 1 month |
+| **Low** | Minor enhancement or WCAG AAA criterion | Next major release |
+
+Fixes are verified through:
+- Manual testing with assistive technologies
+- Automated accessibility scanning (axe-core, Lighthouse)
+- User confirmation when possible
+
+---
+
+#### **6. Testing and Maintenance**
+
+We maintain accessibility through:
+
+- **Automated Testing:** Accessibility tests run on every pull request via CI/CD pipeline.
+- **Manual Audits:** Quarterly internal audits covering keyboard navigation, screen reader compatibility, and color contrast.
+- **Third-Party Audits:** Annual external accessibility audits by certified professionals.
+- **Team Training:** Regular accessibility training for engineering, design, and product teams.
+
+---
+
+#### **7. Supported Assistive Technologies**
+
+Our dApp is tested with the following assistive technologies:
+
+- **Screen Readers:** NVDA (Windows), JAWS (Windows), VoiceOver (macOS, iOS), TalkBack (Android)
+- **Browsers:** Chrome, Firefox, Safari, Edge (latest stable versions)
+- **Input Methods:** Keyboard, touch, voice control
+- **Magnification:** Browser zoom up to 200%, OS-level screen magnifiers
+
+---
+
+#### **8. Third-Party Content**
+
+Some features integrate third-party services (wallet providers, RPC endpoints, oracles) that may have independent accessibility implementations. We advocate for accessibility with our partners and provide alternative interfaces where possible.
+
+---
+
+#### **9. Governance and Review**
+
+This policy is reviewed **[quarterly/annually]** and updated to reflect:
+
+- New WCAG guidelines or legal requirements
+- Lessons learned from user feedback and audits
+- Changes in technology stack or third-party dependencies
+
+Policy updates are communicated via:
+- **Changelog:** [https://yourdapp.com/changelog]
+- **Email notifications** to opted-in users
+- **Public accessibility statement** at [https://yourdapp.com/accessibility]
+
+---
+
+#### **10. Contact Information**
+
+For questions about this policy or accessibility accommodations:
+
+- **Accessibility Coordinator:** [Name, Title]
+- **Email:** [accessibility@yourdapp.com]
+- **Phone:** [+1-XXX-XXX-XXXX] (if applicable)
+- **Mailing Address:** [Physical address if required for legal compliance]
+
+---
+
+**[Your dApp Name] Team**  
+*Building an inclusive financial future on Stellar.*
+
+---
+
+## 7. Practical Implementation Checklist
+
+Use this checklist to implement your accessibility policy:
+
+### Phase 1: Foundation (Week 1-2)
+- [ ] Draft accessibility policy using template above
+- [ ] Create `/accessibility` page with conformance statement
+- [ ] Set up reporting email alias or form
+- [ ] Assign accessibility policy owner
+
+### Phase 2: Baseline Assessment (Week 3-4)
+- [ ] Run automated scan with axe DevTools or Lighthouse
+- [ ] Conduct manual keyboard navigation test
+- [ ] Test with at least one screen reader (NVDA or VoiceOver)
+- [ ] Document known issues with severity ratings
+
+### Phase 3: Critical Fixes (Week 5-8)
+- [ ] Fix P0 Critical issues (WCAG A violations blocking functionality)
+- [ ] Fix P1 High issues (WCAG AA violations with significant impact)
+- [ ] Implement focus management for modals and overlays
+- [ ] Add ARIA labels to icon-only buttons
+
+### Phase 4: Automation (Week 9-10)
+- [ ] Integrate axe-core or Pa11y into CI/CD pipeline
+- [ ] Create accessibility test suite (Jest + axe)
+- [ ] Set up automated contrast checking
+- [ ] Configure linting rules (eslint-plugin-jsx-a11y)
+
+### Phase 5: Ongoing (Quarterly)
+- [ ] Schedule manual audit with keyboard and screen reader
+- [ ] Review and update known issues list
+- [ ] Train new team members on accessibility standards
+- [ ] Conduct user testing with participants who use assistive technologies
+
+---
+
+## 8. Resources and Further Reading
+
+### WCAG Documentation
+- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/) — Interactive quick reference
+- [WCAG 2.1 Understanding Docs](https://www.w3.org/WAI/WCAG21/Understanding/) — Detailed explanations of each criterion
+
+### Testing Tools
+- [axe DevTools](https://www.deque.com/axe/devtools/) — Browser extension for automated testing
+- [WAVE](https://wave.webaim.org/) — Web accessibility evaluation tool
+- [Lighthouse](https://developers.google.com/web/tools/lighthouse) — Built into Chrome DevTools
+- [Pa11y](https://pa11y.org/) — CI-friendly command-line accessibility testing
+
+### Assistive Technology Testing
+- [NVDA](https://www.nvaccess.org/) — Free Windows screen reader
+- [VoiceOver](https://www.apple.com/accessibility/voiceover/) — Built into macOS and iOS
+- [WebAIM Screen Reader Survey](https://webaim.org/projects/screenreadersurvey9/) — Usage statistics
+
+### Legal and Compliance
+- [ADA Website Compliance](https://www.ada.gov/) — Americans with Disabilities Act guidance
+- [Section 508](https://www.section508.gov/) — U.S. federal accessibility standards
+- [European Accessibility Act](https://ec.europa.eu/social/main.jsp?catId=1202) — EU requirements
+
+### Stellar-Specific Considerations
+- [Freighter Wallet Accessibility](https://www.freighter.app/) — Review wallet provider's own accessibility features
+- [Soroban Documentation](https://soroban.stellar.org/) — Ensure smart contract interactions are accessible
+- [Stellar Expert](https://stellar.expert/) — Reference implementation for accessible blockchain explorers
+
+### Related Documentation
+- [Stellar dApp Accessibility](/docs/guides/stellar-dapp-accessibility) — Implementation patterns for WCAG-compliant wallet flows, public key display, and transaction UIs
+
+---
+
+## Conclusion
+
+Accessibility is a continuous process, not a one-time checklist. By establishing a formal policy, clear reporting channels, and structured remediation workflows, your Stellar dApp demonstrates commitment to inclusive design. Start with WCAG 2.1 Level AA conformance, automate testing in CI/CD, and conduct regular manual audits. The result is a more usable, legally compliant, and professionally maintained application that serves all users equally.
+
+For questions or contributions to this guide, open an issue at your documentation repository or contact your accessibility policy owner.

--- a/routes-d/969-marketing-brief-guide.mdx
+++ b/routes-d/969-marketing-brief-guide.mdx
@@ -1,0 +1,565 @@
+---
+title: Stellar dApp Marketing Brief Guide
+description: A comprehensive marketing brief template and strategy guide for launching your Stellar dApp — covering audience identification, message development, distribution channels, and success metrics.
+date: 2026-08-25
+---
+
+# Stellar dApp Marketing Brief Guide
+
+This guide walks through creating a marketing brief for your Stellar dApp launch. Whether you're building a DeFi protocol, NFT marketplace, or payment solution, a structured marketing approach helps you reach your target users and communicate your value proposition effectively.
+
+---
+
+## 1. Understanding Your Stellar dApp Audience
+
+### 1.1 Primary Audience Segments
+
+Identify who will use your dApp and segment them by:
+
+**Technical sophistication:**
+- Crypto-native users (familiar with wallets, gas, DeFi)
+- Web3-curious (have used centralized exchanges, new to self-custody)
+- Traditional users (first blockchain experience)
+
+**Use case alignment:**
+- DeFi traders (yield seekers, liquidity providers)
+- Payment users (remittances, cross-border transactions)
+- Developers (building on your protocol)
+- Enterprise/institutions (compliance-first, high volume)
+
+**Geographic considerations:**
+- Regions with Stellar adoption (emerging markets, remittance corridors)
+- Regulatory environments (friendly jurisdictions vs. restricted)
+- Language and localization needs
+
+### 1.2 User Research
+
+Before finalizing your brief, answer:
+
+1. **What problem does your dApp solve?**
+   - Is it a new capability or an improvement over existing solutions?
+   - How does it compare to Ethereum/Polygon/other L1 alternatives?
+
+2. **Why Stellar?**
+   - Low fees, fast finality, built-in DEX, anchors, Soroban smart contracts
+   - Your specific architectural choice (classic ops vs. Soroban)
+
+3. **User pain points:**
+   - What friction exists today? (high gas, slow settlement, poor UX)
+   - How does your dApp eliminate or reduce that friction?
+
+4. **User goals:**
+   - What do they want to achieve? (earn yield, send money, trade assets)
+   - What success looks like for them
+
+### 1.3 Creating User Personas
+
+Document 2-3 personas:
+
+```text
+Persona: DeFi Yield Farmer
+- Age: 25-40
+- Experience: 2+ years in crypto
+- Tools: Uses multiple chains, familiar with MetaMask/Freighter
+- Goals: Maximize yield, minimize gas costs
+- Pain points: High fees on Ethereum, slow bridging
+- Stellar value: Fast, cheap transactions; built-in DEX
+```
+
+```text
+Persona: Remittance Sender
+- Age: 30-50
+- Experience: Uses traditional remittance services
+- Tools: Mobile-first, prefers simple interfaces
+- Goals: Send money home affordably and quickly
+- Pain points: High Western Union fees, slow settlement
+- Stellar value: Near-instant settlement, low fees, anchor network
+```
+
+---
+
+## 2. Crafting Your Message
+
+### 2.1 Value Proposition
+
+Distill your dApp into one sentence that answers: **"What is this, and why should I care?"**
+
+**Formula:**
+```text
+[Your dApp] helps [target audience] [achieve goal] by [unique approach].
+```
+
+**Examples:**
+- "LunarSwap helps DeFi traders maximize yields by aggregating liquidity across Stellar's DEX and Soroban AMMs."
+- "StableSend helps migrant workers send remittances home in seconds with fees under $0.01 using Stellar anchors."
+- "VaultDAO helps DAOs manage multi-sig treasuries with built-in compliance and audit trails on Soroban."
+
+### 2.2 Key Features and Benefits
+
+List 3-5 features and translate each into a user benefit:
+
+| Feature | Benefit |
+|---------|---------|
+| Sub-cent transaction fees | Keep more of your earnings; trade profitably on small positions |
+| 3-5 second finality | No waiting for confirmations; instant user experience |
+| Built-in DEX integration | Access deep liquidity without bridging to other chains |
+| Soroban smart contracts | Complex DeFi logic with Stellar's speed and low cost |
+| Anchor network support | Easy fiat on/off ramps in 180+ countries |
+
+### 2.3 Differentiation
+
+**Compared to alternatives:**
+
+| Comparison Point | Your dApp | Ethereum/L2 | Centralized Alternative |
+|------------------|-----------|-------------|-------------------------|
+| Transaction cost | \< $0.01 | $0.50 - $50 | Variable fees |
+| Settlement speed | 3-5 seconds | 12s - 2min | Instant (custodial) |
+| Custody | User-controlled | User-controlled | Platform-controlled |
+| Compliance | Built-in (regulated anchors) | Varies | Built-in |
+| Developer experience | Soroban (Rust) | Solidity | Proprietary API |
+
+**Your unique angle:**
+- First Soroban-based X
+- Only Stellar dApp with Y feature
+- Built by team with Z credentials
+
+### 2.4 Messaging Framework
+
+Create a tiered message hierarchy:
+
+**Core message (elevator pitch):**
+"[Your dApp] is a [category] on Stellar that [primary benefit]."
+
+**Supporting messages:**
+1. Technical: "Built on Soroban for sub-cent fees and 5-second finality."
+2. User-focused: "Trade/send/use without worrying about gas prices."
+3. Ecosystem: "Integrates with Stellar wallets, anchors, and DEX."
+
+**Proof points:**
+- Testnet metrics (transactions processed, uptime)
+- Audit reports (if available)
+- Beta user testimonials
+- Team background and partnerships
+
+---
+
+## 3. Distribution Channels and Strategies
+
+### 3.1 Community Channels
+
+**Stellar Community Forum:**
+- Post launch announcement in "Announcements" or "Projects"
+- Engage with questions, provide technical details
+- Share updates and milestones
+
+**Discord:**
+- Stellar Developer Discord: introduce in #showcase
+- Soroban Discord: technical discussions, support
+- Create your own server for user community
+
+**Telegram/WhatsApp:**
+- Regional groups for remittance/payment dApps
+- Developer groups for technical products
+
+### 3.2 Social Media Strategy
+
+**Twitter/X:**
+- Launch thread with visuals and demo video
+- Tag @StellarOrg, @SorobanOfficial, relevant influencers
+- Hashtags: #Stellar, #Soroban, #DeFi, #Web3
+- Post 3-5x/week: feature highlights, user stories, ecosystem news
+- Engage with Stellar community members and projects
+
+**LinkedIn:**
+- For B2B, enterprise, or compliance-focused dApps
+- Thought leadership posts on blockchain payments, DeFi innovation
+- Company updates, team hiring
+
+**YouTube:**
+- Demo videos (3-5 minutes)
+- Tutorial series (how to use your dApp)
+- Technical deep dives for developers
+
+**Medium/Substack:**
+- Launch announcement post
+- Technical architecture breakdown
+- Use case studies
+- Weekly/monthly product updates
+
+### 3.3 Developer Outreach
+
+If your dApp has an API, SDK, or composability:
+
+- **Documentation site:** Comprehensive guides, API reference
+- **GitHub:** Open-source contracts, example integrations
+- **Hackathons:** Sponsor Stellar/Soroban hackathons, offer bounties
+- **Dev workshops:** Host live coding sessions, office hours
+- **Dev community:** Answer questions on Stack Overflow, Stellar Stack Exchange
+
+### 3.4 Partnerships and Integrations
+
+**Wallet integrations:**
+- Freighter, Lobstr, Rabet, xBull
+- Feature your dApp in wallet discovery sections
+
+**Anchor partnerships:**
+- For payment dApps, integrate with anchors (MoneyGram Access, AnchorUSD)
+- Cross-promote through anchor channels
+
+**DeFi aggregators:**
+- List on Stellar DEX explorers (StellarX, StellarTerm, Stellarbeat)
+- Integrate with DeFi dashboards (DeFiLlama, if supported)
+
+**Media and press:**
+- Submit to crypto news sites (CoinDesk, The Block, Decrypt)
+- Stellar-focused media (Stellar Community Blog, Medium publications)
+- Podcasts (Stellar-focused or general crypto podcasts)
+
+### 3.5 Content Marketing
+
+**Educational content:**
+- Blog posts explaining your use case
+- Comparison guides (Stellar vs. other chains)
+- "Why we built on Stellar" narrative
+
+**User guides:**
+- Step-by-step tutorials with screenshots
+- Video walkthroughs
+- FAQ and troubleshooting
+
+**Case studies:**
+- Real-world usage examples
+- User testimonials and stories
+- Transaction volume milestones
+
+### 3.6 Paid Strategies (Optional)
+
+If you have a marketing budget:
+
+- **Twitter ads:** Target crypto/blockchain audiences
+- **Google ads:** Search keywords related to your use case
+- **Sponsorships:** Stellar/Soroban newsletters, podcasts, events
+- **Influencer partnerships:** Crypto KOLs for product reviews
+- **Conference presence:** Meridian (Stellar's annual conference), regional blockchain events
+
+---
+
+## 4. Metrics and Success Tracking
+
+### 4.1 Launch Metrics
+
+Track in the first 30 days:
+
+**Adoption metrics:**
+- Unique wallet addresses connected
+- Total transactions processed
+- Total value locked (TVL) or volume traded
+- Daily/monthly active users (DAU/MAU)
+
+**Engagement metrics:**
+- Website visits and conversion rate
+- Social media followers and engagement rate
+- Discord/Telegram members and activity
+- Documentation page views
+
+**Distribution metrics:**
+- Press mentions and reach
+- Social media impressions and shares
+- Referral sources (where users came from)
+
+### 4.2 Key Performance Indicators (KPIs)
+
+Define success for your dApp:
+
+| Category | Example KPI | Target (Month 1) | Target (Month 3) |
+|----------|-------------|------------------|------------------|
+| Adoption | Unique users | 500 | 2,000 |
+| Usage | Daily transactions | 1,000 | 5,000 |
+| Financial | TVL or volume | $50K | $500K |
+| Community | Twitter followers | 500 | 2,000 |
+| Content | Blog subscribers | 200 | 1,000 |
+
+### 4.3 Analytics Setup
+
+**On-chain tracking:**
+- Transaction volume, unique addresses (via Stellar Expert, StellarChain)
+- Contract invocations (for Soroban dApps)
+- Error rates and failed transactions
+
+**Web analytics:**
+- Google Analytics or Plausible for website
+- UTM parameters for campaign tracking
+- Conversion funnels (landing page → wallet connect → first transaction)
+
+**Social listening:**
+- Mention tracking (Twitter, Reddit, Discord)
+- Sentiment analysis
+- Competitor comparison
+
+### 4.4 Iteration and Optimization
+
+After launch, review weekly:
+
+1. **What's working?** (high engagement, user retention)
+2. **What's not?** (drop-off points, low conversion)
+3. **User feedback:** (feature requests, pain points)
+4. **Adjustments:** (messaging tweaks, new channels, feature prioritization)
+
+---
+
+## 5. Marketing Brief Template
+
+Use this template to create your own brief:
+
+---
+
+### **[Your dApp Name] Marketing Brief**
+
+**Date:** [Date]  
+**Version:** 1.0  
+**Owner:** [Marketing Lead Name]
+
+---
+
+#### **Executive Summary**
+
+[2-3 sentences: What is the dApp, what does it do, when is launch?]
+
+---
+
+#### **Product Overview**
+
+**Category:** [DeFi / Payments / NFT / Other]  
+**Platform:** [Stellar Classic / Soroban / Hybrid]  
+**Stage:** [Testnet / Mainnet Beta / Full Launch]  
+**Launch Date:** [Target date]
+
+**Key Features:**
+1. [Feature 1]
+2. [Feature 2]
+3. [Feature 3]
+
+**Technical Highlights:**
+- [e.g., Sub-cent fees, Soroban smart contracts, anchor integrations]
+
+---
+
+#### **Target Audience**
+
+**Primary Audience:**
+- [Segment 1: Description, size, behavior]
+- [Segment 2: Description, size, behavior]
+
+**Secondary Audience:**
+- [Segment 3: Description]
+
+**User Personas:**
+1. **[Persona Name]**
+   - Demographics: [Age, location, experience level]
+   - Goals: [What they want to achieve]
+   - Pain points: [Current challenges]
+   - Why this dApp: [How it solves their problem]
+
+---
+
+#### **Value Proposition**
+
+**Core Message:**  
+[One-sentence value prop]
+
+**Key Benefits:**
+1. [Benefit 1: Why it matters to users]
+2. [Benefit 2: Why it matters to users]
+3. [Benefit 3: Why it matters to users]
+
+**Differentiation:**  
+[How you're different from alternatives on Stellar and other chains]
+
+---
+
+#### **Marketing Objectives**
+
+**Goals (3 months post-launch):**
+- [e.g., 2,000 unique users]
+- [e.g., $500K TVL]
+- [e.g., 3,000 Twitter followers]
+- [e.g., 10 press mentions]
+
+**Success Metrics:**
+- Adoption: [Metric and target]
+- Engagement: [Metric and target]
+- Community: [Metric and target]
+
+---
+
+#### **Distribution Strategy**
+
+**Phase 1: Pre-Launch (Weeks -4 to 0)**
+- [ ] Announce on Stellar Community Forum
+- [ ] Publish blog post on Medium
+- [ ] Create Twitter thread with demo video
+- [ ] Reach out to Stellar wallets for integration
+- [ ] Set up Discord/Telegram community
+- [ ] Prepare documentation site
+
+**Phase 2: Launch (Week 0)**
+- [ ] Press release to crypto media
+- [ ] Post in all Stellar community channels
+- [ ] Launch Twitter ad campaign (if budget)
+- [ ] Host AMA on Discord
+- [ ] Email announcement to waitlist
+
+**Phase 3: Post-Launch (Weeks 1-12)**
+- [ ] Weekly feature highlight posts
+- [ ] User testimonial content
+- [ ] Partner integration announcements
+- [ ] Tutorial video series
+- [ ] Community events and contests
+
+**Channels:**
+- Social: [List platforms and posting frequency]
+- Community: [List forums, Discord, Telegram]
+- Content: [Blog, YouTube, documentation]
+- Partnerships: [Wallets, anchors, other dApps]
+- Paid: [If applicable: ads, sponsorships]
+
+---
+
+#### **Messaging Framework**
+
+**Elevator Pitch:**  
+[30-second description for anyone asking "What is this?"]
+
+**Technical Pitch:**  
+[For developers and technical audiences]
+
+**User-Focused Pitch:**  
+[For end-users, focused on benefits not features]
+
+**Key Talking Points:**
+- [Point 1: Stellar's advantages]
+- [Point 2: Your unique approach]
+- [Point 3: Real-world impact]
+
+---
+
+#### **Content Calendar (First 4 Weeks)**
+
+| Week | Content Type | Platform | Topic/Message |
+|------|--------------|----------|---------------|
+| -1 | Teaser post | Twitter | Countdown to launch |
+| 0 | Launch announcement | All channels | We're live! |
+| 1 | Tutorial video | YouTube | How to use [feature] |
+| 1 | Blog post | Medium | Why we built on Stellar |
+| 2 | User story | Twitter | First user milestone |
+| 3 | Feature deep dive | Blog | Technical architecture |
+| 4 | AMA | Discord | Q&A with community |
+
+---
+
+#### **Budget (Optional)**
+
+| Category | Item | Cost |
+|----------|------|------|
+| Content | Video production | $X |
+| Paid ads | Twitter ads | $X |
+| Events | Conference booth | $X |
+| Tools | Analytics, social tools | $X |
+| **Total** | | **$X** |
+
+---
+
+#### **Team and Responsibilities**
+
+| Role | Name | Responsibilities |
+|------|------|------------------|
+| Marketing Lead | [Name] | Strategy, oversight, partnerships |
+| Content Creator | [Name] | Blog posts, social media, videos |
+| Community Manager | [Name] | Discord, Telegram, user support |
+| Developer Advocate | [Name] | Technical docs, dev outreach |
+
+---
+
+#### **Risks and Mitigation**
+
+**Risk:** [e.g., Low initial adoption]  
+**Mitigation:** [e.g., Incentive program, user onboarding improvements]
+
+**Risk:** [e.g., Negative press or security concerns]  
+**Mitigation:** [e.g., Audit reports, transparent communication]
+
+**Risk:** [e.g., Wallet integration delays]  
+**Mitigation:** [e.g., Web-based wallet option, backup integrations]
+
+---
+
+#### **Timeline**
+
+```text
+Week -4: Finalize messaging, create assets
+Week -3: Begin pre-launch content, reach out to partners
+Week -2: Launch documentation, open beta testing
+Week -1: Press outreach, teasers on social media
+Week  0: LAUNCH - all channels activated
+Week  1: Monitor metrics, user support, first content pieces
+Week  2: Publish case studies, tutorial videos
+Week  4: Review metrics, adjust strategy
+Week  8: Milestone celebration, expand channels
+Week 12: Retrospective, plan next phase
+```
+
+---
+
+### **Appendix**
+
+**Links:**
+- Website: [URL]
+- Documentation: [URL]
+- GitHub: [URL]
+- Twitter: [URL]
+- Discord: [URL]
+
+**Assets:**
+- Brand guidelines: [Link]
+- Press kit: [Link]
+- Demo videos: [Link]
+- Screenshots: [Link]
+
+---
+
+## Using This Template
+
+1. **Customize for your dApp:** Replace placeholders with your specific information
+2. **Get team alignment:** Share with co-founders, developers, and advisors for feedback
+3. **Treat as living document:** Update as you learn what works and what doesn't
+4. **Share with partners:** Send relevant sections to wallets, anchors, and media contacts
+5. **Track progress:** Check off completed items and monitor metrics weekly
+
+---
+
+## Additional Resources
+
+**Stellar Ecosystem:**
+- [Stellar Community Forum](https://stellar.org/community)
+- [Stellar Developer Discord](https://discord.gg/stellardev)
+- [Soroban Documentation](https://soroban.stellar.org)
+- [Stellar Ecosystem Projects](https://stellar.org/ecosystem)
+
+**Marketing Tools:**
+- Analytics: Google Analytics, Plausible, Mixpanel
+- Social management: Buffer, Hootsuite
+- Community: Discord, Telegram
+- Content: Medium, YouTube, Substack
+
+**Learning:**
+- Crypto marketing case studies
+- Launch post-mortems from other Stellar dApps
+- Meridian conference talks on ecosystem growth
+
+---
+
+## Conclusion
+
+A well-crafted marketing brief aligns your team, focuses your launch efforts, and provides a clear roadmap for reaching your target users. The Stellar ecosystem offers unique advantages — speed, low cost, built-in features — that resonate with both crypto-native users and those new to blockchain. By understanding your audience, articulating your value proposition clearly, and leveraging the right distribution channels, you can successfully launch and grow your Stellar dApp.
+
+Start with this template, adapt it to your specific needs, and iterate based on what you learn from your users. Good marketing is a continuous conversation with your community, not a one-time launch event.


### PR DESCRIPTION
… 

Add four comprehensive documentation guides to routes-d folder:

- Accessibility Policy Guide (#963)
  * WCAG conformance targets and standards
  * User reporting procedures and workflows
  * Remediation processes and timelines
  * Customizable policy template
  * 527 lines of guidance for dApp accessibility

- Marketing Brief Guide (#969)
  * Audience identification and segmentation
  * Message development and value proposition
  * Distribution channel strategies
  * Success metrics and tracking
  * 565 lines with actionable marketing template

- Caching Layer Tutorial (#952)
  * Horizon API caching with React Query
  * Cache invalidation strategies (time-based, event-based)
  * Staleness bounds configuration
  * Complete working TypeScript examples
  * 1044 lines with production-ready code

- Visual Regression Testing Guide (#947)
  * Playwright-based visual testing setup
  * Baseline management and update workflows
  * Flakiness mitigation strategies
  * CI/CD integration patterns
  * 1019 lines with working examples

All guides follow existing MDX frontmatter conventions and writing style. Content is scoped to documentation only as per constraints.

closes #963
closes #969
closes #952
closes #947