### PR TITLE
docs: versioning, CDN strategy, release automation, and CI matrix guides

### DIFF
--- a/routes-d/940-soroban-ci-matrix-testing-tutorial.mdx
+++ b/routes-d/940-soroban-ci-matrix-testing-tutorial.mdx
@@ -1,0 +1,159 @@
+---
+title: CI Matrix Testing Across Networks and SDK Versions
+description: Tutorial for building a CI test matrix that runs a Soroban contract's suite across multiple networks and SDK versions, with safe secret handling — and a working sample.
+date: 2026-08-27
+---
+
+# CI Matrix Testing Across Networks and SDK Versions
+
+A Soroban contract that only runs its tests once, against one network and one SDK version, can pass CI while silently breaking on testnet, or against the SDK version most integrators actually use. This tutorial builds a CI matrix that runs the same suite across combinations of network and SDK version, and covers how to keep per-network secrets (RPC URLs, funded test accounts) from leaking across matrix legs.
+
+<Note type="warning">
+  This tutorial targets GitHub Actions matrix builds. The matrix-design
+  principles (which axes to combine, how to scope secrets) transfer to other CI
+  systems; the exact YAML syntax does not.
+</Note>
+
+## Choosing matrix axes
+
+Two axes are usually worth crossing for a Soroban project:
+
+- **Network**: `local` (a disposable quickstart container), `testnet`, and optionally `futurenet` for bleeding-edge protocol features.
+- **SDK version**: the SDK version your project currently pins, plus the next major/minor, so a breaking SDK release is caught before you upgrade for real.
+
+Resist adding a third axis (e.g. OS) unless you have a concrete reason — each additional axis multiplies job count, and most Soroban test failures are network- or SDK-shape issues, not OS issues.
+
+```yaml
+# .github/workflows/ci-matrix.yml
+name: Contract Test Matrix
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        network: [local, testnet]
+        sdk-version: ['21.0.0', '22.0.0']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install SDK at matrix version
+        run: npm install --no-save "@stellar/stellar-sdk@${{ matrix.sdk-version }}"
+      - name: Start local network
+        if: matrix.network == 'local'
+        run: docker run -d -p 8000:8000 stellar/quickstart:soroban-dev --local
+      - name: Run contract tests
+        env:
+          NETWORK: ${{ matrix.network }}
+          RPC_URL: ${{ matrix.network == 'local' && 'http://localhost:8000/soroban/rpc' || secrets.TESTNET_RPC_URL }}
+          TEST_ACCOUNT_SECRET: ${{ matrix.network == 'local' && '' || secrets.TESTNET_FUNDED_SECRET }}
+        run: npm test
+```
+
+`fail-fast: false` matters here: a testnet flake on one SDK version shouldn't cancel the local-network legs, which are the fastest signal you have.
+
+## Secret handling
+
+Matrix legs share the workflow's secret scope by default — every job in the matrix can see every secret defined at the workflow or repo level, even legs that don't need them. Two rules keep this from becoming a liability:
+
+1. **Scope secrets to the leg that needs them in the step itself**, not by trying to restrict what the job can see (GitHub Actions doesn't support per-matrix-leg secret scoping). The `env:` block above only _reads_ `TESTNET_RPC_URL` when `matrix.network != 'local'` — the local legs never touch it even though they technically could.
+2. **Never use a mainnet-funded account for CI.** Every network leg other than `local` should use a dedicated testnet/futurenet account that is re-funded via friendbot, holds no real value, and is rotated if a fork ever runs CI on a PR from an external contributor (forked-repo PRs don't get repo secrets by default on GitHub Actions — verify this hasn't been overridden with `pull_request_target` before relying on it).
+
+```ts
+// scripts/ci/resolve-network-config.ts
+export interface NetworkConfig {
+  rpcUrl: string;
+  usesSecretAccount: boolean;
+}
+
+export function resolveNetworkConfig(
+  network: string,
+  env: { RPC_URL?: string; TEST_ACCOUNT_SECRET?: string }
+): NetworkConfig {
+  if (network === 'local') {
+    return {
+      rpcUrl: 'http://localhost:8000/soroban/rpc',
+      usesSecretAccount: false,
+    };
+  }
+  if (!env.RPC_URL) {
+    throw new Error(`RPC_URL is required for network '${network}'`);
+  }
+  return {
+    rpcUrl: env.RPC_URL,
+    usesSecretAccount: Boolean(env.TEST_ACCOUNT_SECRET),
+  };
+}
+```
+
+```ts
+// scripts/ci/resolve-network-config.test.ts
+import { describe, expect, it } from 'vitest';
+import { resolveNetworkConfig } from './resolve-network-config';
+
+describe('resolveNetworkConfig', () => {
+  it('uses a fixed local RPC URL and no secret account for the local network', () => {
+    const config = resolveNetworkConfig('local', {});
+    expect(config.rpcUrl).toBe('http://localhost:8000/soroban/rpc');
+    expect(config.usesSecretAccount).toBe(false);
+  });
+
+  it('requires an RPC_URL for non-local networks', () => {
+    expect(() => resolveNetworkConfig('testnet', {})).toThrow(
+      /RPC_URL is required/
+    );
+  });
+
+  it('reports whether a secret account was supplied for a remote network', () => {
+    const config = resolveNetworkConfig('testnet', {
+      RPC_URL: 'https://soroban-testnet.stellar.org',
+      TEST_ACCOUNT_SECRET: 'SA...',
+    });
+    expect(config.usesSecretAccount).toBe(true);
+  });
+
+  it('does not require a secret account to be present for a remote network', () => {
+    const config = resolveNetworkConfig('futurenet', {
+      RPC_URL: 'https://rpc-futurenet.stellar.org',
+    });
+    expect(config.usesSecretAccount).toBe(false);
+  });
+});
+```
+
+## Matrix result aggregation
+
+With `fail-fast: false`, a single required status check ("all tests passed") needs an explicit aggregation job, since GitHub doesn't merge matrix leg statuses into one check by default:
+
+```yaml
+matrix-result:
+  needs: test
+  if: always()
+  runs-on: ubuntu-latest
+  steps:
+    - name: Fail if any matrix leg failed
+      if: contains(needs.test.result, 'failure')
+      run: exit 1
+```
+
+Set branch protection's required check to `matrix-result`, not to any individual `test (local, 21.0.0)` leg — matrix leg names change if you add/remove versions, silently disabling the required check.
+
+## Verifying the tutorial
+
+```bash
+pnpm build:content
+pnpm check:links
+npx vitest run scripts/ci/resolve-network-config.test.ts
+```
+
+## Related docs
+
+- [Release Automation Guide](/routes-d/941-stellar-dapp-release-automation-guide)
+- [CDN Strategy Guide](/routes-d/953-stellar-dapp-cdn-strategy-guide)

--- a/routes-d/941-stellar-dapp-release-automation-guide.mdx
+++ b/routes-d/941-stellar-dapp-release-automation-guide.mdx
@@ -1,0 +1,250 @@
+---
+title: Release Automation for a Stellar dApp Project
+description: Guide to automating version bumps, tagging, and changelog generation for a Stellar dApp release — with a working sample.
+date: 2026-08-27
+---
+
+# Release Automation for a Stellar dApp Project
+
+Manually bumping a version, tagging a commit, and hand-writing a changelog is error-prone and easy to skip under deadline pressure. This guide covers automating all three from conventional commit messages, so a release is a single command with a deterministic, reviewable output.
+
+<Note type="warning">
+  This guide assumes commits follow the
+  <a href="https://www.conventionalcommits.org/">Conventional Commits</a>
+  format (`feat:`, `fix:`, `feat!:` for breaking changes). Without a consistent
+  commit convention, automated version bumping has nothing reliable to key off.
+</Note>
+
+## Version bump rules
+
+Semantic versioning maps directly onto conventional commit types:
+
+| Commit prefix                                    | Version bump | Example           |
+| ------------------------------------------------ | ------------ | ----------------- |
+| `fix:`                                           | patch        | `1.2.3` → `1.2.4` |
+| `feat:`                                          | minor        | `1.2.3` → `1.3.0` |
+| `feat!:` or `BREAKING CHANGE:` footer            | major        | `1.2.3` → `2.0.0` |
+| `docs:`, `chore:`, `test:`, `refactor:` (no `!`) | none         | no release        |
+
+The bump is determined by the **highest-severity** commit since the last release tag — one `feat!:` among ten `fix:` commits still forces a major bump.
+
+## Working sample: version bump resolver
+
+```ts
+// scripts/release/resolve-bump.ts
+export type BumpLevel = 'major' | 'minor' | 'patch' | 'none';
+
+const BUMP_RANK: Record<BumpLevel, number> = {
+  none: 0,
+  patch: 1,
+  minor: 2,
+  major: 3,
+};
+
+export function classifyCommit(message: string): BumpLevel {
+  const firstLine = message.split('\n')[0];
+  const isBreaking =
+    /^\w+(\(.+\))?!:/.test(firstLine) || /BREAKING CHANGE:/.test(message);
+  if (isBreaking) return 'major';
+  if (/^feat(\(.+\))?:/.test(firstLine)) return 'minor';
+  if (/^fix(\(.+\))?:/.test(firstLine)) return 'patch';
+  return 'none';
+}
+
+export function resolveBump(commitMessages: string[]): BumpLevel {
+  return commitMessages
+    .map(classifyCommit)
+    .reduce<BumpLevel>(
+      (highest, level) =>
+        BUMP_RANK[level] > BUMP_RANK[highest] ? level : highest,
+      'none'
+    );
+}
+
+export function applyBump(currentVersion: string, bump: BumpLevel): string {
+  const [major, minor, patch] = currentVersion.split('.').map(Number);
+  switch (bump) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    case 'none':
+      return currentVersion;
+  }
+}
+```
+
+```ts
+// scripts/release/resolve-bump.test.ts
+import { describe, expect, it } from 'vitest';
+import { applyBump, classifyCommit, resolveBump } from './resolve-bump';
+
+describe('classifyCommit', () => {
+  it('classifies fix: as patch', () => {
+    expect(classifyCommit('fix: correct premium rounding')).toBe('patch');
+  });
+
+  it('classifies feat: as minor', () => {
+    expect(classifyCommit('feat: add claim approval endpoint')).toBe('minor');
+  });
+
+  it('classifies feat!: as major', () => {
+    expect(classifyCommit('feat!: rename claimPolicy to fileClaim')).toBe(
+      'major'
+    );
+  });
+
+  it('classifies a BREAKING CHANGE footer as major even on a fix: commit', () => {
+    const message =
+      'fix: adjust default timeout\n\nBREAKING CHANGE: removes the 30s default';
+    expect(classifyCommit(message)).toBe('major');
+  });
+
+  it('classifies docs:/chore: as none', () => {
+    expect(classifyCommit('docs: fix typo in README')).toBe('none');
+    expect(classifyCommit('chore: bump dev dependency')).toBe('none');
+  });
+});
+
+describe('resolveBump', () => {
+  it('picks the highest-severity bump across all commits', () => {
+    const messages = ['fix: a', 'fix: b', 'feat!: c', 'docs: d'];
+    expect(resolveBump(messages)).toBe('major');
+  });
+
+  it('returns none when no commit warrants a release', () => {
+    expect(resolveBump(['docs: a', 'chore: b'])).toBe('none');
+  });
+});
+
+describe('applyBump', () => {
+  it('bumps patch', () => {
+    expect(applyBump('1.2.3', 'patch')).toBe('1.2.4');
+  });
+
+  it('bumps minor and resets patch', () => {
+    expect(applyBump('1.2.3', 'minor')).toBe('1.3.0');
+  });
+
+  it('bumps major and resets minor and patch', () => {
+    expect(applyBump('1.2.3', 'major')).toBe('2.0.0');
+  });
+
+  it('leaves the version unchanged for none', () => {
+    expect(applyBump('1.2.3', 'none')).toBe('1.2.3');
+  });
+});
+```
+
+## Changelog generation
+
+Group commits by type under the new version heading, in a fixed section order so the changelog is scannable release over release:
+
+```ts
+// scripts/release/generate-changelog.ts
+import { classifyCommit } from './resolve-bump';
+
+interface CommitEntry {
+  message: string;
+  hash: string;
+}
+
+const SECTION_ORDER = [
+  { type: 'major', heading: 'Breaking Changes' },
+  { type: 'minor', heading: 'Features' },
+  { type: 'patch', heading: 'Fixes' },
+] as const;
+
+export function generateChangelogSection(
+  version: string,
+  date: string,
+  commits: CommitEntry[]
+): string {
+  const lines = [`## ${version} (${date})`, ''];
+
+  for (const section of SECTION_ORDER) {
+    const matches = commits.filter(
+      (c) => classifyCommit(c.message) === section.type
+    );
+    if (matches.length === 0) continue;
+
+    lines.push(`### ${section.heading}`, '');
+    for (const commit of matches) {
+      const firstLine = commit.message
+        .split('\n')[0]
+        .replace(/^\w+(\(.+\))?!?:\s*/, '');
+      lines.push(`- ${firstLine} (${commit.hash.slice(0, 7)})`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}
+```
+
+```ts
+// scripts/release/generate-changelog.test.ts
+import { describe, expect, it } from 'vitest';
+import { generateChangelogSection } from './generate-changelog';
+
+describe('generateChangelogSection', () => {
+  it('groups commits into fixed section order', () => {
+    const output = generateChangelogSection('1.3.0', '2026-08-27', [
+      { message: 'fix: correct rounding', hash: 'abc1234' },
+      { message: 'feat: add claim endpoint', hash: 'def5678' },
+    ]);
+    const featuresIndex = output.indexOf('### Features');
+    const fixesIndex = output.indexOf('### Fixes');
+    expect(featuresIndex).toBeGreaterThan(-1);
+    expect(fixesIndex).toBeGreaterThan(featuresIndex);
+  });
+
+  it('omits sections with no matching commits', () => {
+    const output = generateChangelogSection('1.2.4', '2026-08-27', [
+      { message: 'fix: correct rounding', hash: 'abc1234' },
+    ]);
+    expect(output).not.toContain('### Features');
+    expect(output).not.toContain('### Breaking Changes');
+  });
+
+  it('strips the conventional-commit prefix from the entry text', () => {
+    const output = generateChangelogSection('1.2.4', '2026-08-27', [
+      { message: 'fix: correct rounding', hash: 'abc1234' },
+    ]);
+    expect(output).toContain('- correct rounding (abc1234)');
+  });
+});
+```
+
+## Tagging
+
+Tag only after the version bump and changelog commit land, so the tag always points at a commit containing its own changelog entry:
+
+```bash
+#!/usr/bin/env bash
+# scripts/release/cut-release.sh
+set -euo pipefail
+
+NEW_VERSION="$1"  # produced by resolve-bump + applyBump, passed in by CI
+
+npm version "$NEW_VERSION" --no-git-tag-version
+git add package.json CHANGELOG.md
+git commit -m "chore(release): v${NEW_VERSION}"
+git tag "v${NEW_VERSION}"
+git push origin main "v${NEW_VERSION}"
+```
+
+## Verifying the guide
+
+```bash
+pnpm build:content
+pnpm check:links
+npx vitest run scripts/release/resolve-bump.test.ts scripts/release/generate-changelog.test.ts
+```
+
+## Related docs
+
+- [CI Matrix Testing Tutorial](/routes-d/940-soroban-ci-matrix-testing-tutorial)
+- [CDN Strategy Guide](/routes-d/953-stellar-dapp-cdn-strategy-guide)

--- a/routes-d/953-stellar-dapp-cdn-strategy-guide.mdx
+++ b/routes-d/953-stellar-dapp-cdn-strategy-guide.mdx
@@ -1,0 +1,170 @@
+---
+title: CDN Strategy for Stellar dApp Wallet Assets and Hooks
+description: Guide to caching wallet-connect assets and SDK hooks behind a CDN — cache tier design and invalidation on release — with a working sample.
+date: 2026-08-27
+---
+
+# CDN Strategy for Stellar dApp Wallet Assets and Hooks
+
+A Stellar dApp typically ships three kinds of static, cacheable assets: wallet-connector bundles (Freighter/Albedo adapters), icon/logo assets for supported wallets, and the compiled hooks bundle (`useWallet`, `useContract`, etc.) consumed by the frontend. This guide covers a CDN cache-tier strategy for these assets and how to invalidate them safely on release.
+
+<Note type="warning">
+  This guide assumes a CDN that supports tiered caching and path-based
+  invalidation (e.g. CloudFront, Cloudflare, Fastly). Exact invalidation API
+  calls differ by provider — the strategy and cache-key design below transfer
+  regardless of which one you use.
+</Note>
+
+## Cache tiers
+
+Not all wallet assets change at the same rate. Splitting them into tiers lets you cache aggressively where it's safe and invalidate precisely where it isn't.
+
+| Tier          | Asset type                     | Example               | TTL                   | Cache key includes version? |
+| ------------- | ------------------------------ | --------------------- | --------------------- | --------------------------- |
+| Immutable     | Versioned hook/adapter bundles | `hooks-v3.2.0.min.js` | 1 year                | Yes (filename hash/version) |
+| Slow-changing | Wallet icons/logos             | `freighter-icon.svg`  | 1 week                | No                          |
+| Release-bound | Unversioned "latest" alias     | `hooks-latest.min.js` | 5 minutes             | No                          |
+| No-cache      | Wallet capability manifest     | `wallets.json`        | 0 (always revalidate) | No                          |
+
+The key design decision: **immutable tier assets are content-addressed** (the version or a content hash is in the filename), so they can be cached forever — a new release produces a new filename, never overwrites an old one. Only the "latest" alias and the capability manifest need short TTLs, because those are the only URLs that change meaning after a release.
+
+## Cache-key design
+
+```ts
+// lib/cdn-cache-policy.ts
+export type CacheTier =
+  | 'immutable'
+  | 'slow-changing'
+  | 'release-bound'
+  | 'no-cache';
+
+export interface CachePolicy {
+  tier: CacheTier;
+  maxAgeSeconds: number;
+  immutable: boolean;
+}
+
+const TIER_POLICIES: Record<CacheTier, CachePolicy> = {
+  immutable: { tier: 'immutable', maxAgeSeconds: 31536000, immutable: true },
+  'slow-changing': {
+    tier: 'slow-changing',
+    maxAgeSeconds: 604800,
+    immutable: false,
+  },
+  'release-bound': {
+    tier: 'release-bound',
+    maxAgeSeconds: 300,
+    immutable: false,
+  },
+  'no-cache': { tier: 'no-cache', maxAgeSeconds: 0, immutable: false },
+};
+
+export function classifyAsset(path: string): CacheTier {
+  if (/^\/hooks-v[\d.]+\.min\.js$/.test(path)) return 'immutable';
+  if (/^\/hooks-latest\.min\.js$/.test(path)) return 'release-bound';
+  if (/^\/wallets\.json$/.test(path)) return 'no-cache';
+  if (/^\/icons\//.test(path)) return 'slow-changing';
+  return 'no-cache';
+}
+
+export function cacheControlHeader(path: string): string {
+  const policy = TIER_POLICIES[classifyAsset(path)];
+  if (policy.maxAgeSeconds === 0) {
+    return 'no-cache, must-revalidate';
+  }
+  const directive = `public, max-age=${policy.maxAgeSeconds}`;
+  return policy.immutable ? `${directive}, immutable` : directive;
+}
+```
+
+```ts
+// lib/cdn-cache-policy.test.ts
+import { describe, expect, it } from 'vitest';
+import { cacheControlHeader, classifyAsset } from './cdn-cache-policy';
+
+describe('classifyAsset', () => {
+  it('classifies a versioned hooks bundle as immutable', () => {
+    expect(classifyAsset('/hooks-v3.2.0.min.js')).toBe('immutable');
+  });
+
+  it('classifies the latest alias as release-bound', () => {
+    expect(classifyAsset('/hooks-latest.min.js')).toBe('release-bound');
+  });
+
+  it('classifies the wallet manifest as no-cache', () => {
+    expect(classifyAsset('/wallets.json')).toBe('no-cache');
+  });
+
+  it('classifies wallet icons as slow-changing', () => {
+    expect(classifyAsset('/icons/freighter-icon.svg')).toBe('slow-changing');
+  });
+
+  it('defaults unknown paths to no-cache', () => {
+    expect(classifyAsset('/unknown-asset.bin')).toBe('no-cache');
+  });
+});
+
+describe('cacheControlHeader', () => {
+  it('marks immutable assets as immutable with a 1-year max-age', () => {
+    expect(cacheControlHeader('/hooks-v3.2.0.min.js')).toBe(
+      'public, max-age=31536000, immutable'
+    );
+  });
+
+  it('gives the latest alias a short max-age, not immutable', () => {
+    expect(cacheControlHeader('/hooks-latest.min.js')).toBe(
+      'public, max-age=300'
+    );
+  });
+
+  it('forces revalidation for the wallet manifest', () => {
+    expect(cacheControlHeader('/wallets.json')).toBe(
+      'no-cache, must-revalidate'
+    );
+  });
+});
+```
+
+## Invalidation on release
+
+Because immutable-tier assets are content-addressed, a release never needs to invalidate them — it just publishes new files under new names. Only two things need invalidating per release:
+
+1. The `-latest` alias (so it now points at the new version's content).
+2. The wallet capability manifest, if the release adds/removes a supported wallet.
+
+```bash
+#!/usr/bin/env bash
+# scripts/invalidate-cdn-on-release.sh
+set -euo pipefail
+
+VERSION="$1"  # e.g. v3.2.0
+DISTRIBUTION_ID="${CDN_DISTRIBUTION_ID:?set CDN_DISTRIBUTION_ID}"
+
+# Upload the new immutable bundle (never overwrites an existing version).
+aws s3 cp "dist/hooks-${VERSION}.min.js" "s3://${CDN_BUCKET}/hooks-${VERSION}.min.js" \
+  --cache-control "public, max-age=31536000, immutable"
+
+# Repoint the -latest alias at the new version's content.
+aws s3 cp "dist/hooks-${VERSION}.min.js" "s3://${CDN_BUCKET}/hooks-latest.min.js" \
+  --cache-control "public, max-age=300"
+
+# Invalidate only the two release-bound paths — never the immutable tier.
+aws cloudfront create-invalidation \
+  --distribution-id "$DISTRIBUTION_ID" \
+  --paths "/hooks-latest.min.js" "/wallets.json"
+```
+
+The important property: **invalidation scope is fixed and small regardless of release size.** Whether a release changes one hook or twenty, exactly two paths get invalidated — the immutable tier is never touched, so there's no cache-stampede risk on the assets clients hit most.
+
+## Verifying the guide
+
+```bash
+pnpm build:content
+pnpm check:links
+npx vitest run lib/cdn-cache-policy.test.ts
+```
+
+## Related docs
+
+- [Release Automation Guide](/routes-d/941-stellar-dapp-release-automation-guide)
+- [Versioning Docs Tutorial](/routes-d/954-docs-versioning-with-sdk-releases-tutorial)

--- a/routes-d/954-docs-versioning-with-sdk-releases-tutorial.mdx
+++ b/routes-d/954-docs-versioning-with-sdk-releases-tutorial.mdx
@@ -1,0 +1,183 @@
+---
+title: Versioning Docs Alongside SDK Releases
+description: Tutorial for keeping documentation versions in sync with SDK releases — branching strategy, publishing workflow, and reader-facing version switching — with a working sample.
+date: 2026-08-27
+---
+
+# Versioning Docs Alongside SDK Releases
+
+As a Stellar SDK evolves, its documentation needs to track which docs version matches which SDK version. A reader on SDK `v2.1.0` should not land on docs written for `v3.0.0` and hit APIs that don't exist yet. This tutorial covers a branching and publishing strategy for versioned docs, and a small reader-facing version switcher.
+
+<Note type="warning">
+  This tutorial covers a documentation-versioning workflow, not a docs platform.
+  It assumes a static-site docs generator (like the one powering this site) that
+  can build multiple version snapshots from git refs.
+</Note>
+
+## Why version docs at all
+
+Two forces push toward versioned docs:
+
+- **Breaking SDK changes.** A method renamed or removed in `v3.0.0` still exists in `v2.x`. Readers on the older SDK need docs that reflect that reality, not the latest one.
+- **Long-lived integrations.** Teams often pin an SDK version for months. They need a stable doc snapshot to reference, not a moving target.
+
+The alternative — a single "latest only" doc tree — silently breaks for anyone not on the newest release.
+
+## Branching strategy
+
+Use one long-lived docs branch per major SDK version, cut at the same time as the SDK's release branch:
+
+```text
+main                 → docs for the unreleased/next SDK version
+docs/v3              → docs for SDK v3.x (frozen at v3 GA, patched for v3.x.y docs fixes)
+docs/v2              → docs for SDK v2.x (maintenance only)
+```
+
+Rules for this to stay sane:
+
+1. **Cut the docs branch at SDK GA, not before.** Branching early means duplicating in-flight edits; branching at GA gives you a clean snapshot.
+2. **Backport only doc corrections, never new content**, to a frozen version branch (`docs/v2`). New features belong on `main`/the next version.
+3. **Tag the docs branch commit that matches the SDK's release tag**, so `docs/v3@sdk-v3.2.0` can be reconstructed exactly:
+
+```bash
+# after cutting docs/v3 and merging content for the v3.2.0 SDK release
+git tag docs-v3.2.0
+git push origin docs-v3.2.0
+```
+
+## Publishing workflow
+
+Each versioned branch builds to its own path segment, so all versions are live simultaneously:
+
+```text
+/docs/v3/...   (from docs/v3, aliased as "latest")
+/docs/v2/...   (from docs/v2)
+/docs/next/... (from main, unreleased)
+```
+
+A minimal CI publishing step, keyed off branch name:
+
+```yaml
+# .github/workflows/docs-publish.yml
+name: Publish Versioned Docs
+on:
+  push:
+    branches: [main, 'docs/v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve version segment
+        id: version
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "segment=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "segment=${GITHUB_REF_NAME#docs/}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:content
+      - name: Deploy to version path
+        run: ./scripts/deploy-docs-version.sh "${{ steps.version.outputs.segment }}"
+```
+
+Each version's build is fully independent — a broken build on `docs/v2` (patched for a doc fix) never blocks publishing `main`.
+
+## Reader-facing version switching
+
+Readers need to know which version they're looking at and be able to jump to another. A small client-side helper reads the current path segment and offers a switcher:
+
+```ts
+// lib/docs-version.ts
+export interface DocsVersion {
+  segment: string;
+  label: string;
+  isLatest: boolean;
+}
+
+export const DOCS_VERSIONS: DocsVersion[] = [
+  { segment: 'v3', label: 'v3.x (latest)', isLatest: true },
+  { segment: 'v2', label: 'v2.x (maintenance)', isLatest: false },
+  { segment: 'next', label: 'Next (unreleased)', isLatest: false },
+];
+
+export function resolveVersionFromPath(pathname: string): DocsVersion {
+  const [, , segment] = pathname.split('/');
+  return (
+    DOCS_VERSIONS.find((v) => v.segment === segment) ??
+    DOCS_VERSIONS.find((v) => v.isLatest)!
+  );
+}
+
+export function pathForVersion(pathname: string, target: DocsVersion): string {
+  const parts = pathname.split('/');
+  parts[2] = target.segment;
+  return parts.join('/');
+}
+```
+
+```ts
+// lib/docs-version.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  DOCS_VERSIONS,
+  pathForVersion,
+  resolveVersionFromPath,
+} from './docs-version';
+
+describe('resolveVersionFromPath', () => {
+  it('resolves a known version segment', () => {
+    expect(resolveVersionFromPath('/docs/v2/guides/intro').segment).toBe('v2');
+  });
+
+  it('falls back to latest for an unknown segment', () => {
+    expect(resolveVersionFromPath('/docs/v99/guides/intro').isLatest).toBe(
+      true
+    );
+  });
+
+  it('falls back to latest for the root path', () => {
+    expect(resolveVersionFromPath('/').isLatest).toBe(true);
+  });
+});
+
+describe('pathForVersion', () => {
+  it('swaps only the version segment, preserving the rest of the path', () => {
+    const target = DOCS_VERSIONS.find((v) => v.segment === 'v2')!;
+    expect(pathForVersion('/docs/v3/guides/intro', target)).toBe(
+      '/docs/v2/guides/intro'
+    );
+  });
+
+  it('round-trips back to the original path', () => {
+    const v3 = DOCS_VERSIONS.find((v) => v.segment === 'v3')!;
+    const v2 = DOCS_VERSIONS.find((v) => v.segment === 'v2')!;
+    const start = '/docs/v3/api/contract-client';
+    const swapped = pathForVersion(start, v2);
+    expect(pathForVersion(swapped, v3)).toBe(start);
+  });
+});
+```
+
+## Reader UX notes
+
+- **Default to the reader's last-viewed version**, not always "latest" — a returning reader mid-integration on `v2` shouldn't be bounced to `v3` docs on every visit. Store the choice in `localStorage`, keyed by version segment.
+- **Bannner, don't block**, when a reader is on a maintenance or unreleased version: "You're viewing v2.x docs (maintenance). [View latest →]" — never redirect automatically, since the reader may be intentionally pinned to that version.
+- **Cross-version links should stay same-version by default.** A relative link inside `docs/v2` content should resolve to `/docs/v2/...`, not `/docs/v3/...`, so a v2 reader isn't silently sent to a page describing a different API surface.
+
+## Verifying the tutorial
+
+This tutorial's sample builds and tests cleanly:
+
+```bash
+pnpm build:content
+pnpm check:links
+npx vitest run lib/docs-version.test.ts
+```
+
+## Related docs
+
+- [Template Comparison Guide](/docs/guides/template-comparison-guide)
+- [CI Matrix Testing Tutorial](/routes-d/940-soroban-ci-matrix-testing-tutorial)


### PR DESCRIPTION
## Summary
Adds 4 documentation-only tutorials/guides to `routes-d/`, each with a working, tested code sample:

- **Docs versioning alongside SDK releases** — branching strategy, publishing workflow per version, and a reader-facing version switcher.
- **Stellar dApp CDN strategy** — cache-tier design for wallet assets/hooks and release-time invalidation scope.
- **Stellar dApp release automation** — conventional-commit-driven version bumping, changelog generation, and tagging.
- **Soroban CI matrix testing** — network × SDK-version test matrix with safe secret scoping.

Closes #954
Closes #953
Closes #941
Closes #940

## Pre-existing tooling notes (not introduced by this PR)
- `pnpm build:content` fails on a clean `main` checkout with 4 pre-existing problems (`examples/payment-app.mdx`, `guides/custom-hook-authoring-playbook.mdx`, `guides/soroban-continuous-token-issuance.mdx`, `guides/soroban-dutch-auction.mdx`) — none of this PR's files. Verified all 4 new files build without error.
- `pnpm check:links` fails on a clean checkout because it requires a running `pnpm dev` server; the 2 failing links are pre-existing component doc links, unrelated to this PR.

## Test plan
- [x] All 4 new `.mdx` files verified to build cleanly under `contentlayer2 build`
- [x] Each guide's embedded code sample has its own unit tests (vitest), all passing
- [x] Frontmatter and writing style matched to existing `routes-d/` conventions