### PR TITLE
docs: add new guides and notes for Soroban and Horizon

### DIFF
--- a/docs/guides/horizon-proxy.mdx
+++ b/docs/guides/horizon-proxy.mdx
@@ -1,0 +1,38 @@
+---
+title: Building a small Horizon proxy
+description: How to build a simple proxy for Stellar Horizon.
+---
+
+# Building a Small Horizon Proxy
+
+A Horizon proxy allows you to cache requests, add authentication, or implement rate limiting before requests reach the public Horizon API.
+
+## Basic Implementation
+
+You can build a proxy using a simple Node.js or Go server. The proxy will intercept incoming HTTP requests and forward them to the Horizon endpoint.
+
+### Example in Node.js (Express)
+
+```javascript
+const express = require('express');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+
+app.use('/horizon', createProxyMiddleware({
+  target: 'https://horizon.stellar.org',
+  changeOrigin: true,
+  pathRewrite: {
+    '^/horizon': '', // remove base path
+  },
+}));
+
+app.listen(3000, () => {
+  console.log('Horizon proxy listening on port 3000');
+});
+```
+
+## Advantages
+- Reduces load on the primary network.
+- Custom filtering of responses.
+- Caching of frequent read requests.

--- a/docs/guides/parsing-operation-xdr.mdx
+++ b/docs/guides/parsing-operation-xdr.mdx
@@ -1,0 +1,26 @@
+---
+title: Parsing Operation XDR
+description: Learn how to parse Stellar Operation XDR strings.
+---
+
+# Parsing Operation XDR
+
+Stellar transactions and operations are serialized into XDR (External Data Representation). When working with the Stellar network, you will often encounter base64 encoded XDR strings.
+
+## Using the Stellar SDK
+
+The easiest way to parse XDR is to use the official Stellar SDKs, which provide built-in decoders.
+
+### JavaScript Example
+
+```javascript
+import { xdr } from '@stellar/stellar-sdk';
+
+// A base64 encoded XDR string
+const xdrString = 'AAAAAQAAA...';
+
+const parsed = xdr.Operation.fromXDR(xdrString, 'base64');
+console.log(parsed);
+```
+
+This will convert the raw XDR bytes into a readable JSON-like object where you can inspect the operation type, source account, and parameters.

--- a/docs/guides/soroban-budget.mdx
+++ b/docs/guides/soroban-budget.mdx
@@ -1,0 +1,23 @@
+---
+title: Soroban Budget and Resource Fees
+description: Understanding the resource budget and fee structure in Soroban.
+---
+
+# Soroban Budget and Resource Fees
+
+Soroban enforces a resource budget to ensure that smart contract execution is predictable and affordable. 
+The network limits resources such as CPU instructions, RAM, and ledger reads/writes per transaction.
+
+## Resource Categories
+
+- **Instructions**: CPU operations performed by the contract.
+- **Read Bytes**: The amount of data read from the ledger.
+- **Write Bytes**: The amount of data written to the ledger.
+- **Read Ledger Entries**: The number of entries accessed.
+- **Write Ledger Entries**: The number of entries modified or created.
+
+## Fee Structure
+
+Fees in Soroban are dynamically adjusted based on network demand but are calculated using the resource metrics. Each resource type has a predefined base fee rate.
+
+To estimate your contract's resource usage, you can use the `simulateTransaction` endpoint before submitting a transaction to the network.

--- a/docs/guides/soroban-footprint.mdx
+++ b/docs/guides/soroban-footprint.mdx
@@ -1,0 +1,16 @@
+---
+title: Soroban Footprint Fields
+description: A quick note on footprint fields in Soroban transactions.
+---
+
+# Soroban Footprint Fields
+
+Every Soroban transaction requires a **footprint** to be specified. The footprint is a predefined list of all ledger entries the contract might read or write during execution.
+
+## Read-Only vs. Read-Write
+
+The footprint is split into two arrays:
+1. `readOnly`: Entries the contract will only read.
+2. `readWrite`: Entries the contract may modify or create.
+
+If a contract attempts to access a ledger entry that was not declared in its footprint, the execution will fail immediately. This mechanism ensures predictable execution and parallel transaction processing.


### PR DESCRIPTION
## Summary
Added documentation and guides for Soroban budget, footprint fields, Horizon proxy, and XDR parsing.

## Changes
- Created `docs/guides/soroban-budget.mdx` for Soroban budget and resource fees.
- Created `docs/guides/horizon-proxy.mdx` for building a small Horizon proxy.
- Created `docs/guides/parsing-operation-xdr.mdx` for parsing operation XDR.
- Created `docs/guides/soroban-footprint.mdx` for Soroban footprint fields.

## Issues
Resolves #1002
Resolves #1001
Resolves #1000
Resolves #987

## Verification
- Manual code review completed.
- `cargo build` was not run.
- `cargo test` was not run.
- No snapshots were committed.
