### PR TITLE
docs(routes-d): SEP-31 sender, SEP-38 quotes, path payment cost analysis, Soroban swap tutorials

### DIFF
--- a/routes-d/909-sep38-quotes-integration-guide.mdx
+++ b/routes-d/909-sep38-quotes-integration-guide.mdx
@@ -1,0 +1,194 @@
+---
+title: SEP-38 Quotes Integration Guide
+description: A comprehensive guide to integrating SEP-38 anchor quotes — requesting indicative and firm quotes, honoring a quote through settlement, handling expiry, and a small worked example.
+date: 2026-08-26
+---
+
+# SEP-38 Quotes Integration Guide
+
+SEP-38 defines an API for requesting exchange-rate quotes from an anchor for converting between an off-chain asset (like a bank-rail currency) and a Stellar asset, or between two Stellar assets. It's the pricing layer that other SEPs — SEP-6, SEP-24, and SEP-31 — reference when a flow needs a firm, time-bound rate rather than an on-the-fly estimate. This guide covers the two kinds of quotes SEP-38 supports, how to request and then _honor_ a firm quote, expiry handling, and a small end-to-end example.
+
+---
+
+## 1. Indicative vs. Firm Quotes
+
+SEP-38 exposes two distinct operations, and mixing them up is the most common integration mistake:
+
+| Endpoint      | Purpose                                                                                              | Binding?                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `GET /prices` | Get indicative rates across all supported (sell, buy) asset pairs, or for one pair at a given amount | No — informational only, rate can move before you request a firm quote |
+| `POST /quote` | Request a firm, time-bound quote for one specific (sell, buy, amount) combination                    | Yes — the anchor commits to honoring `price` until `expires_at`        |
+
+Use `GET /prices` for UI display — showing a user "approximately X" before they commit to a flow — and reserve `POST /quote` for the moment right before you need a rate you can actually execute against. Calling `POST /quote` speculatively for every keystroke in an amount field burns the anchor's rate-lock capacity for quotes you'll never use; debounce or gate firm quote requests to an explicit user action.
+
+---
+
+## 2. Discovering Supported Pairs
+
+Firm quotes only work for pairs the anchor actually prices. Check first:
+
+```typescript
+import { StellarToml } from '@stellar/stellar-sdk';
+
+const toml = await StellarToml.Resolver.resolve('anchor.example.com');
+const quoteServer = toml.ANCHOR_QUOTE_SERVER;
+
+const infoRes = await fetch(`${quoteServer}/info`, {
+  headers: { Authorization: `Bearer ${sep10Token}` },
+});
+const { assets } = await infoRes.json();
+```
+
+`assets` lists each supported asset along with `sell_delivery_methods` / `buy_delivery_methods` (relevant when the off-chain side is a bank rail rather than a pure currency code) and country codes it's restricted to. An asset pair not listed here will be rejected by `POST /quote` — check `/info` once at startup or on a cache TTL, not on every quote request.
+
+---
+
+## 3. Requesting an Indicative Price
+
+```typescript
+const priceRes = await fetch(
+  `${quoteServer}/price?` +
+    new URLSearchParams({
+      context: 'sep31',
+      sell_asset: 'iso4217:NGN',
+      buy_asset:
+        'stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      sell_amount: '750000',
+    }),
+  { headers: { Authorization: `Bearer ${sep10Token}` } }
+);
+const indicative = await priceRes.json();
+// { total_price, price, sell_amount, buy_amount, fee: { total, asset, details? } }
+```
+
+`context` matters — it tells the anchor which regulatory/product flow this quote is for (`sep6`, `sep31`, or `sep24`), and anchors are allowed to price the same pair differently per context (a SEP-31 institutional corridor may get a tighter spread than a SEP-24 retail withdrawal). Always pass the context matching the flow you're actually integrating, not whichever one happens to be convenient.
+
+The distinction between `price` and `total_price`: `price` is the exchange rate before fees, `total_price` includes the anchor's fee baked into the effective rate. When displaying a rate to a user, `total_price` (or the derived `buy_amount`/`sell_amount` pair) is what they'll actually experience — `price` alone understates their real cost.
+
+---
+
+## 4. Requesting a Firm Quote
+
+Once the user commits (e.g., clicks "Confirm" on the indicative rate), lock it in:
+
+```typescript
+interface QuoteRequest {
+  context: 'sep6' | 'sep24' | 'sep31';
+  sell_asset: string;
+  buy_asset: string;
+  sell_amount?: string;
+  buy_amount?: string; // exactly one of sell_amount / buy_amount, not both
+  expire_after?: string; // ISO 8601, request a minimum validity window
+}
+
+async function requestFirmQuote(req: QuoteRequest, token: string) {
+  const res = await fetch(`${quoteServer}/quote`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(`Quote request failed: ${err.error ?? res.status}`);
+  }
+  return res.json();
+  // { id, expires_at, price, total_price, sell_asset, sell_amount, buy_asset, buy_amount, fee }
+}
+```
+
+Specify exactly one of `sell_amount` or `buy_amount` — the anchor computes the other side. Requesting both, or neither, is invalid per the spec and anchors will reject it with a 400. The response's `id` is what downstream flows (a SEP-31 `POST /transactions`, or a SEP-6/SEP-24 deposit/withdraw request) reference to bind the transaction to this exact rate.
+
+---
+
+## 5. Honoring the Quote
+
+"Honoring" a quote means the on-chain and off-chain legs of the transaction must match the amounts and assets the quote committed to — an anchor will reject or fail a transaction that references a `quote_id` but sends a different amount than `sell_amount` (or an incompatible asset). Concretely:
+
+```typescript
+async function executeAgainstQuote(quote: {
+  id: string;
+  sell_asset: string;
+  sell_amount: string;
+}) {
+  // The Stellar payment (or the fiat deposit, depending on direction) must move
+  // exactly quote.sell_amount of quote.sell_asset — not "close enough".
+  const [, code, issuer] = quote.sell_asset.split(':'); // "stellar:CODE:ISSUER"
+
+  const payment = Operation.payment({
+    destination: anchorDepositAddress,
+    asset: issuer ? new Asset(code, issuer) : Asset.native(),
+    amount: quote.sell_amount,
+  });
+
+  return payment;
+}
+```
+
+If the sell asset is off-chain (an `iso4217:` currency rather than a `stellar:` asset), the "execution" is the off-chain leg — e.g., completing a bank transfer for exactly that fiat amount — and the quote is instead honored by the anchor crediting the corresponding Stellar asset once that off-chain payment clears. Either direction, the contract is the same: **amount and asset must match the quote exactly**, and the quote's `id` must be threaded through to whichever SEP is orchestrating the transaction (a SEP-31 `POST /transactions` body's `quote_id` field, for instance) so the anchor can cross-reference the commitment.
+
+---
+
+## 6. Expiry Handling
+
+Every firm quote has an `expires_at`. Once past it, the anchor is no longer bound to `price`, and submitting against an expired quote fails at the orchestrating SEP's layer (e.g., SEP-31 rejects `POST /transactions` referencing an expired `quote_id`):
+
+```typescript
+function isQuoteExpired(quote: { expires_at: string }): boolean {
+  return new Date(quote.expires_at).getTime() <= Date.now();
+}
+
+async function getValidQuote(
+  req: QuoteRequest,
+  token: string,
+  cached?: { id: string; expires_at: string }
+) {
+  if (cached && !isQuoteExpired(cached)) {
+    return cached;
+  }
+  return requestFirmQuote(req, token);
+}
+```
+
+**Edge cases to handle explicitly:**
+
+- **Expiry during a multi-step flow.** If KYC (SEP-12) or user confirmation takes longer than the quote's validity window, re-quote before submitting rather than letting the transaction fail downstream — check `isQuoteExpired` immediately before the step that consumes the quote, not just when it was first fetched.
+- **Clock skew.** `expires_at` is the anchor's clock, not the client's. Build in a safety margin (treat a quote as expired 5-10 seconds before its literal `expires_at`) so a request that departs the client just before expiry doesn't arrive just after it.
+- **`expire_after` is a request, not a guarantee.** Passing `expire_after` in the quote request asks the anchor for at least that much validity; the anchor can return a shorter (or longer) window in `expires_at`. Always read the actual `expires_at` from the response — don't assume the requested duration was honored.
+- **Anchor doesn't support firm quotes for a pair.** Some anchors only implement `GET /price` and not `POST /quote` for certain corridors. Check `/info`'s per-asset capabilities before assuming `POST /quote` will succeed, and fall back to executing against the indicative price with wider slippage tolerance if firm quotes aren't offered.
+- **Quote amount doesn't match at settlement time.** If the off-chain or on-chain leg ends up sending a different amount than `sell_amount` (e.g., a bank wire arrives short due to intermediary fees), the anchor's reconciliation will flag the mismatch — this typically surfaces as the transaction stalling rather than an explicit error, so timeout-and-alert on transactions that don't progress within an expected window.
+
+---
+
+## 7. Worked Example: NGN to USDC Quote Lifecycle
+
+A sender wants to convert 750,000 NGN to USDC through an anchor that supports SEP-38:
+
+1. **Indicative check** — `GET /price?sell_asset=iso4217:NGN&buy_asset=stellar:USDC:...&sell_amount=750000` returns `total_price: "1550.00"`, i.e. roughly 483.87 USDC, shown to the user as an estimate.
+2. **User confirms** — client calls `POST /quote` with the same parameters plus `expire_after: "PT10M"` (request at least 10 minutes).
+3. **Anchor responds** — `{ id: "q-9f2b", expires_at: "2026-08-26T14:32:00Z", total_price: "1551.20", buy_amount: "483.51" }`. Note the rate moved slightly between the indicative check and the firm quote — this is expected and why the firm quote, not the earlier indicative one, is what gets executed against.
+4. **KYC completes** (via SEP-12, if this is part of a SEP-31 flow) with 6 minutes left before `expires_at`.
+5. **Transaction created** referencing `quote_id: "q-9f2b"` — the anchor validates the quote is still valid at creation time.
+6. **Settlement** — the fiat leg (750,000 NGN) is transferred off-chain; once confirmed, the anchor sends exactly 483.51 USDC to the sender's (or ultimate receiver's) Stellar account, matching the locked `buy_amount`.
+
+If step 4 had instead taken 11 minutes, the client should have detected `isQuoteExpired(quote)` returning true and requested a fresh quote before step 5, rather than letting the anchor reject the transaction creation call.
+
+---
+
+## Summary
+
+- `GET /price` is indicative and non-binding; `POST /quote` is firm and time-bound — don't treat them interchangeably.
+- Pass the correct `context` (`sep6`/`sep24`/`sep31`) since anchors may price the same pair differently per flow.
+- Specify exactly one of `sell_amount`/`buy_amount` per request; the anchor computes the other side.
+- Honoring a quote means matching its exact amount and asset at settlement — thread the `quote_id` through to whichever SEP orchestrates the transaction.
+- Always read the actual `expires_at` from the response, build in a clock-skew safety margin, and re-quote proactively if a multi-step flow risks running past expiry.
+
+---
+
+## Related
+
+- [Building a SEP-31 Sender Client](/routes-d/910-sep31-sender-client-tutorial) - Where SEP-38 quotes plug into a full transfer flow
+- [Anchor Onboarding with KYC](/docs/guides/anchor-onboarding-kyc) - SEP-6/SEP-12 fundamentals referenced alongside quotes
+- [Fiat Onramp Tutorial](/docs/guides/fiat-onramp-tutorial) - A deposit flow that can incorporate SEP-38 pricing

--- a/routes-d/910-sep31-sender-client-tutorial.mdx
+++ b/routes-d/910-sep31-sender-client-tutorial.mdx
@@ -1,0 +1,272 @@
+---
+title: Building a SEP-31 Sender Client
+description: A complete walkthrough for building the sending side of a SEP-31 cross-border payment — collecting sender/receiver info, running the transfer flow against a receiving anchor, and handling compliance touchpoints.
+date: 2026-08-26
+---
+
+# Building a SEP-31 Sender Client
+
+SEP-31 defines a direct, API-to-API payment flow between two regulated entities — a **sending anchor** and a **receiving anchor** — for cross-border payments where the end customer of the sending side never talks to the receiving anchor directly. This is the protocol behind "send money to a bank account in another country" flows, where the receiving anchor handles the off-chain payout (bank transfer, mobile money, cash pickup) after receiving a Stellar payment. This tutorial builds the **sending side**: the client your application runs to discover a receiving anchor's requirements, submit sender/receiver KYC, request a quote, and execute the on-chain leg of the transfer.
+
+---
+
+## 1. Where SEP-31 Sits Relative to SEP-12 and SEP-38
+
+SEP-31 doesn't carry KYC fields or pricing itself — it composes two other SEPs:
+
+| SEP    | Role in the flow                                                                                                                              |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| SEP-12 | Collects and submits sender and receiver KYC fields to the receiving anchor's `/customer` endpoint                                            |
+| SEP-38 | Requests a firm quote for the asset conversion (if the receiving anchor supports cross-asset payouts)                                         |
+| SEP-31 | Orchestrates the transaction: registers the payment intent, references the SEP-12 customer and SEP-38 quote, and tracks status through payout |
+
+A sender client needs all three integrated — SEP-31 alone only gets you a `transaction_id` and a Stellar destination to pay; it can't tell you what information the receiving anchor needs or what the receiver will actually get.
+
+---
+
+## 2. Discovering Receiving Anchor Capabilities
+
+Start from the receiving anchor's `stellar.toml`, which points to its `DIRECT_PAYMENT_SERVER`:
+
+```typescript
+import { StellarToml } from '@stellar/stellar-sdk';
+
+const toml = await StellarToml.Resolver.resolve('receiving-anchor.example.com');
+const sep31Server = toml.DIRECT_PAYMENT_SERVER;
+if (!sep31Server) {
+  throw new Error('Anchor does not advertise a SEP-31 endpoint');
+}
+```
+
+Then call `GET /info`, authenticated with a SEP-10 token (SEP-31 requires the sending anchor to authenticate as itself, not as an end user — this is anchor-to-anchor, not anchor-to-customer):
+
+```typescript
+const infoRes = await fetch(`${sep31Server}/info`, {
+  headers: { Authorization: `Bearer ${sep10Token}` },
+});
+const info = await infoRes.json();
+```
+
+The response lists, per supported destination asset, the required `sender_sep12_type` and `receiver_sep12_type` (which SEP-12 KYC field sets apply to each side), any `fields` specific to that corridor (e.g. a required transfer purpose code), and whether `quotes_supported` / `quotes_required` is set. Branch your client's KYC and quoting logic off this response — required fields vary by receiving anchor and by destination country, and a client hardcoded to one anchor's field set will break against another.
+
+---
+
+## 3. Collecting Sender and Receiver Information
+
+SEP-31 needs KYC for **both** parties, submitted via SEP-12 to the receiving anchor before the transaction is created:
+
+```typescript
+async function submitCustomer(
+  sep31Server: string,
+  sep10Token: string,
+  role: 'sender' | 'receiver',
+  fields: Record<string, string>
+): Promise<string> {
+  const res = await fetch(`${sep31Server}/customer`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${sep10Token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      ...fields,
+      type:
+        role === 'sender' ? info.sender_sep12_type : info.receiver_sep12_type,
+    }),
+  });
+  const body = await res.json();
+  return body.id; // SEP-12 customer id — reference this in the SEP-31 POST /transactions call
+}
+
+const senderId = await submitCustomer(sep31Server, sep10Token, 'sender', {
+  first_name: 'Jane',
+  last_name: 'Doe',
+  email_address: 'jane@example.com',
+});
+
+const receiverId = await submitCustomer(sep31Server, sep10Token, 'receiver', {
+  first_name: 'John',
+  last_name: 'Smith',
+  bank_account_number: '0123456789',
+  bank_number: 'ABCDEF01',
+});
+```
+
+**Important distinction:** the _sending anchor_ is your application, authenticated to the receiving anchor via its own SEP-10 token — not the end customer's. The sender and receiver KYC data belongs to your customers, but your service submits it on their behalf. Never let the receiver's bank details or the sender's PII sit in client-side state longer than needed to make this call; SEP-31 exists specifically so the receiving anchor (not the sending anchor's counterpart systems) is the one holding the regulated payout relationship.
+
+If `GET /customer` (checked before `PUT`) returns `status: "NEEDS_INFO"`, the response includes a `fields` object describing exactly what's missing — surface those field names to your KYC form rather than guessing, since required fields differ by corridor and by whether the receiving anchor's compliance provider flags a transaction for enhanced due diligence.
+
+---
+
+## 4. Requesting a Quote (When Supported)
+
+If `info.quotes_supported` is true for the corridor, get a firm quote before creating the transaction so the sender knows exactly what the receiver will get after conversion and anchor fees:
+
+```typescript
+const quoteRes = await fetch(`${quoteServer}/quote`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${sep10Token}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    context: 'sep31',
+    sell_asset:
+      'stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    buy_asset: 'iso4217:NGN',
+    sell_amount: '500',
+  }),
+});
+const quote = await quoteRes.json();
+```
+
+The returned `quote.id` gets referenced in the SEP-31 transaction creation call below — this locks in the rate for `quote.expires_at`. See the companion SEP-38 quotes guide for expiry handling and the full request/response shape; the short version for SEP-31 purposes is: **request the quote after both customers pass KYC, not before**, since a receiving anchor may reject a transaction referencing a quote if the sender or receiver hasn't been approved yet, and quotes typically expire on the order of minutes.
+
+---
+
+## 5. Creating the SEP-31 Transaction
+
+```typescript
+const txRes = await fetch(`${sep31Server}/transactions`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${sep10Token}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    amount: '500',
+    asset_code: 'USDC',
+    asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    quote_id: quote?.id,
+    sender_id: senderId,
+    receiver_id: receiverId,
+    fields: {
+      transaction: {
+        // Corridor-specific fields from GET /info, e.g. transfer purpose
+        purpose_of_payment: 'family_support',
+      },
+    },
+  }),
+});
+const tx = await txRes.json();
+// tx.id            — SEP-31 transaction id, use it to poll status
+// tx.stellar_account_id — where to send the Stellar payment
+// tx.stellar_memo_type / tx.stellar_memo — memo required to attribute the payment to this transaction
+```
+
+The receiving anchor responds with a Stellar account and, almost always, a required memo. **The memo is not optional decoration** — receiving anchors typically pool incoming payments into a single collection account and rely on the memo to attribute a payment to the correct SEP-31 transaction and, transitively, the correct receiver. Sending the payment without the specified memo (or with the wrong type — `text`, `id`, or `hash`) means the receiving anchor cannot reconcile the payment, and the payout to the receiver will stall or fail even though the funds arrived on-chain.
+
+---
+
+## 6. Executing the On-Chain Payment
+
+```typescript
+import {
+  Asset,
+  Operation,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  Memo,
+} from '@stellar/stellar-sdk';
+
+const account = await horizonServer.loadAccount(senderPublicKey);
+
+const memo =
+  tx.stellar_memo_type === 'hash'
+    ? Memo.hash(Buffer.from(tx.stellar_memo, 'base64'))
+    : tx.stellar_memo_type === 'id'
+      ? Memo.id(tx.stellar_memo)
+      : Memo.text(tx.stellar_memo);
+
+const payment = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.PUBLIC,
+})
+  .addOperation(
+    Operation.payment({
+      destination: tx.stellar_account_id,
+      asset: new Asset(
+        'USDC',
+        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+      ),
+      amount: '500',
+    })
+  )
+  .addMemo(memo)
+  .setTimeout(180)
+  .build();
+
+payment.sign(senderKeypair);
+await horizonServer.submitTransaction(payment);
+```
+
+Use a generous `setTimeout` (SEP-31 payouts are not instant, but the _Stellar leg_ still needs to submit within its time bounds) and confirm the memo type/value match the transaction response exactly — a mismatched memo is the most common integration bug in SEP-31 clients and is silent on the Stellar side (the payment succeeds; only the receiving anchor's reconciliation fails).
+
+---
+
+## 7. Polling Transaction Status
+
+```typescript
+async function pollSep31Status(
+  sep31Server: string,
+  sep10Token: string,
+  txId: string
+) {
+  for (let i = 0; i < 30; i++) {
+    const res = await fetch(`${sep31Server}/transactions/${txId}`, {
+      headers: { Authorization: `Bearer ${sep10Token}` },
+    });
+    const { transaction } = await res.json();
+
+    if (transaction.status === 'completed') return transaction;
+    if (transaction.status === 'error') {
+      throw new Error(
+        `SEP-31 transaction failed: ${transaction.status_eta ?? 'no detail provided'}`
+      );
+    }
+    if (transaction.status === 'pending_info_update') {
+      // Receiving anchor needs corrected/additional fields — see required_info_updates
+      throw new Error(
+        `Anchor requires updated info: ${JSON.stringify(transaction.required_info_updates)}`
+      );
+    }
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+  throw new Error('Timed out waiting for SEP-31 transaction to complete');
+}
+```
+
+Status values worth branching on explicitly: `pending_sender` (waiting on your side, e.g. the on-chain payment hasn't landed yet), `pending_receiver` (anchor is processing the payout), `pending_external` (payout initiated, awaiting confirmation from a downstream rail like a bank), `pending_info_update` (compliance needs more from sender or receiver), and terminal `completed` or `error`. Don't collapse these into a generic "processing" state in the UI — `pending_info_update` in particular requires user action and will never resolve on its own.
+
+---
+
+## 8. Compliance Touchpoints
+
+| Touchpoint                 | What to handle                                                                                                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Sender KYC rejected        | `GET /customer` returns `status: "REJECTED"` — the sending anchor's own compliance provider or the receiving anchor's did not approve; do not retry with the same data                                                   |
+| Receiver KYC incomplete    | Transaction stays `pending_info_update`; surface `required_info_updates` fields back to whoever is collecting receiver details                                                                                           |
+| Transaction amount limits  | `GET /info` includes `min_amount`/`max_amount` per asset — validate client-side before creating the transaction to avoid a rejected `POST /transactions`                                                                 |
+| Sanctions/travel-rule data | Some corridors require additional originator/beneficiary fields beyond basic KYC (address, source of funds) — these appear as extra `fields` in `GET /info` and must be collected before transaction creation, not after |
+| Quote expiry mid-flow      | If KYC takes long enough that the SEP-38 quote expires before `POST /transactions`, request a fresh quote — an expired `quote_id` is rejected by the receiving anchor                                                    |
+
+None of these are optional error handling — a sender client that only handles the happy path will fail in production the first time a receiving anchor's compliance provider flags a transaction, which happens routinely for cross-border payments above small thresholds.
+
+---
+
+## Summary
+
+- SEP-31 orchestrates a transfer but delegates KYC to SEP-12 and pricing to SEP-38 — a real sender client integrates all three.
+- Submit sender **and** receiver KYC via `PUT /customer` before creating the transaction; branch required fields off `GET /info` rather than hardcoding them.
+- Request a SEP-38 quote after KYC passes, not before, and re-quote if it expires during the flow.
+- The Stellar memo returned in `POST /transactions` is required for the receiving anchor to reconcile the payment — get its type and value exactly right.
+- Poll `GET /transactions/:id` and handle every status explicitly, especially `pending_info_update`, which needs user action to resolve.
+
+---
+
+## Related
+
+- [Anchor Onboarding with KYC](/docs/guides/anchor-onboarding-kyc) - SEP-6 and SEP-12 fundamentals
+- [SEP-38 Quotes Integration](/routes-d/909-sep38-quotes-integration-guide) - Requesting and honoring firm quotes
+- [Fiat Onramp Tutorial](/docs/guides/fiat-onramp-tutorial) - The deposit-side counterpart flow

--- a/routes-d/913-path-payment-cost-analysis.mdx
+++ b/routes-d/913-path-payment-cost-analysis.mdx
@@ -1,0 +1,197 @@
+---
+title: Path Payment Cost Analysis
+description: How to evaluate the true cost of a path payment on Stellar — reading pathfinding output correctly, weighing fee versus received-amount tradeoffs, and a worked example comparing two candidate paths.
+date: 2026-08-26
+---
+
+# Path Payment Cost Analysis
+
+A path payment lets a sender pay in one asset while the recipient receives another, routing the conversion through one or more intermediate assets and the DEX order books (or liquidity pools) that connect them. Horizon's pathfinding endpoints return several candidate routes for the same payment — this guide covers how to read that output, what actually drives the cost of a given path, and how to pick between competing routes instead of blindly taking the first one returned.
+
+---
+
+## 1. The Two Path Payment Operations
+
+Stellar has two path payment operations, and the cost-analysis question is _inverted_ between them:
+
+| Operation                  | You fix...                      | Horizon/pathfinding solves for...                       |
+| -------------------------- | ------------------------------- | ------------------------------------------------------- |
+| `PathPaymentStrictSend`    | Exact amount you send           | Minimum amount the recipient is guaranteed to receive   |
+| `PathPaymentStrictReceive` | Exact amount the recipient gets | Maximum amount you'd need to send (capped by `sendMax`) |
+
+Cost analysis differs accordingly: for `StrictSend`, worse paths show up as a **lower `destination_amount`** for the same input. For `StrictReceive`, worse paths show up as a **higher required source amount** for the same fixed output. Always compare paths against the operation type you intend to submit — a path that looks cheap under one framing can look expensive under the other, because both are answers to the same order book at slightly different offer depths.
+
+---
+
+## 2. Requesting Candidate Paths
+
+```typescript
+import { Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+// Strict send: "I'm sending exactly 100 USDC, what could the recipient get in XLM?"
+const paths = await server
+  .strictSendPaths(
+    {
+      code: 'USDC',
+      issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    },
+    '100',
+    [{ code: 'XLM', issuer: undefined } as any] // native asset as destination
+  )
+  .call();
+
+console.log(paths.records);
+```
+
+Each record in `paths.records` looks like:
+
+```json
+{
+  "source_asset_type": "credit_alphanum4",
+  "source_asset_code": "USDC",
+  "source_amount": "100.0000000",
+  "destination_asset_type": "native",
+  "destination_amount": "612.3456789",
+  "path": [
+    {
+      "asset_type": "credit_alphanum4",
+      "asset_code": "yUSDC",
+      "asset_issuer": "GB..."
+    }
+  ]
+}
+```
+
+`destination_amount` here is what pathfinding _estimates_ — it's computed by walking the order books at query time, but the actual fill at submission time depends on what liquidity remains. Treat it as a quote, not a guarantee, which is exactly why the path payment operations require you to set a `destMin` (strict send) or `sendMax` (strict receive) — the protocol-level slippage bound.
+
+---
+
+## 3. What Actually Drives Cost
+
+Three factors determine whether a path is cheap or expensive, and pathfinding output doesn't surface all of them equally clearly:
+
+### a. Hop count and cumulative spread
+
+Every intermediate asset in `path` means crossing another order book (or AMM pool), and each one has its own bid/ask spread. A direct `USDC → XLM` path with a tight spread often beats a `USDC → yUSDC → XLM` path with two mediocre spreads, even though the two-hop path might show a _better_ top-of-book rate on the first leg — the effective rate is the product of all legs, not the best individual leg.
+
+### b. Depth at your trade size
+
+Pathfinding returns the best rate achievable for your _specific_ requested amount, walking the book until it satisfies the requested `source_amount` or `destination_amount`. A path that looks excellent for 100 USDC can degrade sharply at 10,000 USDC if the first few offers are thin — request paths at (or close to) your actual trade size rather than a small probe amount, since a probe at 1 USDC only reflects the very top of the book.
+
+### c. Base network fee (and why it's usually not the deciding factor)
+
+Every transaction pays the standard Stellar base fee (a small fixed amount per operation, in stroops, independent of the payment amount or number of path hops — the path itself is one `PathPaymentStrictSend`/`StrictReceive` operation regardless of hop count). For any payment above trivial size, the **DEX spread across hops dominates total cost by orders of magnitude** compared to the network fee. Don't spend analysis effort optimizing the base fee; spend it comparing effective exchange rates across candidate paths.
+
+---
+
+## 4. Computing the Effective Rate
+
+The number that actually matters for comparison is the **effective exchange rate**: destination amount divided by source amount (strict send) or source amount divided by destination amount (strict receive). Compare that ratio across every candidate path, not the raw amounts:
+
+```typescript
+interface PathRecord {
+  source_amount: string;
+  destination_amount: string;
+  path: unknown[];
+}
+
+function effectiveRate(path: PathRecord): number {
+  return parseFloat(path.destination_amount) / parseFloat(path.source_amount);
+}
+
+function rankPathsBySend(paths: PathRecord[]): PathRecord[] {
+  // Higher effective rate = more received per unit sent = better for strict send.
+  return [...paths].sort((a, b) => effectiveRate(b) - effectiveRate(a));
+}
+```
+
+For `StrictReceive`, invert the comparison — lower required source amount for the same fixed destination amount wins:
+
+```typescript
+function rankPathsByReceive(paths: PathRecord[]): PathRecord[] {
+  return [...paths].sort(
+    (a, b) => parseFloat(a.source_amount) - parseFloat(b.source_amount)
+  );
+}
+```
+
+---
+
+## 5. Worked Example: Two Candidate Paths
+
+Say a sender wants to send exactly 1,000 USDC and receive XLM. Horizon's `strictSendPaths` returns two candidates:
+
+| Path                     | Hops | `destination_amount` (XLM) | Effective rate |
+| ------------------------ | ---- | -------------------------- | -------------- |
+| A: `USDC → XLM` (direct) | 1    | 6,050.0000000              | 6.0500         |
+| B: `USDC → yUSDC → XLM`  | 2    | 6,112.3456789              | 6.1123         |
+
+Path B looks better by effective rate — about 1% more XLM for the same 1,000 USDC. But two things need checking before assuming B wins:
+
+1. **Slippage tolerance sizing.** If setting `destMin` at, say, 1% below the quoted `destination_amount`, Path B's tighter two-hop liquidity may move more between quote and submission than Path A's single deep venue — a 1% buffer that's safe for A might not be safe for B. Widening the buffer to protect against B's execution risk can erase some or all of its rate advantage.
+2. **Issuer/trustline risk on the intermediate asset.** Path B routes through `yUSDC`, a different issued asset than the one being sent. That's an additional counterparty whose peg or liquidity could be worse than it appears from the order book alone. A path with an unfamiliar intermediate issuer carries risk that a raw rate comparison doesn't capture — for anything beyond a trivial amount, it's worth resolving what `yUSDC`'s issuer is before routing meaningful value through it.
+
+The mechanical conclusion (better effective rate) and the deployment conclusion (which path to actually submit) aren't always the same decision — surface both to the user rather than auto-selecting the top rate.
+
+---
+
+## 6. Submitting with the Cost-Aware Bound
+
+Once a path is selected, use its `path` array directly as the intermediate hops and set the slippage bound off the _quoted_ amount, not an arbitrary number:
+
+```typescript
+import {
+  Asset,
+  Operation,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+} from '@stellar/stellar-sdk';
+
+const SLIPPAGE_BPS = 100; // 1%
+const destMin = (
+  parseFloat(chosenPath.destination_amount) *
+  (1 - SLIPPAGE_BPS / 10_000)
+).toFixed(7);
+
+const op = Operation.pathPaymentStrictSend({
+  sendAsset: new Asset(
+    'USDC',
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  ),
+  sendAmount: '1000',
+  destination: recipientPublicKey,
+  destAsset: Asset.native(),
+  destMin,
+  path: chosenPath.path.map(
+    (hop: any) => new Asset(hop.asset_code, hop.asset_issuer)
+  ),
+});
+```
+
+**Edge cases to handle:**
+
+- **No path exists.** `strictSendPaths`/`strictReceivePaths` return an empty `records` array when no route connects the two assets at any price — surface this distinctly from "path exists but too expensive," since the fix (add liquidity, pick different assets) is different from a slippage problem.
+- **Recipient lacks a trustline for the destination asset.** Pathfinding doesn't check this. Verify the destination account can hold `destAsset` (or that it's a trustline-free asset like native XLM) before submitting — otherwise the transaction fails with `op_no_trust` after already consuming a fee.
+- **Quote goes stale.** Order books move continuously; a quote fetched more than a few seconds before submission should be re-fetched, especially for thinly-traded pairs where the effective rate in §5 can shift materially.
+- **Path becomes invalid between quote and submission.** If an offer in the path is pulled, the transaction fails with `op_too_few_offers` (strict send) or the equivalent under-fill error — this is exactly what `destMin`/`sendMax` are protecting against, so a failure here means the guard worked, not that something is broken.
+
+---
+
+## Summary
+
+- Compare paths by **effective rate** (destination/source ratio), not raw destination or source amounts — and know which of the two operations you're using, since "better" flips direction between them.
+- Request paths at your actual trade size; a small probe amount only reflects the top of the book and hides depth problems.
+- Hop count and per-hop spread dominate cost far more than the base network fee — optimize the route, not the transaction fee.
+- The best effective rate isn't automatically the best path to submit — factor in execution slippage risk and intermediate-issuer trust before choosing.
+- Set `destMin`/`sendMax` off the live quote, verify the destination trustline exists, and treat "no path found" as a distinct case from "path found but expensive."
+
+---
+
+## Related
+
+- [Soroban Integration](/docs/integrations/soroban) - For swaps executed via contracts rather than the DEX
+- [Transaction Batching](/docs/guides/transaction-batching) - Combining path payments with other operations
+- [Optimizing Transaction Sizes](/docs/guides/optimizing-transaction-sizes) - Fee and size considerations for multi-operation transactions

--- a/routes-d/914-soroban-swap-tutorial.mdx
+++ b/routes-d/914-soroban-swap-tutorial.mdx
@@ -1,0 +1,289 @@
+---
+title: Building a Soroban Swap Contract
+description: A complete walkthrough for writing a two-token swap contract on Soroban — pool state, the swap function, authorization, and a client that invokes it from a Nextellar dApp.
+date: 2026-08-26
+---
+
+# Building a Soroban Swap Contract
+
+This tutorial builds a minimal constant-product swap contract on Soroban — the kind of contract that sits behind a "swap Token A for Token B" button. It covers the contract's storage layout, the `swap` entrypoint and how it authorizes the caller, depositing initial liquidity, and a TypeScript client that simulates and submits the invocation from a Nextellar app. The contract is intentionally small (no LP shares, no fees) so the auth and swap-math mechanics stay visible; production pools layer more on top.
+
+---
+
+## 1. What the Contract Holds
+
+The pool tracks two token contract addresses and its own reserves of each:
+
+```rust
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    TokenA,
+    TokenB,
+    ReserveA,
+    ReserveB,
+}
+
+#[contract]
+pub struct SwapContract;
+```
+
+Reserves live in **instance storage** — they're read on every swap and are small enough to stay cheap regardless of how the contract grows. Storage reads/writes are the dominant cost driver in Soroban fees, so keeping hot state in instance storage (rather than persistent storage with per-entry TTLs) avoids unnecessary bump-and-extend overhead for values touched on every call.
+
+---
+
+## 2. Initialization
+
+```rust
+#[contractimpl]
+impl SwapContract {
+    pub fn initialize(env: Env, token_a: Address, token_b: Address) {
+        if env.storage().instance().has(&DataKey::TokenA) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::TokenA, &token_a);
+        env.storage().instance().set(&DataKey::TokenB, &token_b);
+        env.storage().instance().set(&DataKey::ReserveA, &0i128);
+        env.storage().instance().set(&DataKey::ReserveB, &0i128);
+    }
+}
+```
+
+`token_a` and `token_b` are the contract addresses of two Stellar Asset Contracts (SACs) or custom token contracts implementing the standard `token` interface. There's no auth check here deliberately — in a real deployment you'd either restrict `initialize` to a deployer address (checked with `require_auth`) or make it callable exactly once and rely on the `has()` guard above, which is what this contract does.
+
+---
+
+## 3. Depositing Liquidity
+
+Before anyone can swap, the pool needs reserves:
+
+```rust
+pub fn deposit(env: Env, from: Address, amount_a: i128, amount_b: i128) {
+    from.require_auth();
+
+    let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
+    let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
+
+    token::Client::new(&env, &token_a).transfer(&from, &env.current_contract_address(), &amount_a);
+    token::Client::new(&env, &token_b).transfer(&from, &env.current_contract_address(), &amount_b);
+
+    let reserve_a: i128 = env.storage().instance().get(&DataKey::ReserveA).unwrap();
+    let reserve_b: i128 = env.storage().instance().get(&DataKey::ReserveB).unwrap();
+    env.storage().instance().set(&DataKey::ReserveA, &(reserve_a + amount_a));
+    env.storage().instance().set(&DataKey::ReserveB, &(reserve_b + amount_b));
+}
+```
+
+`from.require_auth()` is the core authorization primitive in Soroban. It doesn't check a signature directly — it asserts that the _invocation tree_ for this transaction includes an authorization entry for `from` that covers this exact contract call (contract address, function name, and arguments). For a `G...` account, that authorization is a signature over the call; for another contract, it's a nested `require_auth` in that contract's own execution. Calling `transfer` immediately afterward re-uses the same authorized invocation, since the token contract's `transfer` also calls `require_auth` on `from` and the Soroban host resolves both from the transaction's signed auth entries.
+
+**Edge case:** `require_auth()` must be called on `from` before any state mutation or external call that assumes `from` authorized it. Calling it after the transfer would still work today, but ordering auth first is the convention — it fails fast and reads correctly.
+
+---
+
+## 4. The Swap Function
+
+```rust
+pub fn swap(env: Env, trader: Address, amount_in: i128, min_amount_out: i128, a_to_b: bool) -> i128 {
+    trader.require_auth();
+
+    if amount_in <= 0 {
+        panic!("amount_in must be positive");
+    }
+
+    let token_a: Address = env.storage().instance().get(&DataKey::TokenA).unwrap();
+    let token_b: Address = env.storage().instance().get(&DataKey::TokenB).unwrap();
+    let reserve_a: i128 = env.storage().instance().get(&DataKey::ReserveA).unwrap();
+    let reserve_b: i128 = env.storage().instance().get(&DataKey::ReserveB).unwrap();
+
+    let (reserve_in, reserve_out, token_in, token_out) = if a_to_b {
+        (reserve_a, reserve_b, token_a, token_b)
+    } else {
+        (reserve_b, reserve_a, token_b, token_a)
+    };
+
+    if reserve_in == 0 || reserve_out == 0 {
+        panic!("pool has no liquidity");
+    }
+
+    // Constant product: (reserve_in + amount_in_after_fee) * (reserve_out - amount_out) = reserve_in * reserve_out
+    // 0.3% fee, expressed as amount_in * 997 / 1000.
+    let amount_in_with_fee = amount_in * 997;
+    let numerator = amount_in_with_fee * reserve_out;
+    let denominator = (reserve_in * 1000) + amount_in_with_fee;
+    let amount_out = numerator / denominator;
+
+    if amount_out < min_amount_out {
+        panic!("slippage: output below minimum");
+    }
+    if amount_out >= reserve_out {
+        panic!("insufficient reserve for this trade size");
+    }
+
+    token::Client::new(&env, &token_in).transfer(&trader, &env.current_contract_address(), &amount_in);
+    token::Client::new(&env, &token_out).transfer(&env.current_contract_address(), &trader, &amount_out);
+
+    if a_to_b {
+        env.storage().instance().set(&DataKey::ReserveA, &(reserve_a + amount_in));
+        env.storage().instance().set(&DataKey::ReserveB, &(reserve_b - amount_out));
+    } else {
+        env.storage().instance().set(&DataKey::ReserveB, &(reserve_b + amount_in));
+        env.storage().instance().set(&DataKey::ReserveA, &(reserve_a - amount_out));
+    }
+
+    amount_out
+}
+```
+
+Key points on the math and auth together:
+
+- **`min_amount_out` is the caller's slippage guard.** The client computes an expected output off-chain (see §6), applies a slippage tolerance, and passes the floor in. The contract enforces it atomically — there's no way for the trade to execute at a worse price than the caller accepted, because the check and the transfers happen in the same transaction.
+- **The 997/1000 fee model** mirrors the standard constant-product AMM formula (as used by Uniswap V2 and its many derivatives). It's computed in integer arithmetic — Soroban's `i128` has no native fixed-point division, so order of operations matters: multiply before dividing to avoid truncating intermediate results to zero.
+- **`trader.require_auth()` authorizes the whole call**, including the subsequent `transfer` of `token_in` from `trader`. The wallet signing this transaction sees (via `simulateTransaction`, covered below) exactly which contract, function, and arguments it's authorizing — this is what the client must render for the user before requesting a signature.
+
+---
+
+## 5. Edge Cases Worth Testing
+
+| Scenario                                                                              | Expected behavior                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `amount_in` is zero or negative                                                       | Contract panics before touching reserves                                                                                                                                            |
+| Pool has zero reserves (never funded, or fully drained)                               | `swap` panics with "pool has no liquidity"                                                                                                                                          |
+| Requested output would exceed available reserve                                       | Panics rather than draining the pool to zero, which would make the pool unusable for the _other_ direction                                                                          |
+| Slippage exceeds tolerance between simulation and submission                          | `min_amount_out` check fails and the whole transaction reverts — no partial fill                                                                                                    |
+| Caller doesn't actually sign the auth entry for `trader`                              | Host rejects the transaction before contract logic runs; `require_auth` never returns                                                                                               |
+| Same trader address used for both `token_a` and `token_b` mistakenly (a == b at init) | Not guarded in this minimal contract — add an explicit check in `initialize` if deploying for real, since swapping a token for itself would silently corrupt the reserve accounting |
+
+That last row is a deliberate simplification worth calling out: this tutorial contract skips the `token_a != token_b` guard and the LP-share/fee-withdrawal bookkeeping a real AMM needs, to keep the auth and swap-math flow readable. Treat it as a teaching contract, not a deployment target.
+
+---
+
+## 6. Client Invocation
+
+Simulate first to get the expected output and let the user review the trade, then build, sign, and submit:
+
+```typescript
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  scValToNative,
+  nativeToScVal,
+  Address,
+} from '@stellar/stellar-sdk';
+import { Server } from '@stellar/stellar-sdk/rpc';
+
+const rpc = new Server('https://soroban-testnet.stellar.org');
+const contract = new Contract(POOL_CONTRACT_ID);
+
+async function simulateSwap(
+  traderPublicKey: string,
+  amountIn: bigint,
+  aToB: boolean
+) {
+  const account = await rpc.getAccount(traderPublicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'swap',
+        new Address(traderPublicKey).toScVal(),
+        nativeToScVal(amountIn, { type: 'i128' }),
+        nativeToScVal(0n, { type: 'i128' }), // min_amount_out placeholder during simulation
+        nativeToScVal(aToB, { type: 'bool' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await rpc.simulateTransaction(tx);
+  if ('error' in sim) throw new Error(sim.error);
+
+  const expectedOut = scValToNative(sim.result!.retval) as bigint;
+  return { tx, expectedOut };
+}
+
+async function buildSignedSwap(
+  traderPublicKey: string,
+  amountIn: bigint,
+  expectedOut: bigint,
+  slippageBps: number,
+  aToB: boolean,
+  signTransaction: (xdr: string) => Promise<string>
+) {
+  const minOut = (expectedOut * BigInt(10_000 - slippageBps)) / 10_000n;
+  const account = await rpc.getAccount(traderPublicKey);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'swap',
+        new Address(traderPublicKey).toScVal(),
+        nativeToScVal(amountIn, { type: 'i128' }),
+        nativeToScVal(minOut, { type: 'i128' }),
+        nativeToScVal(aToB, { type: 'bool' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await rpc.prepareTransaction(tx);
+  const signedXDR = await signTransaction(prepared.toXDR());
+  const signedTx = TransactionBuilder.fromXDR(signedXDR, Networks.TESTNET);
+
+  const sendResult = await rpc.sendTransaction(signedTx);
+  return sendResult;
+}
+```
+
+`prepareTransaction` (rather than a hand-rolled auth entry) is what attaches the correct footprint and resource fees from simulation, and — critically — assembles the authorization entries the host expects for `trader.require_auth()`. The wallet's `signTransaction` call is what actually turns that pending auth entry into a valid signature; without it, `sendTransaction` returns an error indicating the auth entry could not be verified.
+
+**Practical note on slippage:** simulate with a placeholder `min_amount_out` of zero to discover `expectedOut`, show the user the quote, then rebuild the transaction with the real floor once they confirm. Reusing the first simulation's transaction object with a patched operation is _not_ safe — Soroban transactions are prepared against a specific footprint, and changing an argument after `prepareTransaction` can invalidate the resource estimate.
+
+---
+
+## 7. Polling for Confirmation
+
+`sendTransaction` returns immediately with a `PENDING` status; poll for the final result:
+
+```typescript
+async function awaitSwap(hash: string) {
+  for (let i = 0; i < 15; i++) {
+    const res = await rpc.getTransaction(hash);
+    if (res.status === 'SUCCESS') return res;
+    if (res.status === 'FAILED')
+      throw new Error('Swap transaction failed on-chain');
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error('Timed out waiting for swap confirmation');
+}
+```
+
+A `FAILED` status here most commonly means the `min_amount_out` check reverted (price moved between simulation and confirmation) or one of the two token transfers failed (insufficient balance or trustline). Both surface as a generic host trap unless you decode the diagnostic events from `getTransaction`'s result — worth surfacing to the user as "trade expired, try again" rather than a raw error string.
+
+---
+
+## Summary
+
+- Reserves and token addresses live in instance storage since they're read on every call.
+- `require_auth()` on the trader authorizes both the swap invocation and the token transfer inside it — one signature covers the whole call tree.
+- The constant-product formula with an integer fee multiplier (997/1000) computes output; always multiply before dividing to avoid truncation.
+- `min_amount_out` is the atomic slippage guard — simulate for a quote, then rebuild with the real floor before requesting a signature.
+- `prepareTransaction` is what wires up the auth entries and resource fees correctly; don't patch a prepared transaction's arguments after the fact.
+
+---
+
+## Related
+
+- [Soroban Integration](/docs/integrations/soroban) - Nextellar's Soroban hooks overview
+- [useSorobanContract](/docs/hooks/use-soroban-contract) - Contract invocation hook used in dApp UIs
+- [Comprehensive Soroban Smart Contract Authoring Guide](/docs/guides/soroban-contract-authoring) - Project layout, testing, and deployment
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) - Storage, auth, and cross-contract call primitives


### PR DESCRIPTION
## Summary

Adds four `routes-d/` draft guides covering path payments, Soroban swap contracts, and SEP-31/SEP-38 anchor integration flows. These are doc-only drafts placed in `routes-d/` at the repo root (outside `docs/`, intentionally excluded from contentlayer) following the existing pattern from prior routes-d batches.

## #914 — Soroban swap contract tutorial

`routes-d/914-soroban-swap-tutorial.mdx` walks through a minimal constant-product swap contract on Soroban: storage layout for pool reserves, the `swap` entrypoint and how `require_auth()` covers both the swap call and the nested token transfer, the integer-safe fee math (997/1000 model, multiply-before-divide), a table of edge cases worth testing (zero/negative amounts, empty reserves, slippage breaches, missing auth), and a full TypeScript client that simulates via `simulateTransaction`, rebuilds with a real `min_amount_out` floor, and polls for confirmation.

## #913 — Path payment cost analysis guide

`routes-d/913-path-payment-cost-analysis.mdx` covers how to read Horizon's pathfinding output correctly: the inverted cost framing between `PathPaymentStrictSend` and `PathPaymentStrictReceive`, the three real cost drivers (hop count/spread, depth at trade size, and why base network fee is not the deciding factor), how to compute and rank paths by effective rate, and a worked two-path example that shows why the best raw rate isn't always the best path to submit once slippage risk and intermediate-issuer trust are factored in.

## #910 — SEP-31 sender client tutorial

`routes-d/910-sep31-sender-client-tutorial.mdx` builds the sending side of a SEP-31 cross-border payment: how SEP-31 composes SEP-12 (KYC) and SEP-38 (quotes), discovering a receiving anchor's `/info` requirements, submitting sender and receiver KYC via `PUT /customer`, requesting a quote at the right point in the flow, creating the SEP-31 transaction, correctly building the required Stellar memo (and why a mismatched memo silently breaks anchor-side reconciliation), polling transaction status with explicit handling for every status value, and a compliance touchpoints table (KYC rejection, info updates, amount limits, sanctions/travel-rule fields, quote expiry mid-flow).

## #909 — SEP-38 quotes integration guide

`routes-d/909-sep38-quotes-integration-guide.mdx` covers the indicative (`GET /price`) vs. firm (`POST /quote`) quote distinction, discovering supported asset pairs via `/info`, requesting and honoring a firm quote (matching exact amount/asset at settlement), expiry handling with clock-skew and multi-step-flow guidance, and a worked NGN→USDC quote lifecycle example from indicative check through settlement.

## Verification

- `pnpm build:content`: ran on this branch and, separately, on a clean `upstream/main` worktree for comparison. Both report the identical baseline — **"Found 2 problems in 157 documents"** (an undeclared-fields warning on `examples/payment-app.mdx` and a missing-`title` error on `guides/custom-hook-authoring-playbook.mdx`), both pre-existing on `main` and unrelated to this PR. The four new files live in `routes-d/`, which is outside contentlayer's content path, so they don't participate in this build at all — confirmed by identical document counts (156 generated) before and after.
- `pnpm check:links`: fails the same pre-existing way on this branch as it would on `main` — the script requires a live dev server on `localhost:3000` (`ECONNREFUSED`/empty error on both sidebar links tested) and isn't affected by anything in this PR, since it only checks `docs/components/*` sidebar links.
- No files under `docs/` were touched, so neither script's actual output changes as a result of this PR — pre-existing breakage is disclosed here rather than papered over.

closes #914
closes #913
closes #910
closes #909
