### PR TITLE
docs: add pathfinding, simulation, and batching payment guides

### DIFF
--- a/routes-d/984-batching-sequential-payments.mdx
+++ b/routes-d/984-batching-sequential-payments.mdx
@@ -1,0 +1,70 @@
+---
+title: Batching Sequential Payments
+description: A guide on grouping multiple sequential payment operations into a single Stellar transaction, covering the operation count limit, fee choice, and a worked example.
+date: 2026-08-27
+---
+
+# Batching Sequential Payments
+
+When you need to send several payments in a row — for example, paying out a batch of recipients — you can pack multiple `payment` operations into a single transaction instead of submitting one transaction per payment. They share one sequence number and one base fee, and either all of them apply or none do.
+
+## Operation Count Limit
+
+A single Stellar transaction can hold **up to 100 operations**. For a pure payment batch, that means up to 100 `payment` operations in one envelope. If you have more recipients than that, split them across multiple transactions, each using the next sequence number.
+
+## Choosing the Fee
+
+The `fee` passed to `TransactionBuilder` is a **per-operation** rate, not a flat total. The transaction's total fee is `fee × number of operations`, so a batch of payments costs more in total than a single payment at the same rate:
+
+```typescript
+// 50 payment operations at 100 stroops each = 5,000 stroops total
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: '100',
+  networkPassphrase: Networks.TESTNET,
+});
+```
+
+Use `server.fetchBaseFee()` (or a fee-bump-aware estimate) rather than hardcoding `BASE_FEE` when the network is congested, since an underpriced batch is more likely to be skipped by validators under load.
+
+## Example
+
+```typescript
+import {
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Networks,
+  BASE_FEE,
+} from '@stellar/stellar-sdk';
+
+async function batchPayments(
+  server: Horizon.Server,
+  senderKeypair: Keypair,
+  recipients: { destination: string; amount: string }[]
+) {
+  const sourceAccount = await server.loadAccount(senderKeypair.publicKey());
+
+  const builder = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  for (const { destination, amount } of recipients) {
+    builder.addOperation(
+      Operation.payment({
+        destination,
+        asset: Asset.native(),
+        amount,
+      })
+    );
+  }
+
+  const tx = builder.setTimeout(30).build();
+  tx.sign(senderKeypair);
+
+  const result = await server.submitTransaction(tx);
+  return result;
+}
+```
+
+One sequence number, one base fee multiplied by the recipient count, and every payment either lands together or the whole batch is rejected. For batching payments alongside other operation types (trustlines, Soroban invocations), see [Transaction Batching](/docs/guides/transaction-batching).

--- a/routes-d/985-previewing-soroban-invocation.mdx
+++ b/routes-d/985-previewing-soroban-invocation.mdx
@@ -1,0 +1,67 @@
+---
+title: Previewing a Soroban Invocation
+description: How to preview a Soroban contract invocation with simulateTransaction before signing and submitting it, and how to read the returned resource budget.
+date: 2026-08-27
+---
+
+# Previewing a Soroban Invocation
+
+Before signing and submitting a Soroban contract invocation, simulate it against RPC first. Simulation tells you whether the call would succeed, what it would return, and what it would cost — without spending a fee or consuming a sequence number.
+
+## 1. Build the unsigned transaction
+
+Assemble the invocation as you normally would, with a placeholder fee and no footprint yet — simulation fills both in:
+
+```typescript
+import { Contract, TransactionBuilder, Networks, BASE_FEE } from '@stellar/stellar-sdk';
+
+const contract = new Contract(contractId);
+
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(contract.call('transfer', ...args))
+  .setTimeout(30)
+  .build();
+```
+
+## 2. Simulate
+
+Pass the built transaction to `simulateTransaction`. This runs the invocation against the current ledger state and returns the result, required authorizations, and resource costs:
+
+```typescript
+const simulation = await rpcServer.simulateTransaction(tx);
+
+if (rpc.Api.isSimulationError(simulation)) {
+  throw new Error(`Simulation failed: ${simulation.error}`);
+}
+```
+
+## 3. Read the resource budget
+
+The simulation response's `cost` field reports the instructions and memory the invocation consumed, and `minResourceFee` reports the fee needed to cover it:
+
+```typescript
+console.log('CPU instructions used:', simulation.cost.cpuInsns);
+console.log('Memory bytes used:', simulation.cost.memBytes);
+console.log('Minimum resource fee (stroops):', simulation.minResourceFee);
+```
+
+Compare `cost.cpuInsns` against your network's instruction limit before submitting — a simulation that passes but sits close to the limit is worth flagging to the user, since a slightly different ledger state at submission time could push it over.
+
+## 4. Assemble and sign
+
+Apply the simulation's footprint and fee to the transaction with `rpc.assembleTransaction`, then sign the result — not the original unsimulated transaction:
+
+```typescript
+const preparedTx = rpc.assembleTransaction(tx, simulation).build();
+
+preparedTx.sign(sourceKeypair);
+
+const result = await rpcServer.sendTransaction(preparedTx);
+```
+
+Submitting the pre-simulation transaction instead of the assembled one will fail, since it carries no footprint or resource fee.
+
+See [Soroban Simulation Output Fields](/routes-d/986-soroban-simulation-output-fields) for the full set of fields the simulation response returns.

--- a/routes-d/986-soroban-simulation-output-fields.mdx
+++ b/routes-d/986-soroban-simulation-output-fields.mdx
@@ -1,0 +1,33 @@
+---
+title: Soroban Simulation Output Fields
+description: A short note on the key fields returned by rpc.Server.simulateTransaction and how to use each.
+date: 2026-08-27
+---
+
+# Soroban Simulation Output Fields
+
+Calling `rpcServer.simulateTransaction(tx)` against a Soroban RPC server returns an object describing what the invocation would cost and produce, without submitting anything. The fields you'll use most often:
+
+| Field | Use it to... |
+| --- | --- |
+| `cost.cpuInsns` / `cost.memBytes` | Check the CPU instructions and memory the invocation consumed, against the network's resource limits. |
+| `minResourceFee` | Read the minimum fee (in stroops) needed to cover the simulated resources — pass this into the transaction's fee before signing. |
+| `transactionData` | Get the `SorobanTransactionData` (footprint + resource fee) to attach to the transaction via `rpc.assembleTransaction`. |
+| `result.retval` | Read the contract function's return value, decoded as an `xdr.ScVal`. |
+| `result.auth` | Inspect the authorization entries the invocation required, before the user signs anything. |
+| `latestLedger` | Note which ledger the simulation ran against, useful for diagnosing stale-state errors. |
+| `events` | Inspect diagnostic and contract events emitted during the simulated call, for debugging. |
+| `error` | If present, the simulation failed — read this instead of the other fields; the invocation would not succeed as submitted. |
+
+```typescript
+const simulation = await rpcServer.simulateTransaction(tx);
+
+if (rpc.Api.isSimulationError(simulation)) {
+  throw new Error(simulation.error);
+}
+
+console.log('CPU instructions:', simulation.cost.cpuInsns);
+console.log('Minimum resource fee:', simulation.minResourceFee);
+```
+
+Always check `error` (or use `rpc.Api.isSimulationError`) before reading the other fields — a failed simulation has no usable `result` or `cost`.

--- a/routes-d/999-stellar-sdk-pathfinding-helpers.mdx
+++ b/routes-d/999-stellar-sdk-pathfinding-helpers.mdx
@@ -1,0 +1,53 @@
+---
+title: stellar-sdk Pathfinding Helpers
+description: A guide on the Horizon.Server pathfinding helpers in @stellar/stellar-sdk for discovering path payment routes, including their limits and a usage example.
+date: 2026-08-27
+---
+
+# stellar-sdk Pathfinding Helpers
+
+`@stellar/stellar-sdk` exposes two `Horizon.Server` methods that wrap Horizon's path-finding endpoints. They return candidate routes for a path payment without requiring you to build or submit a transaction first.
+
+## Helper Methods
+
+| Method | Horizon endpoint | You fix... | Use to discover... |
+| --- | --- | --- | --- |
+| `server.strictSendPaths(sourceAsset, sourceAmount, destinationAssets)` | `GET /paths/strict-send` | Exact amount you send | The minimum the recipient could receive for each destination asset |
+| `server.strictReceivePaths(destinationAssets, destinationAmount, sourceAssets)` | `GET /paths/strict-receive` | Exact amount the recipient gets | The source assets/amounts that could fund that payment |
+
+Both methods return a `CallBuilder` — call `.call()` to execute the request, or `.limit(n)` to cap the number of candidate paths returned before calling.
+
+## Pathfinding Limits
+
+- A returned path can include **at most 5 intermediate assets**, matching the maximum path length enforced by `PathPaymentStrictSend`/`PathPaymentStrictReceive` operations on the network.
+- Horizon returns a bounded number of candidate routes per request (a handful by default); use `.limit(n)` to request more, up to Horizon's own page-size cap.
+- Pathfinding only considers order book offers and liquidity pools that exist at the time of the request — routes can become stale by the time you submit a payment, so re-query immediately before building the transaction for time-sensitive payments.
+- The source/destination asset lists only accept assets Horizon already knows about (i.e. assets with at least one trustline); unknown assets return no paths rather than an error.
+
+## Example
+
+```typescript
+import { Asset, Horizon } from '@stellar/stellar-sdk';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org');
+
+const USDC = new Asset(
+  'USDC',
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+);
+
+// "I'm sending exactly 100 USDC — what could the recipient receive in XLM?"
+const paths = await server
+  .strictSendPaths(USDC, '100', [Asset.native()])
+  .limit(5)
+  .call();
+
+for (const path of paths.records) {
+  console.log(
+    `${path.source_amount} ${path.source_asset_code ?? 'XLM'} -> ` +
+      `${path.destination_amount} ${path.destination_asset_code ?? 'XLM'}`
+  );
+}
+```
+
+Each record describes one candidate route, including the intermediate `path` array of assets the payment would hop through. See [Path Payment Cost Analysis](/routes-d/913-path-payment-cost-analysis) for how to compare candidate routes once you have them.


### PR DESCRIPTION
## Summary
Adds four documentation drafts covering Stellar SDK pathfinding, Soroban simulation, and payment batching, following the repo's routes-d drafting convention.

## Changes
- Added `routes-d/999-stellar-sdk-pathfinding-helpers.mdx`: guide on the `Horizon.Server` `strictSendPaths`/`strictReceivePaths` helpers, their pathfinding limits, and a usage example.
- Added `routes-d/986-soroban-simulation-output-fields.mdx`: short note listing the key fields returned by `simulateTransaction` and how to use each.
- Added `routes-d/985-previewing-soroban-invocation.mdx`: guide on previewing a Soroban invocation with `simulateTransaction` before signing, including reading the returned resource budget and assembling the prepared transaction.
- Added `routes-d/984-batching-sequential-payments.mdx`: guide on batching sequential payment operations into one transaction, covering the 100-operation limit, per-operation fee choice, and a worked example.

## Issues
Resolves #999
Resolves #986
Resolves #985
Resolves #984

## Verification
All four files were manually reviewed against each issue's requirements and the existing MDX frontmatter/writing conventions used elsewhere in `routes-d/` and `docs/`. `cargo build` and `cargo test` were not run (not applicable to this documentation-only change), and no other build or test commands were executed — verification was manual review only.