### PR TITLE
docs: add stellar-sdk notes and Soroban tx status polling guide

### DIFF
--- a/routes-d/1006-soroban-sendtransaction-status-polling.mdx
+++ b/routes-d/1006-soroban-sendtransaction-status-polling.mdx
@@ -1,0 +1,76 @@
+---
+title: Soroban sendTransaction Status Polling
+description: Guide on polling for a Soroban transaction's final status after sendTransaction, covering the status transitions and timeout handling.
+date: 2026-08-27
+---
+
+# Soroban sendTransaction Status Polling
+
+Soroban RPC's `sendTransaction` returns as soon as the node has accepted (or rejected) the transaction for relay — it does **not** wait for the transaction to be included in a ledger. Getting the final outcome requires polling `getTransaction` separately by hash.
+
+## Status Transitions
+
+`sendTransaction` itself returns one of:
+
+| Status | Meaning |
+| --- | --- |
+| `PENDING` | Accepted and relayed to the network — poll `getTransaction` for the outcome. |
+| `DUPLICATE` | An identical transaction was already submitted; treat it the same as `PENDING` and poll the same hash. |
+| `TRY_AGAIN_LATER` | The node's submission queue is full — back off and resubmit the same signed envelope. |
+| `ERROR` | Rejected outright (for example a malformed envelope); nothing to poll for. |
+
+Once `sendTransaction` returns `PENDING` (or `DUPLICATE`), the hash transitions through `getTransaction` statuses:
+
+```
+sendTransaction → PENDING
+        │
+        ▼
+getTransaction → NOT_FOUND  (not yet in a ledger — keep polling)
+        │
+        ▼
+getTransaction → SUCCESS | FAILED  (final)
+```
+
+## Timeout Handling
+
+Bound the polling loop by **ledgers elapsed**, not a fixed wall-clock duration — a transaction's own validity window (`TransactionBuilder`'s `setTimeout`) is itself expressed in ledgers via the `timeBounds` it produces, so tying your poll timeout to the same unit keeps the two in sync. If `getTransaction` still returns `NOT_FOUND` once that many ledgers have passed, treat the transaction as expired rather than continuing to poll indefinitely.
+
+## Example
+
+```typescript
+import { rpc } from '@stellar/stellar-sdk';
+
+async function submitAndConfirm(
+  server: rpc.Server,
+  signedTx: import('@stellar/stellar-sdk').Transaction,
+  { timeoutLedgers = 30, pollIntervalMs = 2000 } = {}
+) {
+  const sendResult = await server.sendTransaction(signedTx);
+
+  if (sendResult.status === 'ERROR') {
+    throw new Error(`Submission rejected: ${sendResult.errorResult}`);
+  }
+
+  // PENDING or DUPLICATE both mean "poll this hash"
+  const { sequence: startLedger } = await server.getLatestLedger();
+
+  while (true) {
+    const result = await server.getTransaction(sendResult.hash);
+
+    if (result.status === 'SUCCESS') return result;
+    if (result.status === 'FAILED') {
+      throw new Error(`Transaction failed: ${result.resultXdr}`);
+    }
+
+    // still NOT_FOUND — check the ledger-based timeout before waiting and retrying
+    const { sequence: currentLedger } = await server.getLatestLedger();
+    if (currentLedger - startLedger > timeoutLedgers) {
+      throw new Error(`Transaction ${sendResult.hash} expired after ${timeoutLedgers} ledgers`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+```
+
+For a closer look at each piece this builds on, see [Document Soroban getTransaction retrieval](/docs/guides/soroban-gettransaction-retrieval) and [Add a guide on Soroban getLatestLedger polling](/docs/guides/soroban-getlatestledger-polling).

--- a/routes-d/992-stellar-sdk-operation-namespace.mdx
+++ b/routes-d/992-stellar-sdk-operation-namespace.mdx
@@ -1,0 +1,48 @@
+---
+title: stellar-sdk Operation Namespace
+description: A quick reference on the Operation namespace in @stellar/stellar-sdk and its most commonly used factory methods.
+date: 2026-08-27
+---
+
+# stellar-sdk Operation Namespace
+
+`Operation` is a namespace of static factory methods in `@stellar/stellar-sdk`. Each factory builds the XDR for one classic Stellar operation type, ready to be passed to `TransactionBuilder.addOperation()`.
+
+## Frequently Used Factories
+
+| Factory | Description |
+| --- | --- |
+| `Operation.payment({ destination, asset, amount })` | Sends a payment of `asset` to `destination`. |
+| `Operation.createAccount({ destination, startingBalance })` | Funds and creates a new account on the ledger. |
+| `Operation.changeTrust({ asset, limit })` | Creates or modifies a trustline for a non-native asset. |
+| `Operation.pathPaymentStrictSend({ sendAsset, sendAmount, destination, destAsset, destMin })` | Sends a fixed source amount, converted through the DEX to a minimum destination amount. |
+| `Operation.manageSellOffer({ selling, buying, amount, price })` | Creates, updates, or deletes an offer on the DEX. |
+| `Operation.invokeHostFunction({ func, auth })` | Invokes a Soroban contract function (or deploys/uploads one) via the host function XDR. |
+
+## Example
+
+```typescript
+import { Operation, Asset, TransactionBuilder, Networks } from '@stellar/stellar-sdk';
+
+const payment = Operation.payment({
+  destination: 'GDESTINATION...',
+  asset: Asset.native(),
+  amount: '10',
+});
+
+const trustline = Operation.changeTrust({
+  asset: new Asset('USDC', 'GISSUER...'),
+  limit: '1000',
+});
+
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: '100',
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(payment)
+  .addOperation(trustline)
+  .setTimeout(30)
+  .build();
+```
+
+Each factory returns an `xdr.Operation` — multiple operations can be chained onto a single transaction via repeated `addOperation()` calls, and they execute atomically in the order added.

--- a/routes-d/993-stellar-sdk-server-timeout-configuration.mdx
+++ b/routes-d/993-stellar-sdk-server-timeout-configuration.mdx
@@ -1,0 +1,35 @@
+---
+title: stellar-sdk Server Timeout Configuration
+description: How to configure the request timeout used by Horizon Server and Soroban RPC calls in @stellar/stellar-sdk, and what the default is.
+date: 2026-08-27
+---
+
+# stellar-sdk Server Timeout Configuration
+
+Both the Horizon `Server` and the Soroban `rpc.Server` in `@stellar/stellar-sdk` make their HTTP requests through a shared Axios client, whose timeout is controlled globally through the SDK's `Config` object rather than per-instance.
+
+## The Option
+
+```typescript
+import { Config } from '@stellar/stellar-sdk';
+
+// Set a 30 second timeout (in milliseconds) for all subsequent requests
+Config.setTimeout(30000);
+```
+
+`Config.setTimeout()` affects every `Server` and `rpc.Server` instance created afterward in the process — it's a global setting, not something passed into the `Server` constructor itself.
+
+## The Default
+
+By default, `Config`'s timeout is unset, which Axios treats as **no timeout** — a hung connection to Horizon or Soroban RPC will wait indefinitely rather than rejecting on its own. For any production dApp, set an explicit timeout so a stalled request surfaces as an error your UI can react to (retry, show a message) instead of leaving a promise pending forever.
+
+```typescript
+import { Config, rpc } from '@stellar/stellar-sdk';
+
+Config.setTimeout(15000);
+
+const server = new rpc.Server('https://soroban-testnet.stellar.org');
+// requests made through `server` now time out after 15s
+```
+
+Set this once, early in your app's startup, before creating any `Server` instances.

--- a/routes-d/996-stellar-sdk-address-types.mdx
+++ b/routes-d/996-stellar-sdk-address-types.mdx
@@ -1,0 +1,42 @@
+---
+title: stellar-sdk Address Types
+description: A quick reference on the Address class in @stellar/stellar-sdk, its account/contract variants, and the helpers for converting between them.
+date: 2026-08-27
+---
+
+# stellar-sdk Address Types
+
+`Address` in `@stellar/stellar-sdk` represents either kind of value Soroban accepts as an address argument: a classic account (`G...`) or a contract (`C...`). It wraps the raw bytes and knows how to convert to and from the string and XDR forms each part of the SDK expects.
+
+## Address Variants
+
+| Variant | Encoded prefix | Constructed via |
+| --- | --- | --- |
+| Account address | `G...` | `Address.fromString(publicKey)` or `Address.account(rawBytes)` |
+| Contract address | `C...` | `Address.fromString(contractId)` or `Address.contract(rawBytes)` |
+
+## Conversion Helpers
+
+| Method | Description |
+| --- | --- |
+| `Address.fromString(str)` | Parses either a `G...` or `C...` string into an `Address`, detecting the variant automatically. |
+| `address.toString()` | Returns the encoded `G...`/`C...` string. |
+| `address.toScVal()` | Converts to an `xdr.ScVal`, ready to pass as a contract invocation argument. |
+| `address.toBuffer()` | Returns the raw underlying bytes. |
+
+## Example
+
+```typescript
+import { Address } from '@stellar/stellar-sdk';
+
+const accountAddress = Address.fromString('GACCOUNT...');
+const contractAddress = Address.fromString('CCONTRACT...');
+
+// Pass an account address as a contract call argument
+const scVal = accountAddress.toScVal();
+
+// Round-trip back to a string
+console.log(contractAddress.toString()); // 'CCONTRACT...'
+```
+
+Use `Address` any time a Soroban contract function expects an `Address` parameter (for example a token contract's `transfer(from, to, amount)`) — pass the `Address` instance's `.toScVal()` output rather than a raw string.


### PR DESCRIPTION
## Summary
- Add a note on the `Operation` namespace and its common factory methods.
- Add a note on configuring the `Server`/`rpc.Server` request timeout via `Config.setTimeout`.
- Add a note on the `Address` class and its account/contract variants.
- Add a guide on polling for a Soroban transaction's final status after `sendTransaction`.

All drafts are scoped to documentation only and placed in `routes-d/`, named after their issue, matching existing MDX frontmatter and writing style.

Closes #992
Closes #993
Closes #996
Closes #1006

## Test plan
- [x] Drafts follow existing `routes-d/*.mdx` frontmatter (`title`, `description`, `date`) and writing style.
- [x] `routes-d/` is outside Contentlayer's `contentDirPath` (`docs/`), so `pnpm build:content` is unaffected.
- [x] No sidebar/component links touched, so `pnpm check:links` is unaffected.