### PR TITLE
docs: add transaction summary and risk drafts

### DIFF
--- a/routes-d/976-stellar-dapp-transaction-risk-scoring.mdx
+++ b/routes-d/976-stellar-dapp-transaction-risk-scoring.mdx
@@ -1,0 +1,138 @@
+---
+title: Stellar dApp Transaction Risk Scoring
+description: Build a simple, explainable transaction risk score from Stellar account, operation, and behavior signals.
+date: 2026-08-26
+---
+
+# Stellar dApp Transaction Risk Scoring
+
+Risk scoring helps a dApp decide when to allow, warn, slow down, or block a transaction. Keep the score explainable: users and reviewers should be able to see which signals contributed to a decision.
+
+---
+
+## Features to Compute
+
+Start with features that can be computed from Horizon data and local app context:
+
+| Feature | Example threshold | Why it matters |
+| --- | --- | --- |
+| Account age | Less than 1,000 ledgers | Very new accounts are common in Sybil attempts |
+| Transaction velocity | More than 20 ops in 5 minutes | Automation often creates tight bursts |
+| Round amount ratio | More than 80% round amounts | Repeated round values may indicate scripted behavior |
+| Destination reuse | Same destination more than 5 times in 10 minutes | Can indicate farming or circular flows |
+| Asset mismatch | Unexpected asset for this flow | Catches wrong-token approvals or spoofed UI state |
+| Device or session signal | Same session, many wallets | Connects off-chain behavior to on-chain actions |
+
+## Scoring Model
+
+Use additive scoring so every point has a reason:
+
+```ts
+export interface RiskSignal {
+  id: string;
+  points: number;
+  reason: string;
+}
+
+export interface RiskScore {
+  score: number;
+  level: 'low' | 'medium' | 'high' | 'critical';
+  signals: RiskSignal[];
+}
+
+export function scoreTransactionRisk(signals: RiskSignal[]): RiskScore {
+  const score = Math.min(
+    100,
+    signals.reduce((total, signal) => total + signal.points, 0)
+  );
+
+  const level = score >= 80
+    ? 'critical'
+    : score >= 60
+      ? 'high'
+      : score >= 30
+        ? 'medium'
+        : 'low';
+
+  return { score, level, signals };
+}
+```
+
+## Example Feature Builder
+
+```ts
+export function buildRiskSignals(input: {
+  accountAgeLedgers: number;
+  operationsInFiveMinutes: number;
+  roundAmountRatio: number;
+  repeatedDestinationCount: number;
+  expectedAsset: string;
+  actualAsset: string;
+}): RiskSignal[] {
+  const signals: RiskSignal[] = [];
+
+  if (input.accountAgeLedgers < 1000) {
+    signals.push({ id: 'new_account', points: 25, reason: 'Account is very new' });
+  }
+
+  if (input.operationsInFiveMinutes > 20) {
+    signals.push({ id: 'high_velocity', points: 30, reason: 'High recent transaction velocity' });
+  }
+
+  if (input.roundAmountRatio > 0.8) {
+    signals.push({ id: 'round_amounts', points: 10, reason: 'Mostly round-number amounts' });
+  }
+
+  if (input.repeatedDestinationCount > 5) {
+    signals.push({ id: 'destination_reuse', points: 20, reason: 'Destination reused repeatedly' });
+  }
+
+  if (input.actualAsset !== input.expectedAsset) {
+    signals.push({ id: 'asset_mismatch', points: 40, reason: 'Unexpected asset for this flow' });
+  }
+
+  return signals;
+}
+```
+
+## Thresholds and Actions
+
+| Score | Level | Suggested action |
+| --- | --- | --- |
+| 0-29 | Low | Allow silently |
+| 30-59 | Medium | Allow with monitoring or a soft warning |
+| 60-79 | High | Require an extra confirmation or slow the flow |
+| 80-100 | Critical | Block and send to review |
+
+Treat thresholds as policy configuration, not hardcoded truth. Different dApps have different risk tolerance.
+
+## Displaying the Result
+
+Show the risk level and the main reasons, not a mysterious number:
+
+```tsx
+function RiskNotice({ result }: { result: RiskScore }) {
+  if (result.level === 'low') return null;
+
+  return (
+    <div role="alert" className="rounded-lg border border-amber-300 p-4">
+      <p className="font-semibold">Extra review recommended</p>
+      <ul className="mt-2 list-disc pl-5 text-sm">
+        {result.signals.map((signal) => (
+          <li key={signal.id}>{signal.reason}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+## Accuracy Notes
+
+Risk scores are decision-support signals, not proof of fraud. Make sure any automatic block can be reviewed, and log the signals that contributed to the score so support and compliance teams can explain the result later.
+
+## Related Docs
+
+- [Fraud Detection Signals](/docs/guides/fraud-detection-signals)
+- [Transaction Lifecycle](/docs/guides/transaction-lifecycle)
+- [dApp DoS Hardening](/docs/guides/dapp-dos-hardening)

--- a/routes-d/978-inline-transaction-summaries.mdx
+++ b/routes-d/978-inline-transaction-summaries.mdx
@@ -1,0 +1,90 @@
+---
+title: Inline Transaction Summaries
+description: Show compact transaction summaries inside pending transaction UIs, with truncation rules and accessible copy patterns.
+date: 2026-08-26
+---
+
+# Inline Transaction Summaries
+
+Pending transactions should tell users what they are about to approve without forcing them to inspect raw XDR. A good inline summary is short, specific, and honest about what is known before ledger confirmation.
+
+---
+
+## What to Summarize
+
+Show the smallest set of details needed for a user to recognize the action:
+
+| Field | Why it matters |
+| --- | --- |
+| Action | Names the operation, such as payment, trustline, swap, or contract call |
+| Asset and amount | Confirms the value being moved or authorized |
+| Destination or counterparty | Helps users detect the wrong recipient before signing |
+| Network | Prevents testnet/mainnet confusion |
+| Fee | Sets expectations for the cost of submission |
+| Memo | Reveals attached payment context when present |
+
+For contract calls, include the contract alias, method name, and the user-facing effect. Avoid presenting decoded arguments as guaranteed outcomes until the transaction is confirmed.
+
+## Truncation Rules
+
+Use truncation for identifiers, not for value-critical fields.
+
+- Keep full amounts, asset codes, and network names visible.
+- Shorten public keys as `GABC...WXYZ` after showing the first 4 and last 4 characters.
+- Shorten transaction hashes as `abcd1234...ef90abcd` after confirmation.
+- Collapse long memos after 40 characters and provide the full value in a tooltip or details view.
+- Never truncate an error message so aggressively that the recovery action disappears.
+
+## Small Example
+
+```tsx
+function summarizePendingPayment(tx: {
+  amount: string;
+  assetCode: string;
+  destination: string;
+  fee: string;
+  network: 'testnet' | 'public';
+  memo?: string;
+}) {
+  const shortDestination = `${tx.destination.slice(0, 4)}...${tx.destination.slice(-4)}`;
+  const memo = tx.memo && tx.memo.length > 40
+    ? `${tx.memo.slice(0, 37)}...`
+    : tx.memo;
+
+  return {
+    title: `Send ${tx.amount} ${tx.assetCode}`,
+    description: `To ${shortDestination} on ${tx.network}`,
+    metadata: [
+      `Fee: ${tx.fee} stroops`,
+      memo ? `Memo: ${memo}` : 'No memo',
+    ],
+  };
+}
+```
+
+Render the result near the wallet confirmation button:
+
+```tsx
+<div role="status" aria-live="polite" className="rounded-lg border p-4">
+  <p className="text-sm font-semibold">Send 25 USDC</p>
+  <p className="text-xs text-muted-foreground">To GDQP...4XLA on testnet</p>
+  <p className="text-xs text-muted-foreground">Fee: 200 stroops</p>
+</div>
+```
+
+## Pending vs Confirmed Copy
+
+Before submission, use tentative language:
+
+| State | Copy pattern |
+| --- | --- |
+| Awaiting signature | "Review and approve this payment in your wallet." |
+| Submitted | "Transaction submitted. Waiting for ledger confirmation." |
+| Confirmed | "Transaction confirmed in ledger 123456." |
+| Failed | "Transaction failed. Review the message and try again." |
+
+## Related Docs
+
+- [Transaction Lifecycle](/docs/guides/transaction-lifecycle)
+- [Animated Transaction Status](/docs/guides/animated-transaction-status)
+- [Wallet UX Patterns](/docs/guides/wallet-ux-patterns)


### PR DESCRIPTION
Closes #979
Closes #977
Closes #976
Closes #978

## Summary
- Adds a draft guide for inline transaction summaries with truncation rules and a small React example.
- Adds a draft tutorial for Stellar dApp transaction risk scoring with features, thresholds, scoring helpers, and UI guidance.
- Keeps both changes scoped to `routes-d` as requested by the issue constraints.

## Validation
- Not run locally, per request.