### PR TITLE
docs: add insurance pool, DID, reputation voting, and analytics dashboard tutorials

### DIFF
--- a/routes-d/926-soroban-insurance-pool-tutorial.mdx
+++ b/routes-d/926-soroban-insurance-pool-tutorial.mdx
@@ -1,0 +1,712 @@
+---
+title: Building a Soroban Insurance Pool Contract
+description: End-to-end tutorial for a Soroban insurance pool — premium collection, claim filing, payout, and basic fraud checks — with a working sample and client invocation.
+date: 2026-08-27
+---
+
+# Building a Soroban Insurance Pool Contract
+
+An **insurance pool** contract collects premiums from policyholders into a shared reserve, then pays out approved claims from that reserve. This tutorial builds one from scratch on Soroban: policy issuance, premium collection, claim filing, a simple approval/fraud-check flow, and payout — with a working Rust contract, tests, and a TypeScript client.
+
+<Note type="warning">
+  This is an educational reference implementation, not a production insurance
+  product. Real insurance pools need actuarial pricing, regulatory compliance
+  (see the [Regulated Asset Tutorial](/docs/guides/dispute-resolution-patterns)
+  for compliance-adjacent patterns), and typically an off-chain claims
+  adjudication process feeding an on-chain oracle rather than the simplified
+  threshold check used here.
+</Note>
+
+---
+
+## How the Pool Works
+
+```
+Policyholder ──buy_policy(coverage, term)───► Insurance Pool
+                                                │
+                                                ├── require_auth() on policyholder
+                                                ├── compute premium (coverage × rate)
+                                                ├── transfer_in premium
+                                                └── store Policy { coverage, expires_at, claimed: false }
+
+Policyholder ──file_claim(policy_id, amount)─► Insurance Pool
+                                                │
+                                                ├── require_auth() on policyholder
+                                                ├── verify policy active, not expired, not already claimed
+                                                ├── verify amount <= coverage           (fraud check #1)
+                                                ├── verify claim not filed twice          (fraud check #2)
+                                                └── store Claim { status: Pending }
+
+Admin ──approve_claim(claim_id)─────────────►  Insurance Pool
+                                                │
+                                                ├── require_auth() on admin
+                                                ├── verify pool reserve >= claim amount
+                                                ├── transfer_out claim amount to policyholder
+                                                └── mark Claim.status = Paid, Policy.claimed = true
+```
+
+The pool's reserve is simply the sum of all premiums collected, minus payouts made — tracked as a running balance rather than recomputed from history each time.
+
+---
+
+## Project Layout
+
+```
+insurance-pool/
+├── Cargo.toml
+└── contracts/
+    └── insurance-pool/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── types.rs
+            ├── policy.rs
+            ├── claim.rs
+            ├── storage.rs
+            └── test.rs
+```
+
+### Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-insurance-pool"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+```
+
+---
+
+## Types and Storage Keys
+
+```rust
+// src/types.rs
+use soroban_sdk::{contracttype, Address};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Policy {
+    pub owner: Address,
+    /// Maximum payout this policy covers, in stroops of the pool's token.
+    pub coverage: i128,
+    /// Premium paid at purchase time, in stroops.
+    pub premium_paid: i128,
+    pub expires_at: u64,
+    pub claimed: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum ClaimStatus {
+    Pending,
+    Approved,
+    Paid,
+    Rejected,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Claim {
+    pub policy_id: u64,
+    pub owner: Address,
+    pub amount: i128,
+    pub status: ClaimStatus,
+    pub filed_at: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Token,
+    /// Running total of premiums collected minus payouts made.
+    Reserve,
+    NextPolicyId,
+    NextClaimId,
+    Policy(u64),
+    Claim(u64),
+}
+```
+
+```rust
+// src/error.rs
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotInitialized = 1,
+    Unauthorized = 2,
+    InvalidAmount = 3,
+    NotFound = 4,
+    PolicyExpired = 5,
+    PolicyAlreadyClaimed = 6,
+    ClaimExceedsCoverage = 7,
+    ClaimAlreadyResolved = 8,
+    InsufficientReserve = 9,
+}
+```
+
+---
+
+## Policy Issuance
+
+```rust
+// src/policy.rs
+use soroban_sdk::{token, Address, Env};
+use crate::error::Error;
+use crate::types::{DataKey, Policy};
+
+/// Premium is a flat 5% of coverage for this reference implementation —
+/// a real pool would price by risk tier, term length, and claims history.
+const PREMIUM_BPS: i128 = 500; // 5.00%
+const BPS_DENOMINATOR: i128 = 10_000;
+
+pub fn buy_policy(
+    env: &Env,
+    owner: Address,
+    coverage: i128,
+    term_seconds: u64,
+) -> Result<u64, Error> {
+    owner.require_auth();
+
+    if coverage <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let premium = coverage
+        .checked_mul(PREMIUM_BPS)
+        .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+        .ok_or(Error::InvalidAmount)?;
+
+    let token_address: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Token)
+        .ok_or(Error::NotInitialized)?;
+    let token_client = token::Client::new(env, &token_address);
+    token_client.transfer(&owner, &env.current_contract_address(), &premium);
+
+    let reserve: i128 = env.storage().instance().get(&DataKey::Reserve).unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::Reserve, &(reserve + premium));
+
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextPolicyId)
+        .unwrap_or(0);
+    env.storage().instance().set(&DataKey::NextPolicyId, &(id + 1));
+
+    let policy = Policy {
+        owner,
+        coverage,
+        premium_paid: premium,
+        expires_at: env.ledger().timestamp() + term_seconds,
+        claimed: false,
+    };
+    env.storage().persistent().set(&DataKey::Policy(id), &policy);
+
+    Ok(id)
+}
+
+pub fn get_policy(env: &Env, policy_id: u64) -> Result<Policy, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Policy(policy_id))
+        .ok_or(Error::NotFound)
+}
+```
+
+---
+
+## Filing and Resolving Claims
+
+The two fraud checks here are deliberately simple — a **coverage-limit check** (you cannot claim more than your policy covers) and a **double-claim check** (a policy can only be claimed once). A production system would add off-chain signals: claim frequency across policyholders, correlation with recent policy purchases, and manual review above a payout threshold.
+
+```rust
+// src/claim.rs
+use soroban_sdk::{token, Address, Env};
+use crate::error::Error;
+use crate::types::{Claim, ClaimStatus, DataKey, Policy};
+
+pub fn file_claim(env: &Env, owner: Address, policy_id: u64, amount: i128) -> Result<u64, Error> {
+    owner.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    let policy: Policy = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Policy(policy_id))
+        .ok_or(Error::NotFound)?;
+
+    if policy.owner != owner {
+        return Err(Error::Unauthorized);
+    }
+    if env.ledger().timestamp() > policy.expires_at {
+        return Err(Error::PolicyExpired);
+    }
+    if policy.claimed {
+        // Fraud check: a policy may only be claimed once.
+        return Err(Error::PolicyAlreadyClaimed);
+    }
+    if amount > policy.coverage {
+        // Fraud check: cannot claim more than the policy's coverage limit.
+        return Err(Error::ClaimExceedsCoverage);
+    }
+
+    let id: u64 = env.storage().instance().get(&DataKey::NextClaimId).unwrap_or(0);
+    env.storage().instance().set(&DataKey::NextClaimId, &(id + 1));
+
+    let claim = Claim {
+        policy_id,
+        owner,
+        amount,
+        status: ClaimStatus::Pending,
+        filed_at: env.ledger().timestamp(),
+    };
+    env.storage().persistent().set(&DataKey::Claim(id), &claim);
+
+    Ok(id)
+}
+
+/// Admin-only: approve a pending claim and pay it out immediately.
+/// Splitting "approve" from "pay" is a reasonable extension if you want a
+/// review window between decision and disbursement.
+pub fn approve_claim(env: &Env, admin: Address, claim_id: u64) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    if admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut claim: Claim = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Claim(claim_id))
+        .ok_or(Error::NotFound)?;
+
+    if claim.status != ClaimStatus::Pending {
+        return Err(Error::ClaimAlreadyResolved);
+    }
+
+    let reserve: i128 = env.storage().instance().get(&DataKey::Reserve).unwrap_or(0);
+    if claim.amount > reserve {
+        return Err(Error::InsufficientReserve);
+    }
+
+    let token_address: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Token)
+        .ok_or(Error::NotInitialized)?;
+    let token_client = token::Client::new(env, &token_address);
+    token_client.transfer(&env.current_contract_address(), &claim.owner, &claim.amount);
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Reserve, &(reserve - claim.amount));
+
+    claim.status = ClaimStatus::Paid;
+    env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+
+    let mut policy: Policy = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Policy(claim.policy_id))
+        .ok_or(Error::NotFound)?;
+    policy.claimed = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Policy(claim.policy_id), &policy);
+
+    Ok(())
+}
+
+/// Admin-only: reject a pending claim without paying it out.
+pub fn reject_claim(env: &Env, admin: Address, claim_id: u64) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotInitialized)?;
+    if admin != stored_admin {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut claim: Claim = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Claim(claim_id))
+        .ok_or(Error::NotFound)?;
+
+    if claim.status != ClaimStatus::Pending {
+        return Err(Error::ClaimAlreadyResolved);
+    }
+
+    claim.status = ClaimStatus::Rejected;
+    env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+
+    Ok(())
+}
+
+pub fn get_claim(env: &Env, claim_id: u64) -> Result<Claim, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Claim(claim_id))
+        .ok_or(Error::NotFound)
+}
+```
+
+---
+
+## Contract Entrypoints
+
+```rust
+// src/lib.rs
+#![no_std]
+
+mod claim;
+mod error;
+mod policy;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use error::Error;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+use types::{Claim, Policy};
+
+#[contract]
+pub struct InsurancePool;
+
+#[contractimpl]
+impl InsurancePool {
+    pub fn initialize(env: Env, admin: Address, token: Address) -> Result<(), Error> {
+        storage::initialize(&env, admin, token)
+    }
+
+    pub fn buy_policy(env: Env, owner: Address, coverage: i128, term_seconds: u64) -> Result<u64, Error> {
+        policy::buy_policy(&env, owner, coverage, term_seconds)
+    }
+
+    pub fn get_policy(env: Env, policy_id: u64) -> Result<Policy, Error> {
+        policy::get_policy(&env, policy_id)
+    }
+
+    pub fn file_claim(env: Env, owner: Address, policy_id: u64, amount: i128) -> Result<u64, Error> {
+        claim::file_claim(&env, owner, policy_id, amount)
+    }
+
+    pub fn approve_claim(env: Env, admin: Address, claim_id: u64) -> Result<(), Error> {
+        claim::approve_claim(&env, admin, claim_id)
+    }
+
+    pub fn reject_claim(env: Env, admin: Address, claim_id: u64) -> Result<(), Error> {
+        claim::reject_claim(&env, admin, claim_id)
+    }
+
+    pub fn get_claim(env: Env, claim_id: u64) -> Result<Claim, Error> {
+        claim::get_claim(&env, claim_id)
+    }
+
+    pub fn reserve(env: Env) -> i128 {
+        storage::get_reserve(&env)
+    }
+}
+```
+
+```rust
+// src/storage.rs
+use soroban_sdk::{Address, Env};
+use crate::error::Error;
+use crate::types::DataKey;
+
+pub fn initialize(env: &Env, admin: Address, token: Address) -> Result<(), Error> {
+    if env.storage().instance().has(&DataKey::Admin) {
+        return Err(Error::Unauthorized);
+    }
+    env.storage().instance().set(&DataKey::Admin, &admin);
+    env.storage().instance().set(&DataKey::Token, &token);
+    env.storage().instance().set(&DataKey::Reserve, &0i128);
+    Ok(())
+}
+
+pub fn get_reserve(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::Reserve).unwrap_or(0)
+}
+```
+
+---
+
+## Tests
+
+```rust
+// src/test.rs
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
+use crate::{error::Error, types::ClaimStatus, InsurancePool, InsurancePoolClient};
+
+fn setup(env: &Env) -> (InsurancePoolClient, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_id.address();
+
+    let contract_id = env.register(InsurancePool, ());
+    let client = InsurancePoolClient::new(env, &contract_id);
+    client.initialize(&admin, &token_address);
+
+    (client, admin, token_address, token_admin)
+}
+
+fn mint(env: &Env, token: &Address, token_admin: &Address, to: &Address, amount: i128) {
+    env.mock_all_auths();
+    token::StellarAssetClient::new(env, token).mint(to, &amount);
+    let _ = token_admin;
+}
+
+#[test]
+fn buy_policy_computes_premium_and_stores_policy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 1_000_000);
+
+    let policy_id = client.buy_policy(&owner, &1_000_000, &(30 * 24 * 60 * 60));
+    let policy = client.get_policy(&policy_id);
+
+    assert_eq!(policy.coverage, 1_000_000);
+    assert_eq!(policy.premium_paid, 50_000); // 5% of coverage
+    assert!(!policy.claimed);
+    assert_eq!(client.reserve(), 50_000);
+}
+
+#[test]
+fn file_claim_rejects_amount_exceeding_coverage() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 1_000_000);
+    let policy_id = client.buy_policy(&owner, &1_000_000, &(30 * 24 * 60 * 60));
+
+    let result = client.try_file_claim(&owner, &policy_id, &2_000_000);
+    assert_eq!(result, Err(Ok(Error::ClaimExceedsCoverage)));
+}
+
+#[test]
+fn approve_claim_pays_out_and_marks_policy_claimed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 10_000_000);
+    let policy_id = client.buy_policy(&owner, &10_000_000, &(30 * 24 * 60 * 60));
+    let claim_id = client.file_claim(&owner, &policy_id, &500_000);
+
+    client.approve_claim(&admin, &claim_id);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.status, ClaimStatus::Paid);
+
+    let policy = client.get_policy(&policy_id);
+    assert!(policy.claimed);
+}
+
+#[test]
+fn double_claim_on_same_policy_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 10_000_000);
+    let policy_id = client.buy_policy(&owner, &10_000_000, &(30 * 24 * 60 * 60));
+    let claim_id = client.file_claim(&owner, &policy_id, &500_000);
+    client.approve_claim(&admin, &claim_id);
+
+    // Fraud check: the same (now-claimed) policy cannot be claimed again.
+    let result = client.try_file_claim(&owner, &policy_id, &100_000);
+    assert_eq!(result, Err(Ok(Error::PolicyAlreadyClaimed)));
+}
+
+#[test]
+fn claim_on_expired_policy_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 1_000_000);
+    let policy_id = client.buy_policy(&owner, &1_000_000, &1); // 1-second term
+
+    env.ledger().with_mut(|l| l.timestamp += 10);
+
+    let result = client.try_file_claim(&owner, &policy_id, &100_000);
+    assert_eq!(result, Err(Ok(Error::PolicyExpired)));
+}
+
+#[test]
+fn approve_claim_by_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 1_000_000);
+    let policy_id = client.buy_policy(&owner, &1_000_000, &(30 * 24 * 60 * 60));
+    let claim_id = client.file_claim(&owner, &policy_id, &100_000);
+
+    let result = client.try_approve_claim(&attacker, &claim_id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn reject_claim_leaves_reserve_and_policy_unclaimed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+
+    let owner = Address::generate(&env);
+    mint(&env, &token, &token_admin, &owner, 1_000_000);
+    let policy_id = client.buy_policy(&owner, &1_000_000, &(30 * 24 * 60 * 60));
+    let claim_id = client.file_claim(&owner, &policy_id, &100_000);
+    let reserve_before = client.reserve();
+
+    client.reject_claim(&admin, &claim_id);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.status, ClaimStatus::Rejected);
+    assert_eq!(client.reserve(), reserve_before);
+
+    let policy = client.get_policy(&policy_id);
+    assert!(!policy.claimed);
+}
+```
+
+---
+
+## Client Invocation (TypeScript)
+
+```ts
+import {
+  Contract,
+  TransactionBuilder,
+  rpc,
+  Networks,
+  BASE_FEE,
+  Address,
+  nativeToScVal,
+  Keypair,
+} from '@stellar/stellar-sdk';
+
+const server = new rpc.Server('https://soroban-testnet.stellar.org');
+const contract = new Contract('<INSURANCE_POOL_CONTRACT_ID>');
+
+async function buyPolicy(
+  ownerKeypair: Keypair,
+  coverage: bigint,
+  termSeconds: number
+) {
+  const account = await server.getAccount(ownerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'buy_policy',
+        new Address(ownerKeypair.publicKey()).toScVal(),
+        nativeToScVal(coverage, { type: 'i128' }),
+        nativeToScVal(termSeconds, { type: 'u64' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(ownerKeypair);
+  const result = await server.sendTransaction(prepared);
+  return result;
+}
+
+async function fileClaim(
+  ownerKeypair: Keypair,
+  policyId: bigint,
+  amount: bigint
+) {
+  const account = await server.getAccount(ownerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'file_claim',
+        new Address(ownerKeypair.publicKey()).toScVal(),
+        nativeToScVal(policyId, { type: 'u64' }),
+        nativeToScVal(amount, { type: 'i128' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(ownerKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+---
+
+## Deploying & Invoking with the CLI
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/soroban_insurance_pool.wasm \
+  --source admin --network testnet
+
+stellar contract invoke --id <CONTRACT_ID> --source admin --network testnet -- \
+  initialize --admin admin --token <TOKEN_CONTRACT_ID>
+
+stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- \
+  buy_policy --owner alice --coverage 10000000 --term_seconds 2592000
+```
+
+---
+
+## Related docs
+
+- [Comprehensive Soroban Token Contract Implementation Guide](/docs/guides/soroban-token-contract-guide) — the SEP-41 token used to collect premiums and pay claims
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — storage, auth, and cross-contract call primitives
+- [Analytics Integration for Stellar dApps](/docs/guides/analytics-integration-guide) — tracking claim-approval and payout events for a pool's dashboard

--- a/routes-d/927-soroban-reputation-weighted-voting-guide.mdx
+++ b/routes-d/927-soroban-reputation-weighted-voting-guide.mdx
@@ -1,0 +1,649 @@
+---
+title: Soroban Reputation-Weighted Voting Guide
+description: A comprehensive guide to a Soroban voting contract where each voter's influence is weighted by an on-chain reputation score, covering weight sourcing and vote tabulation.
+date: 2026-08-27
+---
+
+# Soroban Reputation-Weighted Voting Guide
+
+In a **reputation-weighted vote**, each participant's ballot counts proportionally to a reputation score rather than 1-address-1-vote — useful for DAOs where contribution history, stake duration, or an external credential should carry more weight than a freshly-created account. This guide covers where the reputation score comes from, how it's read at vote time, and how tabulation works.
+
+<Note type="info">
+  This contract *consumes* a reputation score — it does not compute one. See
+  [Weight Sourcing](#weight-sourcing) below for the two supported models and
+  their trade-offs.
+</Note>
+
+---
+
+## How It Works
+
+```
+Admin ──create_proposal(question, options, ends_at)──► Voting Contract
+                                                        │
+                                                        └── store Proposal { options, tallies: [0, 0, ...], ends_at }
+
+Voter ──cast_vote(proposal_id, option_index)──────────► Voting Contract
+                                                        │
+                                                        ├── require_auth() on voter
+                                                        ├── verify proposal still open (now < ends_at)
+                                                        ├── verify voter has not already voted on this proposal
+                                                        ├── weight = reputation_client.score_of(voter)
+                                                        └── tallies[option_index] += weight
+
+Anyone ──results(proposal_id)─────────────────────────► Voting Contract
+                                                        └── returns Proposal (tallies, winner if closed)
+```
+
+Vote weight is looked up **at the time of voting**, not snapshotted at proposal creation — see [Weight Sourcing](#weight-sourcing) for why that matters and how to change it.
+
+---
+
+## Weight Sourcing
+
+There are two common ways to source a reputation score, with different trust and manipulation trade-offs:
+
+| Model                                | How it works                                                                                      | Pro                                                                                     | Con                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cross-contract call** (this guide) | Voting contract calls a separate `ReputationRegistry` contract's `score_of(address)` at vote time | Reputation stays current; one registry serves many voting contracts                     | A voter's weight can change between when they decide to vote and when the transaction lands, and the registry becomes a dependency every vote transaction relies on |
+| **Snapshot at proposal creation**    | Proposal creation copies each eligible voter's score into the proposal itself                     | Voting is self-contained — no cross-contract call per vote, weight can't shift mid-vote | Requires enumerating all eligible voters up front, which doesn't scale past a bounded allow-list                                                                    |
+
+This guide implements the cross-contract model, since it composes with an existing reputation system (e.g. one built from contribution counts, stake duration, or attestations) without requiring the voting contract to know how reputation is computed.
+
+<Note type="warning">
+  Because weight is read live, a reputation score that itself changes based on
+  recent on-chain activity is manipulable by an attacker who can pump their
+  score immediately before voting and let it decay after. If your reputation
+  source updates frequently, prefer the snapshot model for proposals with a
+  bounded, known voter set.
+</Note>
+
+---
+
+## Project Layout
+
+```
+reputation-vote/
+├── Cargo.toml
+└── contracts/
+    ├── reputation-registry/       # minimal reputation source for this guide
+    │   ├── Cargo.toml
+    │   └── src/
+    │       ├── lib.rs
+    │       └── test.rs
+    └── reputation-vote/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── types.rs
+            ├── error.rs
+            ├── proposal.rs
+            └── test.rs
+```
+
+### Voting Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-reputation-vote"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+```
+
+---
+
+## The Reputation Registry (Weight Source)
+
+A minimal registry with an admin-settable score per address — a stand-in for whatever your real reputation computation is (contribution counts, stake duration, off-chain attestations bridged on-chain, etc.).
+
+```rust
+// contracts/reputation-registry/src/lib.rs
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotInitialized = 1,
+    Unauthorized = 2,
+}
+
+#[contracttype]
+enum DataKey {
+    Admin,
+    Score(Address),
+}
+
+#[contract]
+pub struct ReputationRegistry;
+
+#[contractimpl]
+impl ReputationRegistry {
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Admin-settable score. In a real system this would be computed from
+    /// on-chain history (see the trade-offs discussion above) rather than
+    /// set directly — kept simple here so the voting contract's own logic
+    /// is the focus of this guide.
+    pub fn set_score(env: Env, admin: Address, who: Address, score: u32) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().persistent().set(&DataKey::Score(who), &score);
+        Ok(())
+    }
+
+    /// Anyone may read a score — reputation is public by design here.
+    /// Defaults to 1 (base weight) so an unregistered voter still counts
+    /// once, rather than being silently excluded.
+    pub fn score_of(env: Env, who: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Score(who))
+            .unwrap_or(1)
+    }
+}
+
+#[cfg(test)]
+mod test;
+```
+
+---
+
+## Types and Errors
+
+```rust
+// contracts/reputation-vote/src/types.rs
+use soroban_sdk::{contracttype, Address, String, Vec};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Proposal {
+    pub question: String,
+    pub options: Vec<String>,
+    /// Parallel to `options` — tallies[i] is the weighted vote total for options[i].
+    pub tallies: Vec<u64>,
+    pub ends_at: u64,
+    pub created_by: Address,
+}
+
+#[contracttype]
+pub enum DataKey {
+    ReputationRegistry,
+    NextProposalId,
+    Proposal(u64),
+    /// Tracks (proposal_id, voter) pairs that have already voted.
+    HasVoted(u64, Address),
+}
+```
+
+```rust
+// contracts/reputation-vote/src/error.rs
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotInitialized = 1,
+    NotFound = 2,
+    ProposalClosed = 3,
+    AlreadyVoted = 4,
+    InvalidOption = 5,
+    TooFewOptions = 6,
+}
+```
+
+---
+
+## Proposal Creation and Voting
+
+```rust
+// contracts/reputation-vote/src/proposal.rs
+use soroban_sdk::{Address, Env, String, Vec};
+use crate::error::Error;
+use crate::types::{DataKey, Proposal};
+
+pub fn create_proposal(
+    env: &Env,
+    creator: Address,
+    question: String,
+    options: Vec<String>,
+    ends_at: u64,
+) -> Result<u64, Error> {
+    creator.require_auth();
+
+    if options.len() < 2 {
+        return Err(Error::TooFewOptions);
+    }
+
+    let mut tallies = Vec::new(env);
+    for _ in 0..options.len() {
+        tallies.push_back(0u64);
+    }
+
+    let id: u64 = env.storage().instance().get(&DataKey::NextProposalId).unwrap_or(0);
+    env.storage().instance().set(&DataKey::NextProposalId, &(id + 1));
+
+    let proposal = Proposal {
+        question,
+        options,
+        tallies,
+        ends_at,
+        created_by: creator,
+    };
+    env.storage().persistent().set(&DataKey::Proposal(id), &proposal);
+
+    Ok(id)
+}
+
+pub fn cast_vote(env: &Env, voter: Address, proposal_id: u64, option_index: u32) -> Result<(), Error> {
+    voter.require_auth();
+
+    let mut proposal: Proposal = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Proposal(proposal_id))
+        .ok_or(Error::NotFound)?;
+
+    if env.ledger().timestamp() >= proposal.ends_at {
+        return Err(Error::ProposalClosed);
+    }
+
+    if option_index as u32 >= proposal.options.len() {
+        return Err(Error::InvalidOption);
+    }
+
+    let voted_key = DataKey::HasVoted(proposal_id, voter.clone());
+    if env.storage().persistent().has(&voted_key) {
+        return Err(Error::AlreadyVoted);
+    }
+
+    // Weight is read live from the reputation registry — see "Weight
+    // Sourcing" in the guide for why this is a cross-contract call rather
+    // than a value stored on the proposal.
+    let registry: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::ReputationRegistry)
+        .ok_or(Error::NotInitialized)?;
+    let weight: u32 = env.invoke_contract(
+        &registry,
+        &soroban_sdk::symbol_short!("score_of"),
+        soroban_sdk::vec![env, voter.clone().into_val(env)],
+    );
+
+    let current = proposal.tallies.get(option_index).unwrap_or(0);
+    proposal.tallies.set(option_index, current + weight as u64);
+
+    env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
+    env.storage().persistent().set(&voted_key, &true);
+
+    Ok(())
+}
+
+pub fn results(env: &Env, proposal_id: u64) -> Result<Proposal, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Proposal(proposal_id))
+        .ok_or(Error::NotFound)
+}
+
+/// Returns the index of the option with the highest tally, or `None` if
+/// all tallies are tied at the maximum (a genuine tie has no single
+/// winner — callers should handle that case explicitly rather than
+/// silently picking the first tied option).
+pub fn winning_option(proposal: &Proposal) -> Option<u32> {
+    let mut best_index: Option<u32> = None;
+    let mut best_score: u64 = 0;
+    let mut tie = false;
+
+    for (i, tally) in proposal.tallies.iter().enumerate() {
+        if tally > best_score {
+            best_score = tally;
+            best_index = Some(i as u32);
+            tie = false;
+        } else if tally == best_score && best_index.is_some() {
+            tie = true;
+        }
+    }
+
+    if tie {
+        None
+    } else {
+        best_index
+    }
+}
+```
+
+---
+
+## Contract Entrypoints
+
+```rust
+// contracts/reputation-vote/src/lib.rs
+#![no_std]
+
+mod error;
+mod proposal;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use error::Error;
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use types::{DataKey, Proposal};
+
+#[contract]
+pub struct ReputationVote;
+
+#[contractimpl]
+impl ReputationVote {
+    pub fn initialize(env: Env, reputation_registry: Address) {
+        env.storage()
+            .instance()
+            .set(&DataKey::ReputationRegistry, &reputation_registry);
+    }
+
+    pub fn create_proposal(
+        env: Env,
+        creator: Address,
+        question: String,
+        options: Vec<String>,
+        ends_at: u64,
+    ) -> Result<u64, Error> {
+        proposal::create_proposal(&env, creator, question, options, ends_at)
+    }
+
+    pub fn cast_vote(env: Env, voter: Address, proposal_id: u64, option_index: u32) -> Result<(), Error> {
+        proposal::cast_vote(&env, voter, proposal_id, option_index)
+    }
+
+    pub fn results(env: Env, proposal_id: u64) -> Result<Proposal, Error> {
+        proposal::results(&env, proposal_id)
+    }
+}
+```
+
+---
+
+## Vote Tabulation Details
+
+- **Weighted, not ranked**: each vote adds the voter's full reputation weight to exactly one option — this is weighted plurality voting, not ranked-choice or quadratic voting. Adapting to quadratic voting would mean tallying `sqrt(weight)` per vote instead, which trades simplicity for resistance to a single high-reputation voter dominating a proposal.
+- **No re-voting**: `HasVoted(proposal_id, voter)` is a one-time flag — a voter cannot change their vote once cast. If you want vote-changing, replace the flag with a stored `(option_index, weight)` pair so a repeat call can subtract the old tally before adding the new one.
+- **Closed-proposal reads still work**: `results()` has no `ends_at` check — proposals remain readable (and their final tallies visible) forever after closing. Only `cast_vote` enforces the deadline.
+- **Ties are explicit**: `winning_option()` returns `None` on a tie at the top rather than arbitrarily picking the first-indexed option, so callers must decide how to break ties (re-vote, split outcome, deny) rather than have that decision made implicitly by array order.
+
+---
+
+## Tests
+
+```rust
+// contracts/reputation-vote/src/test.rs
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use crate::{error::Error, proposal::winning_option, ReputationVote, ReputationVoteClient};
+
+// Minimal inline mock standing in for the reputation-registry contract,
+// so this test file doesn't depend on cross-crate wiring — in a real repo
+// you'd register the actual ReputationRegistry contract from the sibling
+// crate instead.
+mod mock_registry {
+    use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+    #[contracttype]
+    enum DataKey {
+        Score(Address),
+    }
+
+    #[contract]
+    pub struct MockRegistry;
+
+    #[contractimpl]
+    impl MockRegistry {
+        pub fn set_score(env: Env, who: Address, score: u32) {
+            env.storage().persistent().set(&DataKey::Score(who), &score);
+        }
+
+        pub fn score_of(env: Env, who: Address) -> u32 {
+            env.storage().persistent().get(&DataKey::Score(who)).unwrap_or(1)
+        }
+    }
+}
+
+fn setup(env: &Env) -> (ReputationVoteClient, mock_registry::MockRegistryClient) {
+    let registry_id = env.register(mock_registry::MockRegistry, ());
+    let registry_client = mock_registry::MockRegistryClient::new(env, &registry_id);
+
+    let vote_id = env.register(ReputationVote, ());
+    let vote_client = ReputationVoteClient::new(env, &vote_id);
+    vote_client.initialize(&registry_id);
+
+    (vote_client, registry_client)
+}
+
+fn options(env: &Env, values: &[&str]) -> soroban_sdk::Vec<String> {
+    let mut v = soroban_sdk::Vec::new(env);
+    for value in values {
+        v.push_back(String::from_str(env, value));
+    }
+    v
+}
+
+#[test]
+fn cast_vote_adds_full_reputation_weight() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env);
+    registry.set_score(&voter, &42);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Fund the grants program?"),
+        &options(&env, &["Yes", "No"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    vote.cast_vote(&voter, &proposal_id, &0);
+
+    let result = vote.results(&proposal_id);
+    assert_eq!(result.tallies.get(0), Some(42));
+    assert_eq!(result.tallies.get(1), Some(0));
+}
+
+#[test]
+fn unregistered_voter_gets_base_weight_of_one() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, _registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env); // never given a score
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    vote.cast_vote(&voter, &proposal_id, &1);
+
+    let result = vote.results(&proposal_id);
+    assert_eq!(result.tallies.get(1), Some(1));
+}
+
+#[test]
+fn double_vote_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env);
+    registry.set_score(&voter, &10);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    vote.cast_vote(&voter, &proposal_id, &0);
+    let result = vote.try_cast_vote(&voter, &proposal_id, &1);
+
+    assert_eq!(result, Err(Ok(Error::AlreadyVoted)));
+}
+
+#[test]
+fn vote_after_deadline_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env);
+    registry.set_score(&voter, &10);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 100),
+    );
+
+    env.ledger().with_mut(|l| l.timestamp += 200);
+
+    let result = vote.try_cast_vote(&voter, &proposal_id, &0);
+    assert_eq!(result, Err(Ok(Error::ProposalClosed)));
+}
+
+#[test]
+fn invalid_option_index_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env);
+    registry.set_score(&voter, &10);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    let result = vote.try_cast_vote(&voter, &proposal_id, &5);
+    assert_eq!(result, Err(Ok(Error::InvalidOption)));
+}
+
+#[test]
+fn creating_proposal_with_fewer_than_two_options_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, _registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let result = vote.try_create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["Only one"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    assert_eq!(result, Err(Ok(Error::TooFewOptions)));
+}
+
+#[test]
+fn weighted_tabulation_reflects_multiple_voters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let whale = Address::generate(&env);
+    let small_a = Address::generate(&env);
+    let small_b = Address::generate(&env);
+    registry.set_score(&whale, &100);
+    registry.set_score(&small_a, &5);
+    registry.set_score(&small_b, &5);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    // Two small voters pick B, one whale picks A — the whale still wins.
+    vote.cast_vote(&small_a, &proposal_id, &1);
+    vote.cast_vote(&small_b, &proposal_id, &1);
+    vote.cast_vote(&whale, &proposal_id, &0);
+
+    let result = vote.results(&proposal_id);
+    assert_eq!(result.tallies.get(0), Some(100));
+    assert_eq!(result.tallies.get(1), Some(10));
+    assert_eq!(winning_option(&result), Some(0));
+}
+
+#[test]
+fn tied_tallies_return_no_winner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (vote, registry) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let voter_a = Address::generate(&env);
+    let voter_b = Address::generate(&env);
+    registry.set_score(&voter_a, &10);
+    registry.set_score(&voter_b, &10);
+
+    let proposal_id = vote.create_proposal(
+        &creator,
+        &String::from_str(&env, "Q"),
+        &options(&env, &["A", "B"]),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    vote.cast_vote(&voter_a, &proposal_id, &0);
+    vote.cast_vote(&voter_b, &proposal_id, &1);
+
+    let result = vote.results(&proposal_id);
+    assert_eq!(winning_option(&result), None);
+}
+```
+
+---
+
+## Related docs
+
+- [Leaderboard from Ledger Events](/docs/guides/leaderboard-from-ledger-events) — a related pattern for deriving on-chain scores from event history, applicable to computing a real reputation score
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — cross-contract calls, storage, and auth primitives
+- [Privacy Considerations](/docs/guides/privacy-considerations) — reputation scores and vote choices are both public on-chain data

--- a/routes-d/928-soroban-did-contract-tutorial.mdx
+++ b/routes-d/928-soroban-did-contract-tutorial.mdx
@@ -1,0 +1,627 @@
+---
+title: Building a Soroban Decentralized Identifier (DID) Contract
+description: End-to-end tutorial for a Soroban DID registry contract — DID creation, key rotation, document updates, and revocation — with a working sample and client invocation.
+date: 2026-08-27
+---
+
+# Building a Soroban Decentralized Identifier (DID) Contract
+
+A **DID (Decentralized Identifier)** contract lets a Stellar account publish a self-owned identity document — a set of verification keys and service endpoints — that other contracts and off-chain services can resolve and trust, without relying on a centralized identity provider. This tutorial builds a minimal `did:soroban:` method contract: registration, document updates, key rotation, and revocation.
+
+<Note type="info">
+  This follows the shape of the [W3C DID Core](https://www.w3.org/TR/did-core/)
+  data model (a DID resolves to a DID Document containing verification methods)
+  adapted to Soroban's storage model, but does not implement a full DID method
+  specification. Treat it as a foundation, not a spec-compliant `did:soroban`
+  resolver.
+</Note>
+
+---
+
+## How It Works
+
+```
+Owner ──register(initial_key, service_endpoint)──► DID Registry
+                                                     │
+                                                     ├── require_auth() on owner
+                                                     ├── verify no existing DID for owner
+                                                     └── store DidDocument { keys: [initial_key], endpoint, revoked: false }
+
+Owner ──rotate_key(old_key, new_key)────────────────► DID Registry
+                                                     │
+                                                     ├── require_auth() on owner
+                                                     ├── verify old_key is a current verification key
+                                                     └── replace old_key with new_key in keys[]
+
+Owner ──update_endpoint(new_endpoint)───────────────► DID Registry
+                                                     │
+                                                     ├── require_auth() on owner
+                                                     └── overwrite service_endpoint
+
+Owner ──revoke()─────────────────────────────────────► DID Registry
+                                                     │
+                                                     ├── require_auth() on owner
+                                                     └── set revoked = true (DID stays resolvable, marked invalid)
+
+Anyone ──resolve(owner)──────────────────────────────► DID Registry
+                                                     └── returns DidDocument (read-only, no auth)
+```
+
+A DID here is identified by the owning Stellar `Address` itself (`did:soroban:<address>`), so there is no separate identifier-allocation step — the account _is_ the identifier, and the contract manages what it currently attests to.
+
+---
+
+## Project Layout
+
+```
+did-registry/
+├── Cargo.toml
+└── contracts/
+    └── did-registry/
+        ├── Cargo.toml
+        └── src/
+            ├── lib.rs
+            ├── types.rs
+            ├── document.rs
+            ├── error.rs
+            └── test.rs
+```
+
+### Contract Cargo.toml
+
+```toml
+[package]
+name = "soroban-did-registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+```
+
+---
+
+## Types and Storage
+
+```rust
+// src/types.rs
+use soroban_sdk::{contracttype, Address, String, Vec};
+
+/// A minimal DID Document: one or more verification keys (any of which can
+/// authorize document updates), a single service endpoint URL, and a
+/// revocation flag. A production method would support multiple typed
+/// verification relationships (authentication, assertion, key agreement)
+/// and multiple service entries — this keeps the storage shape simple.
+#[derive(Clone)]
+#[contracttype]
+pub struct DidDocument {
+    pub owner: Address,
+    pub keys: Vec<Address>,
+    pub service_endpoint: String,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub revoked: bool,
+}
+
+#[contracttype]
+pub enum DataKey {
+    /// Keyed by the owning Address — the DID identifier itself.
+    Document(Address),
+}
+```
+
+```rust
+// src/error.rs
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyRegistered = 1,
+    NotFound = 2,
+    Unauthorized = 3,
+    Revoked = 4,
+    KeyNotFound = 5,
+    DuplicateKey = 6,
+    CannotRemoveLastKey = 7,
+}
+```
+
+---
+
+## Registration and Resolution
+
+```rust
+// src/document.rs (part 1 — register, resolve)
+use soroban_sdk::{Address, Env, String, Vec};
+use crate::error::Error;
+use crate::types::{DataKey, DidDocument};
+
+pub fn register(
+    env: &Env,
+    owner: Address,
+    initial_key: Address,
+    service_endpoint: String,
+) -> Result<(), Error> {
+    owner.require_auth();
+
+    let key = DataKey::Document(owner.clone());
+    if env.storage().persistent().has(&key) {
+        return Err(Error::AlreadyRegistered);
+    }
+
+    let mut keys = Vec::new(env);
+    keys.push_back(initial_key);
+
+    let now = env.ledger().timestamp();
+    let document = DidDocument {
+        owner: owner.clone(),
+        keys,
+        service_endpoint,
+        created_at: now,
+        updated_at: now,
+        revoked: false,
+    };
+
+    env.storage().persistent().set(&key, &document);
+    Ok(())
+}
+
+/// Read-only resolution — no auth required, matching how DID resolution
+/// works off-chain (anyone can look up a public DID Document).
+pub fn resolve(env: &Env, owner: Address) -> Result<DidDocument, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Document(owner))
+        .ok_or(Error::NotFound)
+}
+```
+
+---
+
+## Key Rotation, Endpoint Updates, and Revocation
+
+```rust
+// src/document.rs (part 2 — mutations)
+use soroban_sdk::{Address, Env, String};
+use crate::error::Error;
+use crate::types::DataKey;
+
+fn load_active_document(
+    env: &Env,
+    owner: &Address,
+) -> Result<crate::types::DidDocument, Error> {
+    let document: crate::types::DidDocument = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Document(owner.clone()))
+        .ok_or(Error::NotFound)?;
+
+    if document.revoked {
+        return Err(Error::Revoked);
+    }
+
+    Ok(document)
+}
+
+pub fn rotate_key(env: &Env, owner: Address, old_key: Address, new_key: Address) -> Result<(), Error> {
+    owner.require_auth();
+
+    let mut document = load_active_document(env, &owner)?;
+
+    let position = document.keys.iter().position(|k| k == old_key).ok_or(Error::KeyNotFound)?;
+    if document.keys.iter().any(|k| k == new_key) {
+        return Err(Error::DuplicateKey);
+    }
+
+    document.keys.set(position as u32, new_key);
+    document.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Document(owner), &document);
+    Ok(())
+}
+
+/// Adds an additional verification key without removing an existing one —
+/// useful for multi-device setups where you want more than one key valid
+/// at once, unlike `rotate_key` which is a 1:1 replacement.
+pub fn add_key(env: &Env, owner: Address, new_key: Address) -> Result<(), Error> {
+    owner.require_auth();
+
+    let mut document = load_active_document(env, &owner)?;
+
+    if document.keys.iter().any(|k| k == new_key) {
+        return Err(Error::DuplicateKey);
+    }
+
+    document.keys.push_back(new_key);
+    document.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Document(owner), &document);
+    Ok(())
+}
+
+pub fn remove_key(env: &Env, owner: Address, key: Address) -> Result<(), Error> {
+    owner.require_auth();
+
+    let mut document = load_active_document(env, &owner)?;
+
+    if document.keys.len() <= 1 {
+        // A DID with zero verification keys can never authorize another
+        // update again — refuse to remove the last one.
+        return Err(Error::CannotRemoveLastKey);
+    }
+
+    let position = document.keys.iter().position(|k| k == key).ok_or(Error::KeyNotFound)?;
+    document.keys.remove(position as u32);
+    document.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Document(owner), &document);
+    Ok(())
+}
+
+pub fn update_endpoint(env: &Env, owner: Address, new_endpoint: String) -> Result<(), Error> {
+    owner.require_auth();
+
+    let mut document = load_active_document(env, &owner)?;
+    document.service_endpoint = new_endpoint;
+    document.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Document(owner), &document);
+    Ok(())
+}
+
+/// Revocation is a soft-delete: the document remains resolvable (so
+/// verifiers can distinguish "never existed" from "was revoked") but the
+/// `revoked` flag blocks all further mutations.
+pub fn revoke(env: &Env, owner: Address) -> Result<(), Error> {
+    owner.require_auth();
+
+    let mut document = load_active_document(env, &owner)?;
+    document.revoked = true;
+    document.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Document(owner), &document);
+    Ok(())
+}
+```
+
+---
+
+## Contract Entrypoints
+
+```rust
+// src/lib.rs
+#![no_std]
+
+mod document;
+mod error;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use error::Error;
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use types::DidDocument;
+
+#[contract]
+pub struct DidRegistry;
+
+#[contractimpl]
+impl DidRegistry {
+    pub fn register(env: Env, owner: Address, initial_key: Address, service_endpoint: String) -> Result<(), Error> {
+        document::register(&env, owner, initial_key, service_endpoint)
+    }
+
+    pub fn resolve(env: Env, owner: Address) -> Result<DidDocument, Error> {
+        document::resolve(&env, owner)
+    }
+
+    pub fn rotate_key(env: Env, owner: Address, old_key: Address, new_key: Address) -> Result<(), Error> {
+        document::rotate_key(&env, owner, old_key, new_key)
+    }
+
+    pub fn add_key(env: Env, owner: Address, new_key: Address) -> Result<(), Error> {
+        document::add_key(&env, owner, new_key)
+    }
+
+    pub fn remove_key(env: Env, owner: Address, key: Address) -> Result<(), Error> {
+        document::remove_key(&env, owner, key)
+    }
+
+    pub fn update_endpoint(env: Env, owner: Address, new_endpoint: String) -> Result<(), Error> {
+        document::update_endpoint(&env, owner, new_endpoint)
+    }
+
+    pub fn revoke(env: Env, owner: Address) -> Result<(), Error> {
+        document::revoke(&env, owner)
+    }
+}
+```
+
+---
+
+## Privacy Considerations
+
+<Note type="warning">
+  Everything written to contract storage is public — including via archived
+  ledger history, even after a value is overwritten. Do not put personally
+  identifiable information (names, emails, physical addresses) directly in
+  `service_endpoint` or any future document fields. Store only a pointer (a URL
+  to an off-chain, access-controlled document, or a content hash) and keep the
+  actual PII off-chain.
+</Note>
+
+- **Correlation risk**: because a DID is keyed by the owning `Address`, resolving it links that address to whatever the `service_endpoint` points to. If the endpoint is meant to be pseudonymous, don't reuse an address that's already publicly tied to a real identity elsewhere.
+- **Revocation is not deletion**: `revoke()` sets a flag; the document (including all past keys, visible via ledger history) remains permanently readable. This is a Soroban storage property, not something this contract can opt out of — design your off-chain systems assuming DID history is public and immutable.
+- **Key rotation cadence**: encourage periodic `rotate_key` calls for long-lived DIDs, the same way you'd rotate a signing key in any PKI system — a single long-lived key is a bigger blast radius if compromised.
+
+---
+
+## Tests
+
+```rust
+// src/test.rs
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use crate::{error::Error, DidRegistry, DidRegistryClient};
+
+fn setup(env: &Env) -> DidRegistryClient {
+    let contract_id = env.register(DidRegistry, ());
+    DidRegistryClient::new(env, &contract_id)
+}
+
+#[test]
+fn register_creates_a_resolvable_document() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/did-service");
+
+    client.register(&owner, &key, &endpoint);
+    let doc = client.resolve(&owner);
+
+    assert_eq!(doc.owner, owner);
+    assert_eq!(doc.keys.len(), 1);
+    assert!(!doc.revoked);
+}
+
+#[test]
+fn double_registration_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &key, &endpoint);
+    let result = client.try_register(&owner, &key, &endpoint);
+
+    assert_eq!(result, Err(Ok(Error::AlreadyRegistered)));
+}
+
+#[test]
+fn rotate_key_replaces_old_key_with_new_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let old_key = Address::generate(&env);
+    let new_key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &old_key, &endpoint);
+    client.rotate_key(&owner, &old_key, &new_key);
+
+    let doc = client.resolve(&owner);
+    assert!(doc.keys.iter().any(|k| k == new_key));
+    assert!(!doc.keys.iter().any(|k| k == old_key));
+}
+
+#[test]
+fn rotate_unknown_key_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let real_key = Address::generate(&env);
+    let unrelated_key = Address::generate(&env);
+    let new_key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &real_key, &endpoint);
+    let result = client.try_rotate_key(&owner, &unrelated_key, &new_key);
+
+    assert_eq!(result, Err(Ok(Error::KeyNotFound)));
+}
+
+#[test]
+fn remove_last_key_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &key, &endpoint);
+    let result = client.try_remove_key(&owner, &key);
+
+    assert_eq!(result, Err(Ok(Error::CannotRemoveLastKey)));
+}
+
+#[test]
+fn remove_key_succeeds_when_multiple_keys_exist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key_a = Address::generate(&env);
+    let key_b = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &key_a, &endpoint);
+    client.add_key(&owner, &key_b);
+    client.remove_key(&owner, &key_a);
+
+    let doc = client.resolve(&owner);
+    assert_eq!(doc.keys.len(), 1);
+    assert!(doc.keys.iter().any(|k| k == key_b));
+}
+
+#[test]
+fn revoked_document_rejects_further_mutations_but_still_resolves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key = Address::generate(&env);
+    let new_key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+
+    client.register(&owner, &key, &endpoint);
+    client.revoke(&owner);
+
+    let doc = client.resolve(&owner);
+    assert!(doc.revoked);
+
+    let result = client.try_rotate_key(&owner, &key, &new_key);
+    assert_eq!(result, Err(Ok(Error::Revoked)));
+}
+
+#[test]
+fn update_endpoint_by_non_owner_rejected() {
+    let env = Env::default();
+    // No mock_all_auths(): resolving requires no auth, but require_auth()
+    // inside update_endpoint must fail without an authorized invocation.
+    let client = setup(&env);
+
+    let owner = Address::generate(&env);
+    let key = Address::generate(&env);
+    let endpoint = String::from_str(&env, "https://example.com/a");
+    let new_endpoint = String::from_str(&env, "https://example.com/b");
+
+    env.mock_all_auths();
+    client.register(&owner, &key, &endpoint);
+
+    env.set_auths(&[]);
+    let result = client.try_update_endpoint(&owner, &new_endpoint);
+    assert!(result.is_err());
+}
+```
+
+---
+
+## Client Invocation (TypeScript)
+
+```ts
+import {
+  Contract,
+  TransactionBuilder,
+  rpc,
+  Networks,
+  BASE_FEE,
+  Address,
+  nativeToScVal,
+  Keypair,
+} from '@stellar/stellar-sdk';
+
+const server = new rpc.Server('https://soroban-testnet.stellar.org');
+const contract = new Contract('<DID_REGISTRY_CONTRACT_ID>');
+
+async function registerDid(
+  ownerKeypair: Keypair,
+  initialKey: string,
+  serviceEndpoint: string
+) {
+  const account = await server.getAccount(ownerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        'register',
+        new Address(ownerKeypair.publicKey()).toScVal(),
+        new Address(initialKey).toScVal(),
+        nativeToScVal(serviceEndpoint, { type: 'string' })
+      )
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(ownerKeypair);
+  return server.sendTransaction(prepared);
+}
+
+// resolve() takes no auth — simulate rather than submit a transaction.
+async function resolveDid(ownerPublicKey: string) {
+  const account = await server.getAccount(ownerPublicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call('resolve', new Address(ownerPublicKey).toScVal())
+    )
+    .setTimeout(30)
+    .build();
+
+  const simulated = await server.simulateTransaction(tx);
+  return simulated;
+}
+```
+
+---
+
+## Deploying & Invoking with the CLI
+
+```bash
+stellar contract build
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/soroban_did_registry.wasm \
+  --source alice --network testnet
+
+stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- \
+  register --owner alice --initial_key alice --service_endpoint "https://example.com/did-service"
+
+stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- \
+  resolve --owner alice
+```
+
+---
+
+## Related docs
+
+- [Soroban Host Functions](/docs/guides/soroban-host-functions) — storage, auth, and cross-contract call primitives
+- [Privacy Considerations](/docs/guides/privacy-considerations) — general privacy guidance for on-chain data
+- [Signing with Hardware Wallets](/docs/guides/signing-with-hardware-wallets) — pairs well with key rotation for high-value DIDs

--- a/routes-d/934-stellar-analytics-dashboard-tutorial.mdx
+++ b/routes-d/934-stellar-analytics-dashboard-tutorial.mdx
@@ -1,0 +1,577 @@
+---
+title: Building a Stellar dApp Analytics Dashboard
+description: A complete tutorial for building a small analytics dashboard for a Stellar dApp — event tracking, aggregation, privacy considerations, and a working React sample.
+date: 2026-08-27
+---
+
+# Building a Stellar dApp Analytics Dashboard
+
+This tutorial builds a small, self-hosted **analytics dashboard** for a Stellar dApp: an event-ingestion endpoint, an aggregation store, and a React dashboard that renders the aggregates as charts. It assumes you're already tracking events client-side — see the [Analytics Integration Guide](/docs/guides/analytics-integration-guide) for what to track and why — and picks up from "I have events" to "I have a dashboard."
+
+<Note type="info">
+  This is a minimal, self-hosted reference implementation (in-memory
+  aggregation, one Next.js route). For production traffic, swap the in-memory
+  store for a real time-series database (see [Caching Layer
+  Tutorial](/docs/guides/caching-layer-tutorial) for a Redis-backed pattern that
+  generalizes to this) — the ingestion and aggregation *shape* stays the same.
+</Note>
+
+---
+
+## What This Dashboard Tracks
+
+Following the event taxonomy from the [Analytics Integration Guide](/docs/guides/analytics-integration-guide#events-worth-tracking), this dashboard aggregates four metrics:
+
+| Metric                      | Source event                                                             | Aggregation                                 |
+| --------------------------- | ------------------------------------------------------------------------ | ------------------------------------------- |
+| Daily active wallets        | `dapp_initialized`                                                       | Count of distinct `wallet_address` per day  |
+| Wallet connect success rate | `wallet_connect_attempted` / `wallet_connect_succeeded`                  | Ratio per day                               |
+| Transaction success rate    | `transaction_submitted` / `transaction_confirmed` / `transaction_failed` | Ratio per day                               |
+| Top contract calls          | `contract_invoked`                                                       | Count grouped by `contract_id` + `function` |
+
+---
+
+## Architecture
+
+```
+Client (dApp)                Ingestion Route              Aggregation Store            Dashboard
+─────────────                ────────────────              ──────────────────           ─────────
+trackEvent(name, props) ──►  POST /api/analytics/ingest
+                                    │
+                                    ├── validate event shape
+                                    ├── strip/hash any raw wallet address    (privacy)
+                                    └── append to day-bucketed store  ────►  Map<day, Metrics>
+
+                                                                                              GET /api/analytics/summary
+                                                                             ◄──────────────────────┘
+                                                                                              │
+                                                                                    Dashboard renders charts
+```
+
+Ingestion and aggregation are deliberately separate steps: the ingestion route does the minimum work to validate and privacy-scrub an event, then a background aggregation step (here, done inline for simplicity) rolls it into the day bucket. This keeps ingestion latency low even if aggregation logic grows more complex later.
+
+---
+
+## Privacy Considerations
+
+<Note type="warning">
+  Wallet addresses are pseudonymous, not anonymous — an address that appears in
+  your dashboard alongside timestamps and transaction amounts can often be
+  re-identified by cross-referencing a public block explorer. Treat addresses in
+  analytics data with the same care as any other user identifier.
+</Note>
+
+- **Hash, don't store raw addresses for counting.** "Daily active wallets" only needs to know _how many distinct_ addresses were active, not _which_ ones — hash the address with a server-side secret salt before it ever reaches the aggregation store, so raw addresses never sit in your analytics database.
+- **Aggregate before you persist.** The dashboard should read pre-aggregated daily rollups, not raw per-event rows keyed by address — that way a database breach exposes counts and ratios, not a linkable per-user activity log.
+- **Don't track transaction amounts per-address.** Amount + address + timestamp is enough to identify a specific real-world transaction on a public ledger explorer. Track amount _distributions_ (e.g. bucketed ranges) if you need financial insight, not raw per-user amounts.
+- **Retention limits.** Decide a retention window (e.g. 90 days of daily rollups) and actually enforce it — indefinite retention of behavioral data is a growing regulatory liability even when individually-identifying fields are stripped.
+
+---
+
+## Ingestion Route
+
+```ts
+// app/api/analytics/ingest/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+import { recordEvent } from '@/lib/analytics-store';
+
+const VALID_EVENTS = new Set([
+  'dapp_initialized',
+  'wallet_connect_attempted',
+  'wallet_connect_succeeded',
+  'transaction_submitted',
+  'transaction_confirmed',
+  'transaction_failed',
+  'contract_invoked',
+]);
+
+// Server-only salt — never expose this value client-side. Rotating it
+// periodically breaks cross-day correlation of the same wallet, at the
+// cost of slightly undercounting "distinct wallets" across a rotation
+// boundary (a reasonable trade-off for stronger privacy).
+const HASH_SALT = process.env.ANALYTICS_HASH_SALT ?? '';
+
+function hashWalletAddress(address: string): string {
+  return createHash('sha256')
+    .update(`${HASH_SALT}:${address}`)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: { event?: unknown; wallet_address?: unknown; properties?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { event, wallet_address, properties } = body;
+
+  if (typeof event !== 'string' || !VALID_EVENTS.has(event)) {
+    return NextResponse.json(
+      {
+        error: `event is required and must be one of: ${Array.from(VALID_EVENTS).join(', ')}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  // Wallet address is optional (some events, like contract_invoked from a
+  // background job, have no associated end-user wallet) but hashed
+  // immediately when present — the raw address is never persisted.
+  const walletHash =
+    typeof wallet_address === 'string' && wallet_address.length > 0
+      ? hashWalletAddress(wallet_address)
+      : null;
+
+  recordEvent({
+    event,
+    walletHash,
+    properties:
+      typeof properties === 'object' && properties !== null ? properties : {},
+    day: new Date().toISOString().slice(0, 10), // YYYY-MM-DD, UTC bucket
+  });
+
+  return NextResponse.json({ recorded: true }, { status: 201 });
+}
+```
+
+---
+
+## Aggregation Store
+
+```ts
+// lib/analytics-store.ts
+export interface RecordedEvent {
+  event: string;
+  walletHash: string | null;
+  properties: Record<string, unknown>;
+  day: string; // YYYY-MM-DD
+}
+
+export interface DailyMetrics {
+  day: string;
+  activeWallets: Set<string>;
+  walletConnectAttempted: number;
+  walletConnectSucceeded: number;
+  transactionsSubmitted: number;
+  transactionsConfirmed: number;
+  transactionsFailed: number;
+  contractCalls: Map<string, number>; // "contractId:function" -> count
+}
+
+function emptyDay(day: string): DailyMetrics {
+  return {
+    day,
+    activeWallets: new Set(),
+    walletConnectAttempted: 0,
+    walletConnectSucceeded: 0,
+    transactionsSubmitted: 0,
+    transactionsConfirmed: 0,
+    transactionsFailed: 0,
+    contractCalls: new Map(),
+  };
+}
+
+const store = new Map<string, DailyMetrics>();
+
+export function recordEvent(evt: RecordedEvent): void {
+  let day = store.get(evt.day);
+  if (!day) {
+    day = emptyDay(evt.day);
+    store.set(evt.day, day);
+  }
+
+  switch (evt.event) {
+    case 'dapp_initialized':
+      if (evt.walletHash) day.activeWallets.add(evt.walletHash);
+      break;
+    case 'wallet_connect_attempted':
+      day.walletConnectAttempted += 1;
+      break;
+    case 'wallet_connect_succeeded':
+      day.walletConnectSucceeded += 1;
+      break;
+    case 'transaction_submitted':
+      day.transactionsSubmitted += 1;
+      break;
+    case 'transaction_confirmed':
+      day.transactionsConfirmed += 1;
+      break;
+    case 'transaction_failed':
+      day.transactionsFailed += 1;
+      break;
+    case 'contract_invoked': {
+      const contractId =
+        typeof evt.properties.contract_id === 'string'
+          ? evt.properties.contract_id
+          : 'unknown';
+      const fn =
+        typeof evt.properties.function === 'string'
+          ? evt.properties.function
+          : 'unknown';
+      const key = `${contractId}:${fn}`;
+      day.contractCalls.set(key, (day.contractCalls.get(key) ?? 0) + 1);
+      break;
+    }
+  }
+}
+
+export interface DailySummary {
+  day: string;
+  activeWallets: number;
+  walletConnectSuccessRate: number | null;
+  transactionSuccessRate: number | null;
+  topContractCalls: Array<{ key: string; count: number }>;
+}
+
+export function summarize(sinceDays: number): DailySummary[] {
+  const days = Array.from(store.values())
+    .sort((a, b) => a.day.localeCompare(b.day))
+    .slice(-sinceDays);
+
+  return days.map((d) => ({
+    day: d.day,
+    activeWallets: d.activeWallets.size,
+    walletConnectSuccessRate:
+      d.walletConnectAttempted > 0
+        ? d.walletConnectSucceeded / d.walletConnectAttempted
+        : null,
+    transactionSuccessRate:
+      d.transactionsSubmitted > 0
+        ? d.transactionsConfirmed / d.transactionsSubmitted
+        : null,
+    topContractCalls: Array.from(d.contractCalls.entries())
+      .map(([key, count]) => ({ key, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5),
+  }));
+}
+
+/** Exposed for tests — clears all recorded events between test cases. */
+export function resetStore(): void {
+  store.clear();
+}
+```
+
+---
+
+## Summary Route
+
+```ts
+// app/api/analytics/summary/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { summarize } from '@/lib/analytics-store';
+
+const DEFAULT_DAYS = 14;
+const MAX_DAYS = 90;
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const daysParam = req.nextUrl.searchParams.get('days');
+  let days = DEFAULT_DAYS;
+
+  if (daysParam !== null) {
+    const parsed = Number(daysParam);
+    if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_DAYS) {
+      return NextResponse.json(
+        { error: `days must be an integer between 1 and ${MAX_DAYS}` },
+        { status: 400 }
+      );
+    }
+    days = parsed;
+  }
+
+  return NextResponse.json({ days: summarize(days) });
+}
+```
+
+---
+
+## Dashboard Component
+
+```tsx
+// components/AnalyticsDashboard.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface DailySummary {
+  day: string;
+  activeWallets: number;
+  walletConnectSuccessRate: number | null;
+  transactionSuccessRate: number | null;
+  topContractCalls: Array<{ key: string; count: number }>;
+}
+
+function formatPercent(rate: number | null): string {
+  return rate === null ? '—' : `${(rate * 100).toFixed(1)}%`;
+}
+
+export default function AnalyticsDashboard() {
+  const [data, setData] = useState<DailySummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch('/api/analytics/summary?days=14')
+      .then((res) => {
+        if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+        return res.json();
+      })
+      .then((body) => {
+        if (!cancelled) setData(body.days);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return <p role="alert">Failed to load analytics: {error}</p>;
+  }
+
+  if (!data) {
+    return <p role="status">Loading analytics…</p>;
+  }
+
+  const latest = data[data.length - 1];
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid grid-cols-3 gap-4">
+        <div className="rounded-xl border p-4">
+          <p className="text-sm text-gray-500">Active Wallets (today)</p>
+          <p className="text-2xl font-semibold">{latest?.activeWallets ?? 0}</p>
+        </div>
+        <div className="rounded-xl border p-4">
+          <p className="text-sm text-gray-500">Wallet Connect Success</p>
+          <p className="text-2xl font-semibold">
+            {formatPercent(latest?.walletConnectSuccessRate ?? null)}
+          </p>
+        </div>
+        <div className="rounded-xl border p-4">
+          <p className="text-sm text-gray-500">Transaction Success</p>
+          <p className="text-2xl font-semibold">
+            {formatPercent(latest?.transactionSuccessRate ?? null)}
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h3 className="text-sm font-medium mb-2">Top Contract Calls (today)</h3>
+        <ul className="divide-y">
+          {(latest?.topContractCalls ?? []).map(({ key, count }) => (
+            <li key={key} className="flex justify-between py-2 text-sm">
+              <span className="font-mono">{key}</span>
+              <span>{count}</span>
+            </li>
+          ))}
+          {latest?.topContractCalls.length === 0 && (
+            <li className="py-2 text-sm text-gray-400">
+              No contract calls recorded yet.
+            </li>
+          )}
+        </ul>
+      </section>
+    </div>
+  );
+}
+```
+
+---
+
+## Verifying the Tutorial
+
+Ingest a few events and confirm they show up in the summary:
+
+```bash
+curl -X POST http://localhost:3000/api/analytics/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"event":"dapp_initialized","wallet_address":"GABC...XYZ"}'
+
+curl -X POST http://localhost:3000/api/analytics/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"event":"wallet_connect_attempted"}'
+
+curl -X POST http://localhost:3000/api/analytics/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"event":"wallet_connect_succeeded"}'
+
+curl -X POST http://localhost:3000/api/analytics/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"event":"contract_invoked","properties":{"contract_id":"CABC...","function":"transfer"}}'
+
+curl http://localhost:3000/api/analytics/summary?days=1
+```
+
+The summary response should show `activeWallets: 1`, `walletConnectSuccessRate: 1`, and one entry in `topContractCalls` for `CABC...:transfer`.
+
+Tests for the aggregation logic:
+
+```ts
+// lib/analytics-store.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordEvent, summarize, resetStore } from './analytics-store';
+
+describe('analytics-store', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('counts distinct active wallets per day, not raw events', () => {
+    const day = '2026-08-27';
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'hash-a',
+      properties: {},
+      day,
+    });
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'hash-a',
+      properties: {},
+      day,
+    }); // same wallet again
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'hash-b',
+      properties: {},
+      day,
+    });
+
+    const [summary] = summarize(1);
+    expect(summary.activeWallets).toBe(2);
+  });
+
+  it('computes wallet connect success rate as succeeded / attempted', () => {
+    const day = '2026-08-27';
+    recordEvent({
+      event: 'wallet_connect_attempted',
+      walletHash: null,
+      properties: {},
+      day,
+    });
+    recordEvent({
+      event: 'wallet_connect_attempted',
+      walletHash: null,
+      properties: {},
+      day,
+    });
+    recordEvent({
+      event: 'wallet_connect_succeeded',
+      walletHash: null,
+      properties: {},
+      day,
+    });
+
+    const [summary] = summarize(1);
+    expect(summary.walletConnectSuccessRate).toBe(0.5);
+  });
+
+  it('returns null success rate when there were zero attempts', () => {
+    const [summary] = summarize(1);
+    expect(summary).toBeUndefined(); // no events recorded at all -> no day bucket
+  });
+
+  it('returns null transaction success rate for a day with zero submissions', () => {
+    const day = '2026-08-27';
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'hash-a',
+      properties: {},
+      day,
+    });
+
+    const [summary] = summarize(1);
+    expect(summary.transactionSuccessRate).toBeNull();
+  });
+
+  it('groups contract calls by contract_id and function, sorted descending', () => {
+    const day = '2026-08-27';
+    const props = (contract_id: string, fn: string) => ({
+      contract_id,
+      function: fn,
+    });
+    recordEvent({
+      event: 'contract_invoked',
+      walletHash: null,
+      properties: props('C1', 'transfer'),
+      day,
+    });
+    recordEvent({
+      event: 'contract_invoked',
+      walletHash: null,
+      properties: props('C1', 'transfer'),
+      day,
+    });
+    recordEvent({
+      event: 'contract_invoked',
+      walletHash: null,
+      properties: props('C2', 'swap'),
+      day,
+    });
+
+    const [summary] = summarize(1);
+    expect(summary.topContractCalls[0]).toEqual({
+      key: 'C1:transfer',
+      count: 2,
+    });
+    expect(summary.topContractCalls[1]).toEqual({ key: 'C2:swap', count: 1 });
+  });
+
+  it('limits summarize to the requested number of most recent days', () => {
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'a',
+      properties: {},
+      day: '2026-08-25',
+    });
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'b',
+      properties: {},
+      day: '2026-08-26',
+    });
+    recordEvent({
+      event: 'dapp_initialized',
+      walletHash: 'c',
+      properties: {},
+      day: '2026-08-27',
+    });
+
+    const summary = summarize(2);
+    expect(summary.map((s) => s.day)).toEqual(['2026-08-26', '2026-08-27']);
+  });
+
+  it('defaults an unknown contract_id/function to "unknown" rather than throwing', () => {
+    const day = '2026-08-27';
+    recordEvent({
+      event: 'contract_invoked',
+      walletHash: null,
+      properties: {},
+      day,
+    });
+
+    const [summary] = summarize(1);
+    expect(summary.topContractCalls[0]).toEqual({
+      key: 'unknown:unknown',
+      count: 1,
+    });
+  });
+});
+```
+
+---
+
+## Related docs
+
+- [Analytics Integration for Stellar dApps](/docs/guides/analytics-integration-guide) — what to track client-side and why, before this tutorial's aggregation/dashboard layer
+- [Caching Layer Tutorial](/docs/guides/caching-layer-tutorial) — swap the in-memory store here for a production-grade backing store
+- [Privacy Considerations](/docs/guides/privacy-considerations) — general privacy guidance this tutorial's hashing approach builds on


### PR DESCRIPTION
## Summary

Four new "hard" tutorial/guide drafts, all scoped to documentation only per each issue's constraints, placed in `routes-d/` and named after their issue number:

- **#926 — Soroban insurance pool tutorial**: premium collection, claim filing with two fraud checks (coverage-limit and double-claim guards), admin approve/reject, and payout. Working Rust contract, 7 tests, TypeScript client.
- **#928 — Soroban DID contract tutorial**: DID registration keyed by the owning Address, key rotation and multi-key support, service-endpoint updates, soft-delete revocation, and read-only resolution. Working Rust contract, 9 tests, TypeScript client, and a dedicated privacy-considerations section on address correlation and the permanence of on-chain history.
- **#927 — Soroban reputation-weighted voting guide**: weight sourcing (cross-contract live lookup vs. snapshot-at-creation trade-offs, with a documented recommendation), weighted tabulation via a minimal reputation-registry contract, one-vote-per-proposal enforcement, and explicit tie handling (returns `None` rather than silently picking the first-indexed option). Working Rust contracts (voting + registry), 8 tests.
- **#934 — Stellar dApp analytics dashboard tutorial**: event ingestion with privacy-first address hashing (raw wallet addresses are never persisted), day-bucketed aggregation, a summary API, and a React dashboard rendering active wallets, wallet-connect/transaction success rates, and top contract calls. Builds on the existing [Analytics Integration Guide](/docs/guides/analytics-integration-guide) rather than re-explaining event tracking from scratch. 7 vitest tests for the aggregation logic.

Closes #926
Closes #928
Closes #927
Closes #934

## Duplicate-work check

Searched `docs/guides/` for existing content on all 4 topics before writing anything. Found `docs/guides/analytics-integration-guide.mdx` (#436, already merged) — reviewed it in full: it covers *what to track and why* (events, privacy), but has no dashboard/aggregation/visualization content, so #934 is complementary, not duplicate, and explicitly links back to it rather than re-covering the same ground. No existing content found for DID, reputation-weighted voting, or insurance pools (a few keyword hits on "DID" and "insurance" in unrelated files were false positives — verified by reading each match).

## Testing

- `pnpm build:content` — same 4 pre-existing problems as a clean checkout of `main` (`examples/payment-app.mdx` extra frontmatter fields, `guides/custom-hook-authoring-playbook.mdx` missing `title`, and MDX parse errors in `guides/soroban-continuous-token-issuance.mdx` / `guides/soroban-dutch-auction.mdx`) — confirmed via a pristine `git status` diff that none of these files are touched by this PR, and none of my 4 new files appear in the error output.
- `node scripts/validate-sidebar.cjs` — passes 100%, unaffected (these are `routes-d/` drafts, not wired into sidebar navigation).
- Rust tests are written against real Soroban SDK APIs and existing patterns from already-merged tutorials in this repo (e.g. `915-soroban-token-contract-guide.mdx`'s `setup_with_token`/`mint` helpers) but were not compiled/run in this environment — Soroban contract crates aren't part of this repo's own build; the tutorials are prose+code documentation, consistent with how prior merged tutorials (#915, #916, #917, #911) were reviewed.

## Note

Per the existing convention in this repo (see #915/#916/#917), these files are intentionally left as `routes-d/` drafts and not wired into `docs/` site navigation — that's a separate content-promotion step for a maintainer.
