### PR TITLE
docs: fix JS flag status, trustlines API, and broken code fences

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -14,7 +14,7 @@ Use the table below to find the exact flag name, alias, default, and a short des
 | Category     | Flag                     | Alias | Default                               | Description                                                                  |
 | ------------ | ------------------------ | ----- | ------------------------------------- | ---------------------------------------------------------------------------- |
 | Language     | `--typescript`           | `-t`  | `true`                                | Generate a TypeScript project (default).                                     |
-| Language     | `--javascript`           | `-j`  | `false`                               | Generate a JavaScript project instead of TypeScript; planned future support. |
+| Language     | `--javascript`           | `-j`  | `false`                               | Generate a JavaScript project instead of TypeScript. Supported today for the default template only. |
 | Network      | `--horizon-url <url>`    |       | `https://horizon-testnet.stellar.org` | Override the default Horizon API endpoint.                                   |
 | Network      | `--soroban-url <url>`    |       | `https://soroban-testnet.stellar.org` | Override the default Soroban RPC endpoint.                                   |
 | Wallet       | `--wallets <list>`       | `-w`  | `freighter,albedo,lobstr`             | Comma-separated list of wallet adapters to include.                          |
@@ -38,6 +38,23 @@ Most options are used with the primary scaffold command:
 ```bash
 npx nextellar my-app --wallets freighter,xbull --package-manager pnpm --skip-install
 ```
+
+Generate a JavaScript project with `-j` / `--javascript` (default template only):
+
+```bash
+npx nextellar my-app --javascript
+```
+
+Combining `--javascript` with `--template minimal` or `--template defi` fails immediately:
+
+```bash
+npx nextellar my-app --javascript --template minimal
+npx nextellar my-app --javascript --template defi
+# --javascript (or --no-typescript) currently only supports the default template.
+# Use --template default or omit --javascript/--no-typescript.
+```
+
+See [Scaffolding Templates](/docs/cli/templates) for the restriction note.
 
 Without `--force`, scaffolding into a directory that already exists fails immediately:
 

--- a/docs/cli/templates.mdx
+++ b/docs/cli/templates.mdx
@@ -67,21 +67,27 @@ npx nextellar my-app --template defi
 | Soroban contract calls / events | ✅        | –         | –      |
 | Transaction history             | ✅        | –         | –      |
 | Network switcher                | ✅        | –         | –      |
-| `--javascript` support          | ✅        | –         | ✅     |
+| `--javascript` support          | ✅        | –         | –      |
 
 ## JavaScript variant
 
-Add `-j` / `--javascript` to scaffold `.jsx`/`.js` files instead of TypeScript. Only `default` and `defi` ship a JavaScript variant today; `minimal` does not.
+Add `-j` / `--javascript` to scaffold `.jsx`/`.js` files instead of TypeScript. This ships today for the **default** template only. Combining it with `--template minimal` or `--template defi` fails fast before scaffolding:
 
 ```bash
 npx nextellar my-app --javascript
-npx nextellar my-app --javascript --template defi
 ```
+
+<Note>
+  `--javascript` only supports the default template. With `--template minimal` or `--template defi` the CLI exits with:
+
+  `--javascript (or --no-typescript) currently only supports the default template. Use --template default or omit --javascript/--no-typescript.`
+</Note>
 
 ```bash
 npx nextellar my-app --javascript --template minimal
-# Template "minimal" is not available for JavaScript yet.
-# Please use the default or defi template with --javascript.
+npx nextellar my-app --javascript --template defi
+# --javascript (or --no-typescript) currently only supports the default template.
+# Use --template default or omit --javascript/--no-typescript.
 ```
 
 See [Using JavaScript](/docs/getting-started/javascript) for what else differs between the TypeScript and JavaScript scaffolds, and the open CLI issues tracking JS/TS parity.

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -10,7 +10,6 @@ Welcome to Nextellar docs. This is the getting started page.
 
 ## Quickstart
 
-````bash
-npx nextellar create my-app
 ```bash
-````
+npx nextellar create my-app
+```

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -18,7 +18,7 @@ Before you begin, ensure you have:
 
 ### Check Your Node Version
 
-`````bash
+```bash
 node --version
 # Should output v20.18.0 or higher
 ```
@@ -54,9 +54,9 @@ Customize your project during scaffolding:
 
 ### Basic Usage
 
-````bash
-npx nextellar <project-name> [options]
 ```bash
+npx nextellar <project-name> [options]
+```
 
 ### Available Options
 
@@ -76,7 +76,7 @@ npx nextellar <project-name> [options]
 
 ```bash
 npx nextellar my-app --package-manager pnpm
-`````
+```
 
 **Skip installation (install later):**
 
@@ -156,10 +156,10 @@ README.md
 
 After installation completes:
 
-````bash
+```bash
 cd my-stellar-app
 npm run dev
-```bash
+```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. You should see the Nextellar starter page with a wallet connect button!
 
@@ -183,7 +183,7 @@ If `npx nextellar my-stellar-app` stops while installing dependencies, retry man
 ```bash
 cd my-stellar-app
 npm install
-```bash
+```
 
 Fixes:
 
@@ -197,7 +197,7 @@ If the scaffold fails before install, confirm your Node version:
 
 ```bash
 node --version
-```bash
+```
 
 Fixes:
 
@@ -210,7 +210,7 @@ If `npm run dev` fails because the port is occupied:
 
 ```bash
 npm run dev -- -p 3001
-```bash
+```
 
 Fix:
 
@@ -222,7 +222,7 @@ If `npm run build` reports TypeScript or type-check errors:
 
 ```bash
 npm run build
-```bash
+```
 
 Fixes:
 
@@ -236,7 +236,7 @@ If a dependency is missing after installation:
 ```bash
 rm -rf node_modules package-lock.json
 npm install
-```bash
+```
 
 Fixes:
 
@@ -288,4 +288,3 @@ Fixes:
 - [Read the FAQ](/docs/troubleshooting/faq)
 - [Report an issue](https://github.com/nextellarlabs/nextellar/issues)
 - [Join discussions](https://github.com/nextellarlabs/nextellar/discussions)
-````

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -20,7 +20,7 @@ A payment app with:
 
 ## Step 1: Create Your Project
 
-````bash
+```bash
 npx nextellar stellar-payment-app
 cd stellar-payment-app
 npm run dev
@@ -193,7 +193,7 @@ export default function Home() {
     </div>
   );
 }
-```typescript
+```
 
 ## Step 4: Test Your App
 
@@ -252,7 +252,7 @@ export default function TransactionHistory() {
     </div>
   );
 }
-```typescript
+```
 
 Then add it to your `page.tsx`:
 
@@ -267,7 +267,7 @@ import TransactionHistory from '@/components/TransactionHistory';
     </div>
   );
 }
-```json
+```
 
 ## What You've Learned
 
@@ -365,4 +365,3 @@ In just 10 minutes, you've built a complete Stellar payment app with:
 <p className="text-sm text-center text-muted-foreground mt-8">
   <a href="#"> Back to top</a>
 </p>
-````

--- a/docs/hooks/index.mdx
+++ b/docs/hooks/index.mdx
@@ -92,7 +92,7 @@ Nextellar's hooks are designed to stay out of your way and let you build fast. E
 
 All hooks automatically consume configuration from `WalletProvider` when available:
 
-`````tsx
+```tsx
 // Provider sets global config
 <WalletProvider horizonUrl="https://horizon.stellar.org">
   <App />
@@ -119,12 +119,12 @@ const { balances } = useStellarBalances(publicKey, {
 
 Hooks work without a provider too:
 
-````tsx
+```tsx
 // No WalletProvider needed
 const { balances } = useStellarBalances(publicKey, {
   horizonUrl: 'https://horizon-testnet.stellar.org',
 });
-```css
+```
 
 ---
 
@@ -140,13 +140,13 @@ const { data, loading, error, refresh } = useSomeHook();
 if (loading) return <Spinner />;
 if (error) return <button onClick={refresh}>Retry</button>;
 return <DisplayData data={data} />;
-`````
+```
 
 ### XDR Building Pattern
 
 Transaction hooks follow a consistent pattern for wallet integration:
 
-````tsx
+```tsx
 // 1. Build unsigned XDR
 const xdr = await buildPaymentXDR({ from, to, amount });
 
@@ -155,7 +155,7 @@ const signedXdr = await wallet.signTransaction(xdr);
 
 // 3. Submit signed transaction
 const result = await submitSignedXDR(signedXdr);
-```typescript
+```
 
 ---
 
@@ -165,4 +165,3 @@ const result = await submitSignedXDR(signedXdr);
 - [CLI Commands](/docs/cli/commands) — Scaffold options
 - [WalletProvider](/docs/hooks/wallet-provider) — Global wallet context
 - [Hook Error Handling](/docs/guides/hook-error-handling) — Shared recovery patterns and common failures
-````

--- a/docs/hooks/use-soroban-contract.mdx
+++ b/docs/hooks/use-soroban-contract.mdx
@@ -18,7 +18,7 @@ The `useSorobanContract` hook provides a complete interface for interacting with
 
 ## Basic Usage
 
-`````tsx
+```tsx
 import { useSorobanContract } from '@/hooks/useSorobanContract';
 
 export default function ContractDemo() {
@@ -44,13 +44,13 @@ export default function ContractDemo() {
 
 ### Parameters
 
-````typescript
+```typescript
 useSorobanContract(options: {
   contractId: string;
   sorobanRpc?: string;
   network?: 'TESTNET' | 'PUBLIC';
 }): SorobanContractReturn
-```css
+```
 
 | Parameter    | Type                    | Default                                 | Description                  |
 | ------------ | ----------------------- | --------------------------------------- | ---------------------------- |
@@ -71,7 +71,7 @@ interface SorobanContractReturn {
   loading: boolean;
   error: Error | null;
 }
-```typescript
+```
 
 ## Methods
 
@@ -89,7 +89,7 @@ const result = await callFunction('transfer', [
   'GDEF456...', // to
   1000, // amount
 ]);
-`````
+```
 
 **Supported Argument Types:**
 
@@ -222,13 +222,13 @@ if (loading) return <Spinner />;
 
 ### 3. Validate Contract Responses
 
-````tsx
+```tsx
 const result = await callFunction('get_balance', [address]);
 
 if (typeof result !== 'number') {
   throw new Error('Invalid balance returned');
 }
-```typescript
+```
 
 ## Related Hooks
 
@@ -262,4 +262,3 @@ if (typeof result !== 'number') {
     <span className="text-sm text-muted-foreground block">Scaffold, deploy, and invoke a Soroban contract end to end</span>
   </a>
 </div>
-````

--- a/docs/hooks/use-stellar-payment.mdx
+++ b/docs/hooks/use-stellar-payment.mdx
@@ -18,7 +18,7 @@ The `useStellarPayment` hook provides advanced utilities for building, signing, 
 
 ## Basic Usage
 
-`````tsx
+```tsx
 import { useStellarPayment } from '@/hooks/useStellarPayment';
 
 export default function PaymentBuilder() {
@@ -51,12 +51,12 @@ export default function PaymentBuilder() {
 
 ### Parameters
 
-````typescript
+```typescript
 useStellarPayment(options?: {
   horizonUrl?: string;
   network?: 'TESTNET' | 'PUBLIC';
 }): PaymentHookReturn
-```css
+```
 
 | Parameter    | Type                    | Default                                 | Description        |
 | ------------ | ----------------------- | --------------------------------------- | ------------------ |
@@ -73,7 +73,7 @@ interface PaymentHookReturn {
     params: PaymentParams & { secret: string }
   ) => Promise<PaymentResult>;
 }
-`````
+```
 
 ### Types
 
@@ -124,7 +124,7 @@ console.log(xdr); // "AAAAAgAAAAC..."
 
 Submit a signed transaction XDR to the network.
 
-````tsx
+```tsx
 const result = await submitSignedXDR(signedXDR);
 
 if (result.success) {
@@ -132,7 +132,7 @@ if (result.success) {
 } else {
   console.error('Failed:', result.error);
 }
-```bash
+```
 
 **Returns:**
 
@@ -152,7 +152,7 @@ const result = await signAndSubmitWithSecret({
   amount: '10',
   secret: 'SABC123...', // Never use in production!
 });
-````
+```
 
 > **Warning**: Never use this method in production. Secret keys should never be handled in client-side code. Use external wallet signing instead.
 
@@ -319,7 +319,7 @@ await buildPaymentXDR({
 
 ### 4. Verify Before Submitting
 
-````tsx
+```tsx
 const xdr = await buildPaymentXDR(params);
 
 // Show confirmation to user
@@ -327,7 +327,7 @@ const confirmed = confirm(`Send ${params.amount} XLM to ${params.to}?`);
 if (!confirmed) return;
 
 // Then sign and submit
-```typescript
+```
 
 ## Related Hooks
 
@@ -360,4 +360,3 @@ if (!confirmed) return;
 <p className="text-sm text-center text-muted-foreground mt-8">
   <a href="#"> Back to top</a>
 </p>
-````

--- a/docs/hooks/use-stellar-wallet.mdx
+++ b/docs/hooks/use-stellar-wallet.mdx
@@ -19,7 +19,7 @@ The `useStellarWallet` hook provides a complete solution for connecting to Stell
 
 ## Basic Usage
 
-`````tsx
+```tsx
 import { useStellarWallet } from '@/hooks/useStellarWallet';
 
 export default function WalletDemo() {
@@ -46,12 +46,12 @@ export default function WalletDemo() {
 
 ### Parameters
 
-````typescript
+```typescript
 useStellarWallet(
   horizonUrl?: string,
   network?: string
 ): StellarWalletState
-```css
+```
 
 | Parameter    | Type     | Default                                 | Description                |
 | ------------ | -------- | --------------------------------------- | -------------------------- |
@@ -73,7 +73,7 @@ interface StellarWalletState {
     opts: PaymentOptions
   ) => Promise<HorizonApi.SubmitTransactionResponse>;
 }
-`````
+```
 
 #### Properties
 
@@ -81,11 +81,11 @@ interface StellarWalletState {
 
 Whether a wallet is currently connected.
 
-````tsx
+```tsx
 {
   connected && <p>Wallet is connected!</p>;
 }
-```css
+```
 
 ---
 
@@ -95,7 +95,7 @@ The connected wallet's Stellar public key (G-address).
 
 ```tsx
 <p>Your address: {publicKey}</p>
-```css
+```
 
 ---
 
@@ -105,7 +105,7 @@ Name of the connected wallet (e.g., "Freighter", "Albedo").
 
 ```tsx
 <p>Connected via {walletName}</p>
-```css
+```
 
 ---
 
@@ -120,7 +120,7 @@ interface Balance {
   asset_code?: string;
   asset_issuer?: string;
 }
-````
+```
 
 ```tsx
 {
@@ -138,7 +138,7 @@ interface Balance {
 
 Opens the wallet selection modal and connects to the chosen wallet.
 
-````tsx
+```tsx
 const handleConnect = async () => {
   try {
     await connect();
@@ -149,7 +149,7 @@ const handleConnect = async () => {
     }
   }
 };
-```css
+```
 
 ---
 
@@ -159,7 +159,7 @@ Disconnects the current wallet and clears all state.
 
 ```tsx
 <button onClick={disconnect}>Disconnect</button>
-```bash
+```
 
 ---
 
@@ -172,7 +172,7 @@ const handleRefresh = async () => {
   await refreshBalances();
   console.log('Balances updated!');
 };
-```css
+```
 
 ---
 
@@ -187,7 +187,7 @@ interface PaymentOptions {
   asset?: 'XLM' | { code: string; issuer: string };
   memo?: string;
 }
-````
+```
 
 ```tsx
 const result = await sendPayment({
@@ -235,7 +235,7 @@ await sendPayment({
 
 Show all assets the account holds:
 
-````tsx
+```tsx
 function BalanceList() {
   const { balances, connected } = useStellarWallet();
 
@@ -264,7 +264,7 @@ function BalanceList() {
     </div>
   );
 }
-```bash
+```
 
 ### Auto-Refresh Balances After Payment
 
@@ -290,7 +290,7 @@ function SendPaymentWithRefresh() {
 
   return <button onClick={handleSend}>Send 10 XLM</button>;
 }
-````
+```
 
 ### Handling Unfunded Accounts
 
@@ -503,10 +503,10 @@ const handleConnect = async () => {
 
 **Solution**:
 
-````tsx
+```tsx
 // Manually refresh after funding
 await refreshBalances();
-```bash
+```
 
 ### Payment Fails with "op_underfunded"
 
@@ -559,4 +559,3 @@ await refreshBalances();
 <p className="text-sm text-center text-muted-foreground mt-8">
   <a href="#"> Back to top</a>
 </p>
-````

--- a/docs/hooks/use-trustlines.mdx
+++ b/docs/hooks/use-trustlines.mdx
@@ -8,6 +8,8 @@ date: 2026-06-02
 
 The `useTrustlines` hook manages asset trustlines, allowing accounts to hold custom Stellar assets. It provides methods to query existing trustlines, build change-trust transactions, and submit them to the network.
 
+**Available in templates:** `default`, `defi`, `js` (not `minimal`)
+
 ## Features
 
 - **Query Trustlines**: Fetch and list all active trustlines for an account
@@ -15,7 +17,7 @@ The `useTrustlines` hook manages asset trustlines, allowing accounts to hold cus
 - **Dev-Only Submission**: Sign and submit with secret key (testing only)
 - **Authorization Tracking**: Monitor asset authorization status
 - **Custom Limits**: Set trust limits on assets
-- **Auto-Consume Config**: Automatically uses `WalletProvider` settings as fallback
+- **Auto-Consume Config**: Uses `WalletProvider` `horizonUrl` as fallback
 
 ## Basic Usage
 
@@ -60,6 +62,9 @@ export default function TrustlineManager({ publicKey }: { publicKey: string }) {
             <span> (Issuer: {tl.asset_issuer.substring(0, 8)}...)</span>
             <span> Balance: {tl.balance || '0'}</span>
             {tl.limit && <span> Limit: {tl.limit}</span>}
+            {tl.authorized !== undefined && (
+              <span>{tl.authorized ? ' Authorized' : ' Not authorized'}</span>
+            )}
           </div>
         ))
       )}
@@ -76,15 +81,23 @@ export default function TrustlineManager({ publicKey }: { publicKey: string }) {
 useTrustlines(
   publicKey?: string | null,
   options?: {
-    horizonUrl?: string;        // Defaults to WalletProvider config or testnet
+    horizonUrl?: string;
     network?: 'TESTNET' | 'PUBLIC';
   }
 ): TrustlinesState
 ```
 
+| Parameter    | Type                    | Default                                          | Description                                         |
+| ------------ | ----------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| `publicKey`  | `string \| null`        | `undefined`                                      | Account to load trustlines for                      |
+| `horizonUrl` | `string`                | WalletProvider config or `https://horizon-testnet.stellar.org` | Horizon server URL                    |
+| `network`    | `'TESTNET' \| 'PUBLIC'` | `'TESTNET'`                                      | Network passphrase used when building transactions  |
+
+`horizonUrl` falls back to `WalletProvider`. `network` does **not** — it defaults to `'TESTNET'` unless you pass it in `options`.
+
 ### Return Value
 
-````typescript
+```typescript
 interface TrustlinesState {
   trustlines: Trustline[];
   loading: boolean;
@@ -98,7 +111,12 @@ interface TrustlinesState {
   submitChangeTrustWithSecret: (
     xdr: string,
     secret: string
-  ) => Promise<{ success: boolean; hash?: string; error?: string }>;
+  ) => Promise<{
+    success: boolean;
+    hash?: string;
+    raw?: unknown;
+    error?: string;
+  }>;
 }
 ```
 
@@ -113,6 +131,8 @@ interface Trustline {
   authorized?: boolean;
 }
 ```
+
+Trustlines are parsed from Horizon `account.balances` entries where `asset_type !== 'native'`. `authorized` maps from Horizon `is_authorized`.
 
 ## Examples
 
@@ -131,6 +151,15 @@ const xdr = await buildChangeTrustXDR({
 // Sign with Freighter or other wallet
 const signedXdr = await freighter.signTransaction(xdr);
 ```
+
+`buildChangeTrustXDR` validates the asset before talking to Horizon. Invalid input throws:
+
+- `'Invalid asset code: must be 1-12 alphanumeric characters'`
+- `'Invalid asset issuer: must be a valid Stellar public key'`
+- `'Asset limit must be a positive number'` (the string `"0"` is allowed and removes the trustline)
+- `'Public key required to build change trust XDR'`
+
+If the account is not on the network yet, it throws `Account {publicKey} not found. Account may need funding.`
 
 ### Dev-Only: Submit with Secret Key
 
@@ -157,9 +186,11 @@ if (result.success) {
 }
 ```
 
+Validation failures (bad secret, XDR, or mismatched key) **throw**. Horizon submission failures **return** `{ success: false, error, raw }` instead of throwing. On success the hook calls `refresh()` so `trustlines` updates.
+
 ### Remove Trustline
 
-To remove a trustline, set the limit to `"0"`:
+To remove a trustline, set the limit to `"0"` (Stellar `change_trust` with limit 0). The account's balance for that asset must already be 0 or Horizon will reject the operation:
 
 ```tsx
 const xdr = await buildChangeTrustXDR({
@@ -175,17 +206,33 @@ const xdr = await buildChangeTrustXDR({
 const { trustlines } = useTrustlines(publicKey);
 
 const hasUSDC = trustlines.some((tl) => tl.asset_code === 'USDC');
-````
+```
 
 ## Error Handling
 
 ### Invalid Asset Data
 
-Validate the asset code and issuer before building the transaction. A malformed issuer address should fail fast.
+`buildChangeTrustXDR` fails fast on malformed asset data. Catch the thrown `Error` and keep the form editable:
+
+```tsx
+try {
+  await buildChangeTrustXDR({ code: assetCode, issuer: assetIssuer });
+} catch (err) {
+  setFormError(err instanceof Error ? err.message : 'Invalid asset');
+}
+```
 
 ### Insufficient Reserve
 
-Explain that trustlines require account reserve when the wallet or Horizon returns an underfunded error.
+The hook does **not** check account reserve locally. Opening a trustline requires an additional base reserve (0.5 XLM) on the account. If Horizon rejects the submitted change-trust as underfunded, `submitChangeTrustWithSecret` returns `{ success: false, error }` with the Horizon result codes, typically:
+
+```text
+Transaction failed - op_low_reserve
+```
+
+Surface `result.error` (or the wallet/Horizon message when signing externally) and keep the form editable so the user can fund the account and retry.
+
+Unfunded accounts (Horizon 404) return an empty `trustlines` array from `refresh()`, and `buildChangeTrustXDR` throws `Account ${publicKey} not found. Account may need funding.`
 
 ### Submission Failures
 
@@ -207,38 +254,47 @@ if (error) {
 1. **Verify Issuer**: Always verify the asset issuer address before adding a trustline
 2. **Set Limits**: Use trust limits to cap your exposure to a particular asset
 3. **Remove Unused**: Remove trustlines for assets you no longer use (balance must be 0)
-4. **Check Authorization**: Some assets require issuer authorization before you can hold them
+4. **Check Authorization**: Some assets require issuer authorization before you can hold them (`authorized` on each `Trustline`)
 5. **Use Wallet Signing**: In production, always use `buildChangeTrustXDR` with external wallet signing
+6. **Leave Reserve**: Keep extra XLM so the account can fund the new trustline's base reserve
 
 ## Using with WalletProvider
 
-The hook automatically consumes configuration from `WalletProvider`:
+The hook uses `WalletProvider`'s `horizonUrl` as a fallback. Pass `network` yourself if you need mainnet transaction building:
 
-`````tsx
-// In your app layout
-<WalletProvider horizonUrl="https://horizon.stellar.org" network="PUBLIC">
-  <App />
-</WalletProvider>;
+```tsx
+import { WalletProvider } from '@/contexts';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+import { useTrustlines } from '@/hooks/useTrustlines';
 
-// In your component - hook uses provider's horizonUrl automatically
-function MyComponent() {
+export function App() {
+  return (
+    <WalletProvider horizonUrl="https://horizon.stellar.org" network="PUBLIC">
+      <TrustlineList />
+    </WalletProvider>
+  );
+}
+
+function TrustlineList() {
+  const { publicKey } = useStellarWallet();
   const { trustlines } = useTrustlines(publicKey);
-  // Uses mainnet automatically from provider
+  // Uses the provider horizonUrl (mainnet). network still defaults to TESTNET
+  // unless you pass it in options — see override below.
+  return <p>{trustlines.length} trustlines</p>;
 }
 ```
 
 Or override per-component:
 
-````tsx
+```tsx
 const { trustlines } = useTrustlines(publicKey, {
   horizonUrl: 'https://horizon-testnet.stellar.org',
   network: 'TESTNET',
 });
-```typescript
+```
 
 ## Related Hooks
 
 - [`useStellarBalances`](/docs/hooks/use-stellar-balances) - View asset balances
 - [`useStellarPayment`](/docs/hooks/use-stellar-payment) - Send custom assets
 - [`useStellarWallet`](/docs/hooks/use-stellar-wallet) - Wallet connection and management
-`````

--- a/docs/hooks/wallet-provider.mdx
+++ b/docs/hooks/wallet-provider.mdx
@@ -20,7 +20,7 @@ The `WalletProvider` component wraps your application to provide global wallet f
 
 Wrap your app with `WalletProvider`:
 
-`````tsx
+```tsx
 // app/layout.tsx or _app.tsx
 import { WalletProvider } from '@/contexts';
 
@@ -49,7 +49,7 @@ interface WalletProviderProps {
 
 ### Networks
 
-````tsx
+```tsx
 // Testnet (default)
 <WalletProvider>
   <App />
@@ -62,7 +62,7 @@ interface WalletProviderProps {
 >
   <App />
 </WalletProvider>
-```css
+```
 
 ---
 
@@ -98,11 +98,11 @@ function WalletStatus() {
     </div>
   );
 }
-`````
+```
 
 ### Return Value
 
-````typescript
+```typescript
 interface WalletContextState {
   connected: boolean;
   publicKey?: string;
@@ -113,7 +113,7 @@ interface WalletContextState {
   refreshBalances: () => Promise<void>;
   sendPayment?: (opts: PaymentOptions) => Promise<TransactionResponse>;
 }
-```css
+```
 
 > [!NOTE]
 > `sendPayment` is only available when a wallet is connected.
@@ -138,16 +138,16 @@ function MultiNetworkComponent() {
 
   return <div>...</div>;
 }
-````
+```
 
 ### Return Value
 
-````typescript
+```typescript
 interface WalletConfigContextState {
   horizonUrl: string;
   network: string;
 }
-```css
+```
 
 Returns `undefined` when used outside a `WalletProvider`.
 
@@ -198,18 +198,18 @@ function PaymentForm() {
     </form>
   );
 }
-````
+```
 
 ### PaymentOptions
 
-````typescript
+```typescript
 interface PaymentOptions {
   to: string;
   amount: string;
   asset?: 'XLM' | { code: string; issuer: string };
   memo?: string;
 }
-```css
+```
 
 ---
 
@@ -223,7 +223,7 @@ The provider automatically reconnects on page reload if the user was previously 
 // - stellar_wallet_id: wallet adapter ID
 // - stellar_wallet_address: public key
 // - stellar_wallet_name: wallet display name
-```css
+```
 
 ---
 
@@ -241,7 +241,7 @@ function useStellarBalances(publicKey, options = {}) {
 
   // ... rest of hook
 }
-```typescript
+```
 
 This means you can:
 
@@ -270,4 +270,3 @@ When child hooks fail, keep the provider state visible and let the child hook ow
 - [useStellarWallet](/docs/hooks/use-stellar-wallet) - Standalone wallet hook
 - [WalletConnectButton](/docs/hooks/wallet-connect-button) - Pre-built UI component
 - [useStellarBalances](/docs/hooks/use-stellar-balances) - Balance fetching
-````


### PR DESCRIPTION
## Summary

Fixes four assigned accuracy/rendering issues on the docs site.

- **#614** — `--javascript` is no longer described as “planned future support”. It ships today for the **default** template only. Combining it with `--template minimal` or `--template defi` fails fast with the CLI’s actual error:

  `--javascript (or --no-typescript) currently only supports the default template. Use --template default or omit --javascript/--no-typescript.`

  Verified against Nextellar `main` (v1.1.0 source): a real `--javascript --skip-install --defaults` scaffold produced `src/hooks/useTrustlines.js`; `--javascript --template minimal` and `--javascript --template defi` both printed the error above. (Published npm `1.0.4` still rejects JS entirely; this docs change tracks the current CLI source.)

- **#618** — `use-trustlines.mdx` API, add/remove (`limit: "0"`), options, return shape (`raw` on submit), and reserve caveats now match `src/templates/default/src/hooks/useTrustlines.ts`. The hook does not check reserve locally; Horizon underfunded submissions surface as `Transaction failed - op_low_reserve`. Added template availability (`default`, `defi`, `js` — not `minimal`) and repaired fences.

- **#627** — Fence-only pass on the six hooks pages with odd fence counts so code samples open and close correctly.

- **#626** — Fence-only pass on getting-started `index.mdx`, `installation.mdx`, and `quick-start.mdx`. Step 2 prose on Quick Start now sits outside the Step 1 bash block.

## Test plan

- [ ] `docs/cli/flags.mdx`: no “planned future support”; `--javascript` row + error note match the CLI fail-fast
- [ ] `docs/cli/templates.mdx`: comparison table `--javascript` column is default-only; Note quotes the exact error
- [ ] `docs/hooks/use-trustlines.mdx` renders with even fences, availability note, and API that matches the default template hook
- [ ] Getting-started and remaining hooks pages render with even fence counts; Quick Start Step 2 is prose, not swallowed by a code block
- [ ] Optional: `npx tsx bin/nextellar.ts my-app --javascript --skip-install --defaults` from nextellar `main`

Closes #614
Closes #618
Closes #626
Closes #627


Made with [Cursor](https://cursor.com)