### PR TITLE
docs: Soroban RPC polling guides and dApp testing guides

### DIFF
--- a/routes-d/1004-soroban-getlatestledger-polling.mdx
+++ b/routes-d/1004-soroban-getlatestledger-polling.mdx
@@ -1,0 +1,69 @@
+---
+title: Soroban getLatestLedger Polling
+description: Guide on calling Soroban RPC's getLatestLedger, reading its response fields, and choosing a safe polling cadence.
+date: 2026-08-27
+---
+
+# Soroban getLatestLedger Polling
+
+`getLatestLedger` returns the most recent ledger the Soroban RPC node has ingested. It has no parameters, so it is cheap to call, but polling it too aggressively still wastes requests and can trip rate limits on public endpoints.
+
+## Request
+
+```typescript
+import { rpc } from '@stellar/stellar-sdk';
+
+const server = new rpc.Server('https://soroban-testnet.stellar.org');
+
+const latest = await server.getLatestLedger();
+```
+
+No arguments are accepted — the node always answers for its current head ledger.
+
+## Response Fields
+
+| Field             | Type     | Meaning                                                                                                          |
+| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `id`              | `string` | Hash of the latest ledger.                                                                                       |
+| `sequence`        | `number` | Ledger sequence number — the value you diff against a previously recorded sequence to measure elapsed ledgers.   |
+| `protocolVersion` | `number` | Protocol version the ledger closed under. Useful for gating features that only exist on newer protocol versions. |
+
+`sequence` is the field almost every polling loop cares about — it is a monotonically increasing integer, so comparing two readings tells you exactly how many ledgers have elapsed between them.
+
+## Polling Cadence
+
+Stellar ledgers close roughly every 5–6 seconds. Polling faster than that only returns the same `sequence` repeatedly:
+
+- Poll no more often than once per ledger close (`~5s`) for a tight loop; `2s`–`3s` is a reasonable margin without hammering the endpoint.
+- Prefer measuring elapsed **ledgers** (`sequence` deltas) over elapsed **wall-clock time** for anything tied to transaction validity — ledger close time drifts under network load, but the ledger count does not.
+- Back off (double the interval, cap it) if consecutive calls return an identical `sequence` more times than expected — it usually means the endpoint itself is lagging, not that the network stalled.
+
+## Example
+
+```typescript
+import { rpc } from '@stellar/stellar-sdk';
+
+async function waitForLedgers(
+  server: rpc.Server,
+  ledgersToWait: number,
+  pollIntervalMs = 3000
+) {
+  const { sequence: startSequence } = await server.getLatestLedger();
+
+  while (true) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+
+    const { sequence: currentSequence } = await server.getLatestLedger();
+    if (currentSequence - startSequence >= ledgersToWait) {
+      return currentSequence;
+    }
+  }
+}
+```
+
+This is the same pattern [Soroban sendTransaction Status Polling](/docs/guides/soroban-sendtransaction-status-polling) uses to bound a `getTransaction` polling loop by ledgers elapsed rather than a fixed timeout.
+
+## Related docs
+
+- [Document Soroban getTransaction retrieval](/docs/guides/soroban-gettransaction-retrieval) — reading the final status once you know a transaction should have landed.
+- [Soroban sendTransaction Status Polling](/docs/guides/soroban-sendtransaction-status-polling) — combines both calls into a full submit-and-confirm flow.

--- a/routes-d/1007-soroban-gettransaction-retrieval.mdx
+++ b/routes-d/1007-soroban-gettransaction-retrieval.mdx
@@ -1,0 +1,73 @@
+---
+title: Soroban getTransaction Retrieval
+description: Guide on retrieving a Soroban transaction by hash with getTransaction, including request shape and how to handle each returned field.
+date: 2026-08-27
+---
+
+# Soroban getTransaction Retrieval
+
+`getTransaction` looks up a transaction by its hash on the Soroban RPC node. It is the call you poll after `sendTransaction` to learn whether the transaction actually landed, and it is also how you look up any past transaction once you have its hash.
+
+## Request
+
+```typescript
+import { rpc } from '@stellar/stellar-sdk';
+
+const server = new rpc.Server('https://soroban-testnet.stellar.org');
+
+const result = await server.getTransaction(
+  '3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc'
+);
+```
+
+The only input is the 64-character hex transaction hash — the same hash returned by `sendTransaction`.
+
+## Return Field Handling
+
+| Field           | Present when                         | Meaning                                                                                                                                                                            |
+| --------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`        | Always                               | One of `SUCCESS`, `FAILED`, or `NOT_FOUND`.                                                                                                                                        |
+| `ledger`        | `SUCCESS` or `FAILED`                | Ledger sequence the transaction was included in.                                                                                                                                   |
+| `createdAt`     | `SUCCESS` or `FAILED`                | Unix timestamp of that ledger's close time.                                                                                                                                        |
+| `envelopeXdr`   | `SUCCESS` or `FAILED`                | The submitted transaction envelope, base64-encoded XDR.                                                                                                                            |
+| `resultXdr`     | `SUCCESS` or `FAILED`                | The transaction result, base64-encoded XDR — decode this to get the precise failure reason on `FAILED`.                                                                            |
+| `resultMetaXdr` | `SUCCESS` or `FAILED`                | Full ledger entry changes and, for contract invocations, the Soroban return value.                                                                                                 |
+| `returnValue`   | `SUCCESS`, contract invocations only | Convenience field with the contract function's return value already parsed as an `xdr.ScVal` — decode with `scValToNative` rather than digging it out of `resultMetaXdr` yourself. |
+
+`NOT_FOUND` does **not** mean the transaction failed — it means the node has no record of it yet (still propagating) or any more (expired from the node's retention window). Treat it as "keep polling until your own timeout", never as a terminal failure.
+
+## Example
+
+```typescript
+import { rpc, scValToNative } from '@stellar/stellar-sdk';
+
+async function fetchTransactionOutcome(server: rpc.Server, hash: string) {
+  const result = await server.getTransaction(hash);
+
+  switch (result.status) {
+    case 'NOT_FOUND':
+      // Not an error — the caller decides whether to keep polling.
+      return { status: 'pending' as const };
+
+    case 'FAILED':
+      return {
+        status: 'failed' as const,
+        resultXdr: result.resultXdr,
+      };
+
+    case 'SUCCESS':
+      return {
+        status: 'success' as const,
+        ledger: result.ledger,
+        returnValue: result.returnValue
+          ? scValToNative(result.returnValue)
+          : undefined,
+      };
+  }
+}
+```
+
+## Related docs
+
+- [Add a guide on Soroban getLatestLedger polling](/docs/guides/soroban-getlatestledger-polling) — bounding how long you keep calling `getTransaction` for.
+- [Soroban sendTransaction Status Polling](/docs/guides/soroban-sendtransaction-status-polling) — the full submit → poll → confirm flow this call is part of.

--- a/routes-d/1008-stellar-dapp-contract-testing.mdx
+++ b/routes-d/1008-stellar-dapp-contract-testing.mdx
@@ -1,0 +1,114 @@
+---
+title: Stellar dApp API Contract Testing
+description: A guide to consumer-driven contract testing between a Stellar dApp's UI and its backend, covering versioning and a runnable example.
+date: 2026-08-27
+---
+
+# Stellar dApp API Contract Testing
+
+Most Stellar dApps have a backend layer sitting between the UI and Horizon/Soroban RPC — an API that assembles account data, caches ledger lookups, or exposes a simplified endpoint the frontend calls instead of talking to Horizon directly. Contract testing verifies that this backend's API still matches what the UI expects, without either side needing the other running to test against.
+
+This is a different concern from [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban), which mocks Horizon and Soroban RPC themselves — contract testing targets the layer your own backend exposes to your own frontend.
+
+## Consumer-Driven Contracts
+
+In a consumer-driven setup, the **consumer** (the frontend) defines the shape of the requests and responses it needs, and the **provider** (the backend) is tested against that same definition:
+
+1. The frontend team writes a contract: "a `GET /api/account/:id` call returns this JSON shape."
+2. The contract is published as a fixture both sides can reference.
+3. The frontend's tests run against a mock server generated from the contract — no backend required.
+4. The backend's tests replay the same contract against its real implementation — no frontend required.
+5. CI fails on either side the moment the contract and the real implementation diverge.
+
+This catches breaking changes — a renamed field, a dropped balance entry, a status code that changed — at the PR that introduced them, rather than at runtime in production.
+
+### Example contract
+
+```typescript
+// contracts/get-account.contract.ts
+export const getAccountContract = {
+  request: {
+    method: 'GET',
+    path: '/api/account/GABC1234567890123456789012345678901234567890123456789012',
+  },
+  response: {
+    status: 200,
+    body: {
+      id: 'GABC1234567890123456789012345678901234567890123456789012',
+      sequence: '123456789',
+      balances: [{ asset_type: 'native', balance: '100.0000000' }],
+    },
+  },
+};
+```
+
+### Consumer side — frontend test against the contract
+
+```typescript
+// tests/contract/account-consumer.test.ts
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { getAccountContract } from '../../contracts/get-account.contract';
+
+const server = setupServer(
+  http.get(`http://localhost${getAccountContract.request.path}`, () =>
+    HttpResponse.json(getAccountContract.response.body, {
+      status: getAccountContract.response.status,
+    })
+  )
+);
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+
+it('renders the account balance from the contracted shape', async () => {
+  const res = await fetch(`http://localhost${getAccountContract.request.path}`);
+  const body = await res.json();
+
+  // Assert against the fields the UI actually reads — this is what breaks
+  // if the backend renames or drops one of them.
+  expect(body.balances[0].balance).toBe('100.0000000');
+});
+```
+
+### Provider side — backend test against the same contract
+
+```typescript
+// tests/contract/account-provider.test.ts
+import { createServer } from '../../src/server';
+import { getAccountContract } from '../../contracts/get-account.contract';
+
+it('the real handler satisfies the published contract', async () => {
+  const app = createServer();
+  const res = await app.inject({
+    method: getAccountContract.request.method,
+    url: getAccountContract.request.path,
+  });
+
+  expect(res.statusCode).toBe(getAccountContract.response.status);
+  // Structural check — the real response must be a superset of the
+  // contracted fields, not necessarily an exact match.
+  expect(res.json()).toMatchObject(getAccountContract.response.body);
+});
+```
+
+Both tests import the **same** contract file, so a change to `contracts/get-account.contract.ts` immediately shows up as a failure on whichever side hasn't been updated to match.
+
+## Versioning
+
+Backend API shapes change over time; the contract has to change with them without silently breaking older frontend deployments:
+
+- Keep contracts in a versioned directory (`contracts/v1/`, `contracts/v2/`) rather than mutating one in place — a frontend still deployed against `v1` should keep passing against the `v1` contract.
+- Bump the version whenever a change is **not** additive — a removed field, a renamed field, or a changed type. Adding a new optional field to a response is not a breaking change and does not need a new version.
+- Tag the backend route itself with the version it satisfies (`/api/v1/account/:id`) so provider tests can run all supported versions' contracts against the routes that claim to implement them.
+- Retire a contract version only once analytics or logs confirm no consumer is still requesting that route version.
+
+## Verifying the Guide
+
+- Run both the consumer and provider contract tests in CI on every PR that touches either the frontend API client or the backend route handlers.
+- Confirm a deliberately broken contract (rename a field in `contracts/get-account.contract.ts` without updating the backend) fails the provider test — if it doesn't, the provider test isn't actually checking the field.
+
+## Related docs
+
+- [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban) — mocking Horizon and Soroban RPC directly, one layer below this guide.
+- [Stellar dApp Chaos Testing Tutorial](/docs/guides/stellar-dapp-chaos-testing) — failure-injection testing for the same API boundary this guide contract-tests for shape correctness.

--- a/routes-d/1009-stellar-dapp-chaos-testing.mdx
+++ b/routes-d/1009-stellar-dapp-chaos-testing.mdx
@@ -1,0 +1,156 @@
+---
+title: Stellar dApp Chaos Testing Tutorial
+description: An end-to-end tutorial for chaos testing a Stellar dApp — injecting failures at the Horizon and Soroban RPC boundary, verifying recovery, and a runnable sample.
+date: 2026-08-27
+---
+
+# Stellar dApp Chaos Testing Tutorial
+
+Chaos testing deliberately breaks the dependencies your dApp relies on — Horizon, Soroban RPC, the user's wallet — while it is running, so you find out how it behaves under failure before your users do. This tutorial builds a small chaos harness on top of MSW (already used for [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban)) and walks through what "correct" recovery looks like for each failure.
+
+---
+
+## Failure Injection Points
+
+A Stellar dApp has a small number of network boundaries worth attacking. Each maps to a specific class of real-world incident:
+
+| Injection point                                                  | Simulates                                    | Where to inject it                                             |
+| ---------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| Horizon request hangs or times out                               | Horizon under load, regional outage          | MSW handler delays the response past your client timeout       |
+| Horizon returns 5xx / malformed JSON                             | Horizon deploy, bad upstream state           | MSW handler returns a non-2xx status or truncated body         |
+| Soroban RPC `sendTransaction` returns `TRY_AGAIN_LATER`          | RPC node submission queue full               | MSW handler for the RPC method                                 |
+| Soroban RPC `getTransaction` stays `NOT_FOUND` past your timeout | Ledger congestion, dropped transaction       | MSW handler always returns `NOT_FOUND`                         |
+| Wallet extension disconnects mid-flow                            | User closes Freighter, browser crash/restore | Mock the wallet hook's `signTransaction` to reject             |
+| Network switch (mainnet ↔ testnet) while a request is in flight  | User changes wallet network manually         | Change the mocked `networkPassphrase` after the request starts |
+
+Only inject at the boundary — the actual XDR encode/decode and signing logic should run unmodified so a chaos test still exercises real parsing code, not a stub of it.
+
+## Recovery Expectations
+
+Define what "handled correctly" means for each injection point before you start asserting on it:
+
+- **Timeouts** — the request aborts at your configured client timeout, not the OS default; the UI shows a retry affordance instead of hanging indefinitely.
+- **5xx / malformed responses** — the error is caught and surfaced as a user-facing message; it never reaches the UI as an unhandled promise rejection or a raw stack trace.
+- **`TRY_AGAIN_LATER`** — the same signed envelope is resubmitted with backoff, per [Soroban sendTransaction Status Polling](/docs/guides/soroban-sendtransaction-status-polling); the transaction is never silently dropped.
+- **`getTransaction` stuck at `NOT_FOUND`** — the polling loop stops at its ledger-based timeout (see [Soroban getLatestLedger Polling](/docs/guides/soroban-getlatestledger-polling)) and reports "expired," not an infinite spinner.
+- **Wallet disconnect mid-flow** — any in-progress submission is cancelled cleanly; the UI returns to a "reconnect wallet" state rather than retrying with a stale session.
+- **Network switch mid-flight** — the in-flight request either completes against the network it started on or is rejected and re-initiated; results are never attributed to the wrong network.
+
+## Working Sample
+
+```typescript
+// tests/chaos/horizon-timeout.test.ts
+import { http, HttpResponse, delay } from 'msw';
+import { setupServer } from 'msw/node';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStellarWallet } from '@/hooks/useStellarWallet';
+
+const HORIZON = 'https://horizon-testnet.stellar.org';
+const CLIENT_TIMEOUT_MS = 5000;
+
+const server = setupServer(
+  http.get(`${HORIZON}/accounts/:id`, async () => {
+    // Hang well past the client's own timeout.
+    await delay(CLIENT_TIMEOUT_MS + 2000);
+    return HttpResponse.json({ id: 'unreachable' });
+  })
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('Horizon timeout', () => {
+  it('surfaces a timeout error instead of hanging', async () => {
+    const { result } = renderHook(() =>
+      useStellarWallet(HORIZON, 'Test SDF Network ; September 2015', {
+        timeoutMs: CLIENT_TIMEOUT_MS,
+      })
+    );
+
+    await waitFor(
+      () => {
+        expect(result.current.error).toMatch(/timed out/i);
+      },
+      { timeout: CLIENT_TIMEOUT_MS + 1000 }
+    );
+
+    // The hook must not still be loading once the timeout has fired.
+    expect(result.current.loading).toBe(false);
+  });
+});
+```
+
+```typescript
+// tests/chaos/rpc-try-again-later.test.ts
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+const SOROBAN_RPC = 'https://soroban-testnet.stellar.org';
+
+let attempt = 0;
+
+const server = setupServer(
+  http.post(SOROBAN_RPC, async ({ request }) => {
+    const body = (await request.json()) as { method: string };
+    if (body.method !== 'sendTransaction') {
+      return HttpResponse.json({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32601, message: 'unhandled' },
+      });
+    }
+
+    attempt += 1;
+    // Fail the queue twice, then accept — verifies the retry loop actually retries.
+    if (attempt < 3) {
+      return HttpResponse.json({
+        jsonrpc: '2.0',
+        id: 1,
+        result: { status: 'TRY_AGAIN_LATER' },
+      });
+    }
+    return HttpResponse.json({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { status: 'PENDING', hash: 'aabbcc' },
+    });
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  attempt = 0;
+});
+afterAll(() => server.close());
+
+describe('sendTransaction TRY_AGAIN_LATER', () => {
+  it('resubmits the same envelope until the node accepts it', async () => {
+    // ... call the submit-with-retry helper from
+    // /docs/guides/soroban-sendtransaction-status-polling and assert
+    // it made exactly 3 attempts before resolving PENDING.
+  });
+});
+```
+
+Run the chaos suite on its own so a flaky failure-injection test never blocks the main unit run:
+
+```bash
+pnpm vitest run tests/chaos
+```
+
+## Verifying the Tutorial
+
+Before treating a chaos test as done:
+
+- Confirm the test fails (red) when you temporarily remove the recovery code it targets — a chaos test that passes against broken recovery code is testing nothing.
+- Run the full chaos suite at least twice locally; MSW's `delay()`-based tests are timing-sensitive and should not be flaky.
+- Keep chaos tests in their own directory (`tests/chaos/`) and out of the default `pnpm test:unit` run, the same way [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban) isolates Docker-based integration tests.
+
+## Related docs
+
+- [Testing Horizon and Soroban Interactions](/docs/guides/testing-horizon-soroban) — the MSW setup this tutorial builds on.
+- [Soroban sendTransaction Status Polling](/docs/guides/soroban-sendtransaction-status-polling) — the retry/backoff behavior the `TRY_AGAIN_LATER` sample verifies.
+- [Soroban getLatestLedger Polling](/docs/guides/soroban-getlatestledger-polling) — the ledger-based timeout the stuck-`NOT_FOUND` sample verifies.
+- [dApp Denial of Service Hardening](/docs/guides/dapp-dos-hardening) — hardening measures that chaos tests are a good way to validate.


### PR DESCRIPTION
## Summary

Adds four documentation-only draft guides under `routes-d/`, matching the requirement to keep working drafts scoped to that folder pending maintainer review:

- **#1004** — `routes-d/1004-soroban-getlatestledger-polling.mdx`: request shape, response fields, and a safe polling cadence for `getLatestLedger`.
- **#1007** — `routes-d/1007-soroban-gettransaction-retrieval.mdx`: request shape and full return-field handling for `getTransaction`, including `NOT_FOUND` vs terminal statuses.
- **#1008** — `routes-d/1008-stellar-dapp-contract-testing.mdx`: consumer-driven contract testing between a dApp UI and its backend, with a runnable consumer/provider example and a versioning strategy.
- **#1009** — `routes-d/1009-stellar-dapp-chaos-testing.mdx`: end-to-end chaos testing tutorial covering Horizon/Soroban RPC/wallet failure injection points, recovery expectations, and a runnable MSW-based sample.

Each guide follows the existing MDX frontmatter (`title`, `description`, `date`) and writing style used elsewhere in `docs/guides/` and `routes-d/`, and cross-links the other three plus related existing guides (`soroban-sendtransaction-status-polling`, `testing-horizon-soroban`, `dapp-dos-hardening`).

## Test plan

- [x] Verified `pnpm build:content` — pre-existing failures in unrelated files (`custom-hook-authoring-playbook.mdx`, `soroban-continuous-token-issuance.mdx`, `soroban-dutch-auction.mdx`, `examples/payment-app.mdx`); none introduced by this change, and `routes-d/` is outside `contentDirPath` so these drafts aren't part of the build.
- [x] Checked formatting via `prettier` / the repo's pre-commit lint-staged hook (auto-formatted on commit, consistent with how other merged docs are formatted).
- [ ] Awaiting maintainer review before promotion into `docs/guides/`.

Closes #1004
Closes #1007
Closes #1008
Closes #1009